### PR TITLE
perf: reduce registration churn and harden Unity MCP readiness

### DIFF
--- a/.github/workflows/perf-numbers.yml
+++ b/.github/workflows/perf-numbers.yml
@@ -169,7 +169,7 @@ jobs:
       has-autocommit-app: ${{ steps.check-autocommit-app.outputs.has-app }}
     steps:
       - name: Require a registered performance runner
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/check-unity-runner-availability@e6fa595a336e95d800c1139bdebf6d749ee6f186 # post-v1.10.0
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/check-unity-runner-availability@c054699118065984d49b97cce685da090d57ab37 # post-v1.10.0
         with:
           reader-app-id: ${{ secrets.BUILD_LOCK_READER_APP_ID }}
           reader-app-private-key: ${{ secrets.BUILD_LOCK_READER_APP_PRIVATE_KEY }}
@@ -235,7 +235,7 @@ jobs:
     steps:
       - name: Require current PR head before self-hosted setup
         timeout-minutes: 2
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-current-pr-head@e6fa595a336e95d800c1139bdebf6d749ee6f186 # post-v1.10.0
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-current-pr-head@c054699118065984d49b97cce685da090d57ab37 # post-v1.10.0
         with:
           github-token: ${{ github.token }}
           pull-request-number: ${{ github.event.pull_request.number }}
@@ -405,7 +405,7 @@ jobs:
       - name: Acquire organization Unity lock
         id: acquire_lock
         timeout-minutes: 305
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@e6fa595a336e95d800c1139bdebf6d749ee6f186 # post-v1.10.0
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@c054699118065984d49b97cce685da090d57ab37 # post-v1.10.0
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: perf-${{ matrix.unity-version }}-${{ matrix.test-mode }}-${{ matrix.benchmark-suite }}
@@ -1091,7 +1091,7 @@ jobs:
         id: return_unity_license
         if: ${{ always() && steps.acquire_lock.outputs.acquired == 'true' }}
         timeout-minutes: 5
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/return-unity-license@e6fa595a336e95d800c1139bdebf6d749ee6f186
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/return-unity-license@c054699118065984d49b97cce685da090d57ab37
         with:
           unity-version: ${{ matrix.unity-version }}
           tool-cache: ${{ runner.tool_cache }}
@@ -1103,7 +1103,7 @@ jobs:
         id: cleanup_classification
         if: ${{ always() && steps.acquire_lock.outputs.acquired == 'true' }}
         timeout-minutes: 2
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/classify-unity-cleanup-evidence@e6fa595a336e95d800c1139bdebf6d749ee6f186
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/classify-unity-cleanup-evidence@c054699118065984d49b97cce685da090d57ab37
         with:
           return-log-path: ${{ steps.return_unity_license.outputs.return-log-path }}
           return-command-completed: ${{ steps.return_unity_license.outputs.return-command-completed }}
@@ -1115,7 +1115,7 @@ jobs:
         id: release_unity_lock
         if: always()
         timeout-minutes: 5
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@e6fa595a336e95d800c1139bdebf6d749ee6f186 # post-v1.10.0
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@c054699118065984d49b97cce685da090d57ab37 # post-v1.10.0
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: perf-${{ matrix.unity-version }}-${{ matrix.test-mode }}-${{ matrix.benchmark-suite }}
@@ -1130,7 +1130,7 @@ jobs:
       - name: Require confirmed Unity cleanup
         if: always()
         timeout-minutes: 2
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-confirmed-unity-cleanup@e6fa595a336e95d800c1139bdebf6d749ee6f186
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-confirmed-unity-cleanup@c054699118065984d49b97cce685da090d57ab37
         with:
           # A leg that aborts before `Acquire organization Unity lock` runs never
           # took a seat, and this gate's own contract treats `acquired: false` as
@@ -1257,7 +1257,7 @@ jobs:
       - name: Require current PR head before reporting
         if: needs.perf-benchmarks.result == 'success'
         timeout-minutes: 2
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-current-pr-head@e6fa595a336e95d800c1139bdebf6d749ee6f186 # post-v1.10.0
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-current-pr-head@c054699118065984d49b97cce685da090d57ab37 # post-v1.10.0
         with:
           github-token: ${{ github.token }}
           pull-request-number: ${{ github.event.pull_request.number }}
@@ -1469,7 +1469,7 @@ jobs:
         id: report-freshness
         if: always()
         timeout-minutes: 2
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-current-pr-head@e6fa595a336e95d800c1139bdebf6d749ee6f186 # post-v1.10.0
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-current-pr-head@c054699118065984d49b97cce685da090d57ab37 # post-v1.10.0
         with:
           github-token: ${{ github.token }}
           pull-request-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,7 +168,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Require a registered Unity runner
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/check-unity-runner-availability@e6fa595a336e95d800c1139bdebf6d749ee6f186 # post-v1.10.0
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/check-unity-runner-availability@c054699118065984d49b97cce685da090d57ab37 # post-v1.10.0
         with:
           reader-app-id: ${{ secrets.BUILD_LOCK_READER_APP_ID }}
           reader-app-private-key: ${{ secrets.BUILD_LOCK_READER_APP_PRIVATE_KEY }}
@@ -324,7 +324,7 @@ jobs:
       - name: Acquire organization Unity lock
         id: acquire_lock
         timeout-minutes: 305
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@e6fa595a336e95d800c1139bdebf6d749ee6f186 # post-v1.10.0
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@c054699118065984d49b97cce685da090d57ab37 # post-v1.10.0
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: release-editmode
@@ -422,7 +422,7 @@ jobs:
         id: return_unity_license
         if: ${{ always() && steps.acquire_lock.outputs.acquired == 'true' }}
         timeout-minutes: 5
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/return-unity-license@e6fa595a336e95d800c1139bdebf6d749ee6f186
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/return-unity-license@c054699118065984d49b97cce685da090d57ab37
         with:
           unity-version: 2022.3.45f1
           tool-cache: ${{ runner.tool_cache }}
@@ -434,7 +434,7 @@ jobs:
         id: cleanup_classification
         if: ${{ always() && steps.acquire_lock.outputs.acquired == 'true' }}
         timeout-minutes: 2
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/classify-unity-cleanup-evidence@e6fa595a336e95d800c1139bdebf6d749ee6f186
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/classify-unity-cleanup-evidence@c054699118065984d49b97cce685da090d57ab37
         with:
           return-log-path: ${{ steps.return_unity_license.outputs.return-log-path }}
           return-command-completed: ${{ steps.return_unity_license.outputs.return-command-completed }}
@@ -446,7 +446,7 @@ jobs:
         id: release_unity_lock
         if: always()
         timeout-minutes: 5
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@e6fa595a336e95d800c1139bdebf6d749ee6f186 # post-v1.10.0
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@c054699118065984d49b97cce685da090d57ab37 # post-v1.10.0
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: release-editmode
@@ -461,7 +461,7 @@ jobs:
       - name: Require confirmed Unity cleanup
         if: always()
         timeout-minutes: 2
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-confirmed-unity-cleanup@e6fa595a336e95d800c1139bdebf6d749ee6f186
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-confirmed-unity-cleanup@c054699118065984d49b97cce685da090d57ab37
         with:
           # A leg that aborts before `Acquire organization Unity lock` runs never
           # took a seat, and this gate's own contract treats `acquired: false` as
@@ -626,7 +626,7 @@ jobs:
       - name: Acquire organization Unity lock
         id: acquire_lock
         timeout-minutes: 305
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@e6fa595a336e95d800c1139bdebf6d749ee6f186 # post-v1.10.0
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@c054699118065984d49b97cce685da090d57ab37 # post-v1.10.0
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: release-unitypackage
@@ -710,7 +710,7 @@ jobs:
         id: return_unity_license
         if: ${{ always() && steps.acquire_lock.outputs.acquired == 'true' }}
         timeout-minutes: 5
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/return-unity-license@e6fa595a336e95d800c1139bdebf6d749ee6f186
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/return-unity-license@c054699118065984d49b97cce685da090d57ab37
         with:
           unity-version: 2022.3.45f1
           tool-cache: ${{ runner.tool_cache }}
@@ -722,7 +722,7 @@ jobs:
         id: cleanup_classification
         if: ${{ always() && steps.acquire_lock.outputs.acquired == 'true' }}
         timeout-minutes: 2
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/classify-unity-cleanup-evidence@e6fa595a336e95d800c1139bdebf6d749ee6f186
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/classify-unity-cleanup-evidence@c054699118065984d49b97cce685da090d57ab37
         with:
           return-log-path: ${{ steps.return_unity_license.outputs.return-log-path }}
           return-command-completed: ${{ steps.return_unity_license.outputs.return-command-completed }}
@@ -734,7 +734,7 @@ jobs:
         id: release_unity_lock
         if: always()
         timeout-minutes: 5
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@e6fa595a336e95d800c1139bdebf6d749ee6f186 # post-v1.10.0
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@c054699118065984d49b97cce685da090d57ab37 # post-v1.10.0
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: release-unitypackage
@@ -749,7 +749,7 @@ jobs:
       - name: Require confirmed Unity cleanup
         if: always()
         timeout-minutes: 2
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-confirmed-unity-cleanup@e6fa595a336e95d800c1139bdebf6d749ee6f186
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-confirmed-unity-cleanup@c054699118065984d49b97cce685da090d57ab37
         with:
           # A leg that aborts before `Acquire organization Unity lock` runs never
           # took a seat, and this gate's own contract treats `acquired: false` as

--- a/.github/workflows/runner-bootstrap.yml
+++ b/.github/workflows/runner-bootstrap.yml
@@ -69,7 +69,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Require a registered Windows Unity runner
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/check-unity-runner-availability@e6fa595a336e95d800c1139bdebf6d749ee6f186 # post-v1.10.0
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/check-unity-runner-availability@c054699118065984d49b97cce685da090d57ab37 # post-v1.10.0
         with:
           reader-app-id: ${{ secrets.BUILD_LOCK_READER_APP_ID }}
           reader-app-private-key: ${{ secrets.BUILD_LOCK_READER_APP_PRIVATE_KEY }}

--- a/.github/workflows/unity-benchmarks.yml
+++ b/.github/workflows/unity-benchmarks.yml
@@ -33,7 +33,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Require a registered Unity runner
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/check-unity-runner-availability@e6fa595a336e95d800c1139bdebf6d749ee6f186 # post-v1.10.0
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/check-unity-runner-availability@c054699118065984d49b97cce685da090d57ab37 # post-v1.10.0
         with:
           reader-app-id: ${{ secrets.BUILD_LOCK_READER_APP_ID }}
           reader-app-private-key: ${{ secrets.BUILD_LOCK_READER_APP_PRIVATE_KEY }}
@@ -207,7 +207,7 @@ jobs:
       - name: Acquire organization Unity lock
         id: acquire_lock
         timeout-minutes: 305
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@e6fa595a336e95d800c1139bdebf6d749ee6f186 # post-v1.10.0
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@c054699118065984d49b97cce685da090d57ab37 # post-v1.10.0
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}
@@ -320,7 +320,7 @@ jobs:
         id: return_unity_license
         if: ${{ always() && steps.acquire_lock.outputs.acquired == 'true' }}
         timeout-minutes: 5
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/return-unity-license@e6fa595a336e95d800c1139bdebf6d749ee6f186
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/return-unity-license@c054699118065984d49b97cce685da090d57ab37
         with:
           unity-version: ${{ matrix.unity-version }}
           tool-cache: ${{ runner.tool_cache }}
@@ -332,7 +332,7 @@ jobs:
         id: cleanup_classification
         if: ${{ always() && steps.acquire_lock.outputs.acquired == 'true' }}
         timeout-minutes: 2
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/classify-unity-cleanup-evidence@e6fa595a336e95d800c1139bdebf6d749ee6f186
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/classify-unity-cleanup-evidence@c054699118065984d49b97cce685da090d57ab37
         with:
           return-log-path: ${{ steps.return_unity_license.outputs.return-log-path }}
           return-command-completed: ${{ steps.return_unity_license.outputs.return-command-completed }}
@@ -344,7 +344,7 @@ jobs:
         id: release_unity_lock
         if: always()
         timeout-minutes: 5
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@e6fa595a336e95d800c1139bdebf6d749ee6f186 # post-v1.10.0
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@c054699118065984d49b97cce685da090d57ab37 # post-v1.10.0
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}
@@ -359,7 +359,7 @@ jobs:
       - name: Require confirmed Unity cleanup
         if: always()
         timeout-minutes: 2
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-confirmed-unity-cleanup@e6fa595a336e95d800c1139bdebf6d749ee6f186
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-confirmed-unity-cleanup@c054699118065984d49b97cce685da090d57ab37
         with:
           # A leg that aborts before `Acquire organization Unity lock` runs never
           # took a seat, and this gate's own contract treats `acquired: false` as

--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -128,7 +128,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Require a registered Unity runner
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/check-unity-runner-availability@e6fa595a336e95d800c1139bdebf6d749ee6f186 # post-v1.10.0
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/check-unity-runner-availability@c054699118065984d49b97cce685da090d57ab37 # post-v1.10.0
         with:
           reader-app-id: ${{ secrets.BUILD_LOCK_READER_APP_ID }}
           reader-app-private-key: ${{ secrets.BUILD_LOCK_READER_APP_PRIVATE_KEY }}
@@ -166,7 +166,7 @@ jobs:
     steps:
       - name: Require current PR head before setup
         timeout-minutes: 2
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-current-pr-head@e6fa595a336e95d800c1139bdebf6d749ee6f186 # post-v1.10.0
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-current-pr-head@c054699118065984d49b97cce685da090d57ab37 # post-v1.10.0
         with:
           github-token: ${{ github.token }}
           pull-request-number: ${{ github.event.pull_request.number }}
@@ -344,7 +344,7 @@ jobs:
             steps.compute_standalone.outputs.is-empty != 'true'
           }}
         timeout-minutes: 2
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-current-pr-head@e6fa595a336e95d800c1139bdebf6d749ee6f186 # post-v1.10.0
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-current-pr-head@c054699118065984d49b97cce685da090d57ab37 # post-v1.10.0
         with:
           github-token: ${{ github.token }}
           pull-request-number: ${{ github.event.pull_request.number }}
@@ -353,7 +353,7 @@ jobs:
       - name: Acquire organization Unity lock
         id: acquire_lock
         timeout-minutes: 305
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@e6fa595a336e95d800c1139bdebf6d749ee6f186 # post-v1.10.0
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@c054699118065984d49b97cce685da090d57ab37 # post-v1.10.0
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-all-modes
@@ -628,7 +628,7 @@ jobs:
         id: return_unity_license
         if: ${{ always() && steps.acquire_lock.outputs.acquired == 'true' }}
         timeout-minutes: 5
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/return-unity-license@e6fa595a336e95d800c1139bdebf6d749ee6f186
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/return-unity-license@c054699118065984d49b97cce685da090d57ab37
         with:
           unity-version: ${{ matrix.unity-version }}
           tool-cache: ${{ runner.tool_cache }}
@@ -640,7 +640,7 @@ jobs:
         id: cleanup_classification
         if: ${{ always() && steps.acquire_lock.outputs.acquired == 'true' }}
         timeout-minutes: 2
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/classify-unity-cleanup-evidence@e6fa595a336e95d800c1139bdebf6d749ee6f186
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/classify-unity-cleanup-evidence@c054699118065984d49b97cce685da090d57ab37
         with:
           return-log-path: ${{ steps.return_unity_license.outputs.return-log-path }}
           return-command-completed: ${{ steps.return_unity_license.outputs.return-command-completed }}
@@ -652,7 +652,7 @@ jobs:
         id: release_unity_lock
         if: always()
         timeout-minutes: 5
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@e6fa595a336e95d800c1139bdebf6d749ee6f186 # post-v1.10.0
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@c054699118065984d49b97cce685da090d57ab37 # post-v1.10.0
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-all-modes
@@ -667,7 +667,7 @@ jobs:
       - name: Require confirmed Unity cleanup
         if: always()
         timeout-minutes: 2
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-confirmed-unity-cleanup@e6fa595a336e95d800c1139bdebf6d749ee6f186
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-confirmed-unity-cleanup@c054699118065984d49b97cce685da090d57ab37
         with:
           # A leg that aborts before `Acquire organization Unity lock` runs never
           # took a seat, and this gate's own contract treats `acquired: false` as

--- a/.llm/index.json
+++ b/.llm/index.json
@@ -486,7 +486,7 @@
         "category": "unity",
         "tags": "unity, testing, mcp, devcontainer, test-runner"
       },
-      "lineCount": 103,
+      "lineCount": 116,
       "references": [
         ".llm/skills/unity-mcp-test-loop/references/mcp-test-loop.md"
       ]

--- a/.llm/skills/unity-mcp-test-loop/SKILL.md
+++ b/.llm/skills/unity-mcp-test-loop/SKILL.md
@@ -29,14 +29,27 @@ Do not use it for source-generator or analyzer tests under `SourceGenerators/` (
 | Command                       | Runs on      | Purpose                                                  |
 | ----------------------------- | ------------ | -------------------------------------------------------- |
 | `npm run unity:mcp:bridge`    | Windows host | Spawn the relay and serve it over authenticated HTTP     |
-| `npm run unity:mcp:probe`     | Devcontainer | Discover a live endpoint and complete an MCP handshake   |
+| `npm run unity:mcp:probe`     | Devcontainer | Find an endpoint advertising `Unity_RunCommand`          |
 | `npm run unity:mcp:configure` | Devcontainer | Discover, then write every MCP client config in the repo |
 
 - Start the bridge on the host with `npm run unity:mcp:bridge -- --project 'D:\Path\To\HostUnityProject'`. `--project` is required for this command only and names a HOST filesystem path. The relay is discovered under `~/.unity/relay/`; override with `--relay <path>` or `UNITY_MCP_RELAY_PATH`.
 - The bridge requires a bearer token and generates one into `.env.local` at the repository root if none is set. Both sides must present the same `UNITY_MCP_BEARER_TOKEN`; copy it across or pass `--token` when host and container do not share `.env.local`. Add a Windows firewall rule for the port if the container cannot reach it.
-- From the container run `npm run unity:mcp:configure` then `npm run unity:mcp:probe`. Both probe before acting.
-- Discovery walks hosts in order - any explicit host, `host.docker.internal`, `127.0.0.1`, `nameserver` entries in `/etc/resolv.conf` (the Windows host under WSL2), then default-route gateways in `/proc/net/route` - and ports `9020` then `9003`. An explicit `--host` or `--port` is always tried first and is never overridden. `--no-discover` narrows probing to the configured host and port instead of walking the fallbacks; it still performs the handshake.
-- Failure statuses classify the fix: `unreachable` (nothing accepted TCP), `unauthorized` (bridge running, token rejected), `http-error` (not a streamable-HTTP MCP endpoint), `malformed` (no valid `initialize` result).
+- From the container run `npm run unity:mcp:configure` then `npm run unity:mcp:probe`. Discovery pins
+  MCP `2025-11-25`. Configure selects the first initialized endpoint without inspecting tools, or
+  writes the configured/default endpoint if none initializes. Probe follows `tools/list` pages and
+  requires `Unity_RunCommand`; it does not execute the tool or prove the heartbeat remains fresh.
+- Discovery walks hosts in order - `host.docker.internal`, `127.0.0.1`, `nameserver` entries in
+  `/etc/resolv.conf`, then default-route gateways - and ports `9020` then `9003`. An explicit
+  `--host` or `--port` replaces the fallbacks on that axis. `--no-discover` uses only the configured
+  host and port but still performs the protocol check.
+- Failure statuses classify the fix: `unreachable` (nothing accepted TCP), `transport-error` (a
+  request timed out or ended before an HTTP response), `unauthorized` (token rejected), `http-error`
+  (an operation returned non-success HTTP), `jsonrpc-error` (valid server error), `malformed`
+  (invalid media type, result, status, version, or cursor), and `not-ready` (`Unity_RunCommand` was
+  not advertised). The SDK transport streams SSE, validates schemas, and uses one lifecycle deadline;
+  a session-bearing HTTP 404 restarts initialization once without resetting that deadline.
+- A session-bearing probe always attempts bounded `DELETE` cleanup and releases its response. HTTP
+  405 is allowed; other cleanup failures warn without changing the readiness result.
 - `configure` writes `.mcp.json` (`mcpServers`), `.cursor/mcp.json` (`mcpServers`), `.vscode/mcp.json` (`servers`), and `.codex/config.toml` (`mcp_servers`) in one transaction with rollback. All four are machine-local and gitignored; only the `unity-mcp` entry is rewritten and other servers are preserved.
 - Local overrides go in `.env.local` or the matching flag: `UNITY_MCP_BRIDGE_HOST`, `UNITY_MCP_BRIDGE_PORT`, `UNITY_MCP_BRIDGE_PATH`, `UNITY_MCP_BEARER_TOKEN`, `UNITY_PROJECT_PATH`. `node scripts/mcp/unity-mcp.mjs --help` lists every flag.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Show a pause announcement coordinating independent UI and audio systems and a source-bound
   collision driving independent sound and breakable-object reactions on the homepage
   ([#426](https://github.com/Ambiguous-Interactive/DxMessaging/issues/426)).
+- Reduce repeated message-handler subscribe/unsubscribe churn by six managed allocation calls per
+  cycle ([#414](https://github.com/Ambiguous-Interactive/DxMessaging/issues/414)).
 
 ## [3.3.0]
 

--- a/Runtime/Core/Configuration/DxMessagingRuntimeSettings.cs
+++ b/Runtime/Core/Configuration/DxMessagingRuntimeSettings.cs
@@ -28,7 +28,7 @@ namespace DxMessaging.Core.Configuration
         /// <summary>Resource name (no extension) used by <c>Resources.Load</c>.</summary>
         public const string ResourceName = "DxMessagingRuntimeSettings";
 
-        /// <summary>Default soft cap on per-pool retained entries.</summary>
+        /// <summary>Default soft cap on retained entries in shared pools and the per-bus priority-leaf spare.</summary>
         public const int DefaultBufferMaxDistinctEntries = 512;
 
         /// <summary>Default idle threshold in seconds before an empty slot is eligible for eviction.</summary>
@@ -46,7 +46,7 @@ namespace DxMessaging.Core.Configuration
 
         [SerializeField]
         [Tooltip(
-            "Soft cap on the number of distinct entries each shared collection pool will retain. Excess entries are evicted (LRU or LIFO depending on BufferUseLruEviction)."
+            "Soft cap on distinct entries retained by shared collection pools and the per-bus empty priority-leaf spare. Zero disables retention; LRU selection does not affect the one-entry spare."
         )]
         [Min(0)]
         internal int _bufferMaxDistinctEntries = DefaultBufferMaxDistinctEntries;

--- a/Runtime/Core/MessageBus/MessageBus.cs
+++ b/Runtime/Core/MessageBus/MessageBus.cs
@@ -795,6 +795,7 @@ namespace DxMessaging.Core.MessageBus
             // bus-side map remains a separate candidate.
             public readonly List<MessageHandler> insertionOrder = new();
             public long version;
+            public int highWaterDistinctHandlers;
 
             /// <summary>
             /// Clears all handler references and resets the mutation version.
@@ -809,6 +810,38 @@ namespace DxMessaging.Core.MessageBus
                 version = 0;
             }
         }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private HandlerCache RentHandlerCache()
+        {
+            HandlerCache cache = _recycledEmptyHandlerCache;
+            if (cache == null)
+            {
+                return new HandlerCache();
+            }
+
+            _recycledEmptyHandlerCache = null;
+            return cache;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void RecycleHandlerCache(HandlerCache cache)
+        {
+            cache.Clear();
+            if (
+                _recycledEmptyHandlerCache == null
+                && _handlerCacheRetentionLimit > 0
+                && cache.highWaterDistinctHandlers <= _handlerCacheRetentionLimit
+            )
+            {
+                _recycledEmptyHandlerCache = cache;
+            }
+        }
+
+        internal object RecycledHandlerCacheForTesting => _recycledEmptyHandlerCache;
+
+        internal int RecycledHandlerCacheHighWaterForTesting =>
+            _recycledEmptyHandlerCache?.highWaterDistinctHandlers ?? 0;
 
         public int RegisteredTargeted
         {
@@ -1635,6 +1668,18 @@ namespace DxMessaging.Core.MessageBus
             DxPools.Configure(settings);
             ContextHandlerByTargetDicts.UseLru = settings.BufferUseLruEviction;
             ContextHandlerByTargetDicts.MaxRetained = settings.BufferMaxDistinctEntries;
+            _handlerCacheRetentionLimit = Math.Max(0, settings.BufferMaxDistinctEntries);
+            if (
+                _recycledEmptyHandlerCache != null
+                && (
+                    _handlerCacheRetentionLimit == 0
+                    || _recycledEmptyHandlerCache.highWaterDistinctHandlers
+                        > _handlerCacheRetentionLimit
+                )
+            )
+            {
+                _recycledEmptyHandlerCache = null;
+            }
             if (!settings.IsFallbackInstance)
             {
                 IMessageBus.GlobalMessageBufferSize = Math.Max(0, settings.MessageBufferSize);
@@ -1813,6 +1858,9 @@ namespace DxMessaging.Core.MessageBus
         private double _evictionTickIntervalSeconds = DefaultEvictionTickIntervalSeconds;
         private bool _idleEvictionEnabled = true;
         private bool _trimApiEnabled = true;
+        private int _handlerCacheRetentionLimit =
+            DxMessagingRuntimeSettings.DefaultBufferMaxDistinctEntries;
+        private HandlerCache _recycledEmptyHandlerCache;
         private double _lastSweepSeconds;
         private readonly List<int> _dirtyTypes = new();
         private readonly Dictionary<int, List<InstanceId>> _dirtyTargets = new();
@@ -2110,6 +2158,11 @@ namespace DxMessaging.Core.MessageBus
             if (force && _dispatchDepth == 0 && _postRouteCompactionRoutes != null)
             {
                 _postRouteCompactionRoutes = null;
+                pooledCollectionsEvicted++;
+            }
+            if (force && _recycledEmptyHandlerCache != null)
+            {
+                _recycledEmptyHandlerCache = null;
                 pooledCollectionsEvicted++;
             }
             _lastSweepSeconds = _clock.NowSeconds;
@@ -3193,6 +3246,7 @@ namespace DxMessaging.Core.MessageBus
             _dirtyHandlerSet.Clear();
             _dirtyHandlerTicks.Clear();
             _globalSlotSweepCandidate = false;
+            _recycledEmptyHandlerCache = null;
             _lastSweepSeconds = _clock.NowSeconds;
 
 #if UNITY_2021_3_OR_NEWER
@@ -5635,7 +5689,7 @@ namespace DxMessaging.Core.MessageBus
             if (!handlers.handlers.TryGetValue(priority, out HandlerCache cache))
             {
                 handlers.version++;
-                cache = new HandlerCache();
+                cache = RentHandlerCache();
                 handlers.handlers[priority] = cache;
                 // insert priority in sorted order
                 List<int> order = handlers.order;
@@ -5658,6 +5712,10 @@ namespace DxMessaging.Core.MessageBus
                 // record its position. Refcount increments (count > 0) must
                 // NOT move it.
                 cache.insertionOrder.Add(messageHandler);
+                cache.highWaterDistinctHandlers = Math.Max(
+                    cache.highWaterDistinctHandlers,
+                    cache.insertionOrder.Count
+                );
             }
             StageDispatchSnapshot<T>(this, capturedHandlers, slotKey);
             Type type = typeof(T);
@@ -5764,6 +5822,7 @@ namespace DxMessaging.Core.MessageBus
                         {
                             order.RemoveAt(removeIdx);
                         }
+                        RecycleHandlerCache(cache);
                     }
 
                     if (capturedHandlers.handlers.Count == 0)
@@ -5848,7 +5907,7 @@ namespace DxMessaging.Core.MessageBus
             if (!handlers.handlers.TryGetValue(priority, out HandlerCache cache))
             {
                 handlers.version++;
-                cache = new HandlerCache();
+                cache = RentHandlerCache();
                 handlers.handlers[priority] = cache;
                 // insert priority in sorted order
                 List<int> order = handlers.order;
@@ -5871,6 +5930,10 @@ namespace DxMessaging.Core.MessageBus
                 // record its position. Refcount increments (count > 0) must
                 // NOT move it.
                 cache.insertionOrder.Add(messageHandler);
+                cache.highWaterDistinctHandlers = Math.Max(
+                    cache.highWaterDistinctHandlers,
+                    cache.insertionOrder.Count
+                );
             }
 
             Type type = typeof(T);
@@ -5973,6 +6036,7 @@ namespace DxMessaging.Core.MessageBus
                         {
                             order.RemoveAt(removeIdx);
                         }
+                        RecycleHandlerCache(cache);
                     }
 
                     if (capturedHandlers.handlers.Count == 0)

--- a/Tests/Editor/Allocations/RegistrationAllocationCountTests.cs
+++ b/Tests/Editor/Allocations/RegistrationAllocationCountTests.cs
@@ -103,6 +103,7 @@ namespace DxMessaging.Tests.Editor.Allocations
         private const int WarmupRegistrations = 512;
         private const int SettleRegistrations = 64;
         private const int MeasuredRegistrations = 16;
+        private const int MeasuredDirectBusChurnCycles = 256;
 
         // Attempts for AllocationProbe.MeasureMin: a single allocation window in a warm,
         // long-lived editor domain intermittently spikes above the true cost, so we take
@@ -408,6 +409,46 @@ namespace DxMessaging.Tests.Editor.Allocations
                     + "RegistrationStorageStructuralGuardTests."
                     + "InternalRegisterPassesMetadataByValueNotFactory (per-PR EditMode leg)."
             );
+        }
+
+        [Test]
+        [Category("Allocation")]
+        public void WarmedDirectBusRegisterRemoveChurnIsAllocationFree()
+        {
+            MessageBus bus = NewBus();
+            MessageHandler handler = new MessageHandler(Owner, bus) { active = true };
+            MessageBusRegistration warm = bus.RegisterUntargeted<SimpleUntargetedMessage>(
+                handler,
+                priority: 0
+            );
+            bus.Deregister<SimpleUntargetedMessage>(in warm);
+
+            long allocationCount = AllocationProbe.MeasureMin(
+                MinAttempts,
+                prepare: null,
+                operation: () =>
+                {
+                    for (int i = 0; i < MeasuredDirectBusChurnCycles; ++i)
+                    {
+                        MessageBusRegistration registration =
+                            bus.RegisterUntargeted<SimpleUntargetedMessage>(handler, priority: 0);
+                        bus.Deregister<SimpleUntargetedMessage>(in registration);
+                    }
+                }
+            );
+
+            if (allocationCount == AllocationProbe.Unmeasured)
+            {
+                Assert.Ignore("GC.Alloc allocation probe is non-functional on this backend.");
+            }
+
+            Assert.AreEqual(
+                0,
+                allocationCount,
+                $"{MeasuredDirectBusChurnCycles} warmed direct-bus register/remove cycles must "
+                    + "reuse the detached priority leaf without managed allocation calls."
+            );
+            handler.active = false;
         }
 
         [Test]

--- a/Tests/Editor/Contract/StaleOverDeregistrationTests.cs
+++ b/Tests/Editor/Contract/StaleOverDeregistrationTests.cs
@@ -79,7 +79,8 @@ namespace DxMessaging.Tests.Editor.Contract
             );
             bus.Deregister<ProbeMessage>(in ownerOneRegistration);
 
-            // Owner two registers a live handler at the SAME (type, priority) -- a brand-new bucket.
+            // Owner two registers a live handler at the SAME (type, priority). The empty leaf may
+            // be recycled, but the stale registration still belongs to owner one.
             int ownerTwoInvocations = 0;
             Action<ProbeMessage> ownerTwoHandler = _ => ownerTwoInvocations++;
             _ = ownerTwo.RegisterUntargetedMessageHandler<ProbeMessage>(
@@ -120,7 +121,7 @@ namespace DxMessaging.Tests.Editor.Contract
             );
             bus.Deregister<ProbeMessage>(in ownerOneRegistration);
 
-            // A second bus-level registration so we hold the NEW bucket's handle for reflection.
+            // A second bus-level registration so we hold the live bucket's handle for reflection.
             MessageBusRegistration ownerTwoRegistration = bus.RegisterUntargeted<ProbeMessage>(
                 ownerTwo,
                 priority: 0

--- a/Tests/Runtime/Core/ReentrantMutationEmissionTests.cs
+++ b/Tests/Runtime/Core/ReentrantMutationEmissionTests.cs
@@ -135,6 +135,78 @@ namespace DxMessaging.Tests.Runtime.Core
             handler.active = false;
         }
 
+        [Test]
+        public void SoleHandlerRemoveRegisterThenReentrantEmitPreservesSnapshots(
+            [ValueSource(typeof(MessageScenarios), nameof(MessageScenarios.AllKinds))]
+                MessageScenario scenario
+        )
+        {
+            GameObject host = new(
+                nameof(SoleHandlerRemoveRegisterThenReentrantEmitPreservesSnapshots) + scenario.Kind
+            );
+            _spawned.Add(host);
+            MessageHandler handler = new(host) { active = true };
+            MessageBus bus = new();
+            MessageRegistrationToken token = MessageRegistrationToken.Create(handler, bus);
+            token.Enable();
+            using LeakWatcher watcher = new(
+                bus: bus,
+                throwOnLeak: true,
+                label: scenario.DisplayName
+            );
+            InstanceId hostId = host;
+            List<string> trace = new(2);
+            int depth = 0;
+            MessageRegistrationHandle soleHandle = default;
+            soleHandle = ScenarioCallbacks.RegisterCountingHandler(
+                scenario,
+                token,
+                hostId,
+                () =>
+                {
+                    trace.Add($"d{depth}:A");
+                    if (depth != 0)
+                    {
+                        return;
+                    }
+
+                    token.RemoveRegistration(soleHandle);
+                    _ = ScenarioCallbacks.RegisterCountingHandler(
+                        scenario,
+                        token,
+                        hostId,
+                        () => trace.Add($"d{depth}:B"),
+                        priority: 0
+                    );
+                    ++depth;
+                    try
+                    {
+                        ScenarioCallbacks.EmitForKind(scenario, bus, hostId);
+                    }
+                    finally
+                    {
+                        --depth;
+                    }
+                },
+                priority: 0
+            );
+
+            Assert.DoesNotThrow(
+                () => ScenarioCallbacks.EmitForKind(scenario, bus, hostId),
+                "[{0}] recycling the sole handler's empty priority leaf during dispatch must not throw.",
+                scenario.Kind
+            );
+            CollectionAssert.AreEqual(
+                new[] { "d0:A", "d1:B" },
+                trace,
+                "[{0}] the outer frozen snapshot must finish on the removed handler while the nested "
+                    + "snapshot dispatches only the replacement from the recycled leaf.",
+                scenario.Kind
+            );
+            token.UnregisterAll();
+            handler.active = false;
+        }
+
         /// <summary>
         /// A priority-0 handler registers a NEW same-type handler on the same
         /// bus and then re-emits the same type reentrant-style the same message type (guarded to a

--- a/Tests/Runtime/MemoryReclaim/MemoryReclamationTests.cs
+++ b/Tests/Runtime/MemoryReclaim/MemoryReclamationTests.cs
@@ -446,6 +446,224 @@ namespace DxMessaging.Tests.Runtime.MemoryReclaim
         }
 
         [Test]
+        public void EmptyPriorityLeafIsReusedAcrossEveryHandlerRoute(
+            [ValueSource(
+                typeof(MessageScenarios),
+                nameof(MessageScenarios.WithAndWithoutPostProcessorIncludingWithoutContext)
+            )]
+                MessageScenario scenario
+        )
+        {
+            MessageBus bus = MessageBus.CreateForInternalUse(new FakeClock());
+            using LeakWatcher watcher = LeakWatcher.WatchWithSlots(
+                bus,
+                label: scenario.DisplayName
+            );
+            using IDisposable cleanup = ForceTrimCleanup(bus);
+            MessageHandler handler = CreateActiveHandler(bus);
+
+            Action firstDeregister = RegisterDirect(
+                scenario,
+                handler,
+                bus,
+                DefaultContext,
+                () => { }
+            );
+            firstDeregister();
+            object firstSpare = bus.RecycledHandlerCacheForTesting;
+            Assert.IsNotNull(
+                firstSpare,
+                "[{0}] removing the sole priority handler must retain one detached empty leaf.",
+                scenario.DisplayName
+            );
+
+            Action secondDeregister = RegisterDirect(
+                scenario,
+                handler,
+                bus,
+                DefaultContext,
+                () => { }
+            );
+            Assert.IsNull(
+                bus.RecycledHandlerCacheForTesting,
+                "[{0}] the retained leaf must be rented while the replacement route is live.",
+                scenario.DisplayName
+            );
+            secondDeregister();
+
+            Assert.AreSame(
+                firstSpare,
+                bus.RecycledHandlerCacheForTesting,
+                "[{0}] scalar/context and handle/post routes must return the same leaf identity.",
+                scenario.DisplayName
+            );
+            handler.active = false;
+        }
+
+        [Test]
+        public void EmptyPriorityLeafSpareHasCapacityOneAndResetDrainsIt()
+        {
+            MessageBus bus = MessageBus.CreateForInternalUse(new FakeClock());
+            using LeakWatcher watcher = LeakWatcher.WatchWithSlots(bus, label: nameof(MessageBus));
+            using IDisposable cleanup = ForceTrimCleanup(bus);
+            MessageHandler firstHandler = new MessageHandler(new InstanceId(0x5A17_0010), bus)
+            {
+                active = true,
+            };
+            MessageHandler secondHandler = new MessageHandler(new InstanceId(0x5A17_0011), bus)
+            {
+                active = true,
+            };
+            MessageBusRegistration first = bus.RegisterUntargeted<UntargetedOne>(
+                firstHandler,
+                priority: 0
+            );
+            MessageBusRegistration second = bus.RegisterUntargeted<UntargetedOne>(
+                secondHandler,
+                priority: 1
+            );
+
+            bus.Deregister<UntargetedOne>(in first);
+            object retained = bus.RecycledHandlerCacheForTesting;
+            bus.Deregister<UntargetedOne>(in second);
+
+            Assert.AreSame(
+                retained,
+                bus.RecycledHandlerCacheForTesting,
+                "Returning a second empty leaf must not replace or grow the one-entry spare."
+            );
+            bus.ResetState();
+            Assert.IsNull(
+                bus.RecycledHandlerCacheForTesting,
+                "ResetState must release the detached empty priority leaf."
+            );
+            firstHandler.active = false;
+            secondHandler.active = false;
+        }
+
+        [Test]
+        public void EmptyPriorityLeafHonorsZeroAndHighWaterCaps()
+        {
+            DxMessagingRuntimeSettings settings =
+                ScriptableObject.CreateInstance<DxMessagingRuntimeSettings>();
+            IDisposable overrideToken = null;
+            try
+            {
+                settings._bufferMaxDistinctEntries = 2;
+                overrideToken = DxMessagingRuntimeSettingsProvider.Override(settings);
+                MessageBus bus = MessageBus.CreateForInternalUse(new FakeClock());
+                using IDisposable cleanup = ForceTrimCleanup(bus);
+                MessageHandler firstHandler = new MessageHandler(new InstanceId(0x5A17_0020), bus)
+                {
+                    active = true,
+                };
+                MessageHandler secondHandler = new MessageHandler(new InstanceId(0x5A17_0021), bus)
+                {
+                    active = true,
+                };
+                MessageBusRegistration first = bus.RegisterUntargeted<UntargetedOne>(
+                    firstHandler,
+                    priority: 0
+                );
+                MessageBusRegistration second = bus.RegisterUntargeted<UntargetedOne>(
+                    secondHandler,
+                    priority: 0
+                );
+                bus.Deregister<UntargetedOne>(in first);
+                bus.Deregister<UntargetedOne>(in second);
+
+                Assert.AreEqual(
+                    2,
+                    bus.RecycledHandlerCacheHighWaterForTesting,
+                    "A leaf at the configured distinct-handler cap must remain eligible."
+                );
+
+                settings._bufferMaxDistinctEntries = 1;
+                DxMessagingRuntimeSettings.RaiseSettingsChanged(settings);
+                Assert.IsNull(
+                    bus.RecycledHandlerCacheForTesting,
+                    "Lowering the cap below a retained leaf's high-water must drain it immediately."
+                );
+
+                first = bus.RegisterUntargeted<UntargetedOne>(firstHandler, priority: 0);
+                second = bus.RegisterUntargeted<UntargetedOne>(secondHandler, priority: 0);
+                bus.Deregister<UntargetedOne>(in first);
+                bus.Deregister<UntargetedOne>(in second);
+                Assert.IsNull(
+                    bus.RecycledHandlerCacheForTesting,
+                    "An active leaf whose high-water exceeds the lowered cap must drop on return."
+                );
+
+                MessageBusRegistration small = bus.RegisterUntargeted<UntargetedOne>(
+                    firstHandler,
+                    priority: 0
+                );
+                bus.Deregister<UntargetedOne>(in small);
+                Assert.AreEqual(
+                    1,
+                    bus.RecycledHandlerCacheHighWaterForTesting,
+                    "A replacement leaf within the cap must be eligible for reuse."
+                );
+
+                settings._bufferMaxDistinctEntries = 0;
+                DxMessagingRuntimeSettings.RaiseSettingsChanged(settings);
+                Assert.IsNull(
+                    bus.RecycledHandlerCacheForTesting,
+                    "Hot reload to cap zero must drain the retained leaf immediately."
+                );
+                MessageBusRegistration zeroCap = bus.RegisterUntargeted<UntargetedOne>(
+                    firstHandler,
+                    priority: 0
+                );
+                bus.Deregister<UntargetedOne>(in zeroCap);
+                Assert.IsNull(
+                    bus.RecycledHandlerCacheForTesting,
+                    "Cap zero must keep subsequent empty priority leaves out of retention."
+                );
+                firstHandler.active = false;
+                secondHandler.active = false;
+                GC.KeepAlive(bus);
+            }
+            finally
+            {
+                overrideToken?.Dispose();
+                UnityEngine.Object.DestroyImmediate(settings);
+            }
+        }
+
+        [Test]
+        public void ForcedTrimCountsPriorityLeafOnceAndThenIsIdempotent()
+        {
+            _ = DxPools.TrimAll(force: true);
+            MessageBus bus = MessageBus.CreateForInternalUse(new FakeClock());
+            MessageHandler handler = CreateActiveHandler(bus);
+            MessageBusRegistration registration = bus.RegisterUntargeted<UntargetedOne>(
+                handler,
+                priority: 0
+            );
+            bus.Deregister<UntargetedOne>(in registration);
+
+            IMessageBus.TrimResult first = bus.Trim(force: true);
+            IMessageBus.TrimResult second = bus.Trim(force: true);
+
+            Assert.AreEqual(
+                1,
+                first.PooledCollectionsEvicted,
+                "Forced trim must count the one detached priority leaf exactly once."
+            );
+            Assert.AreEqual(
+                0,
+                second.PooledCollectionsEvicted,
+                "Repeated forced trim must not count an already-drained priority leaf."
+            );
+            Assert.IsNull(
+                bus.RecycledHandlerCacheForTesting,
+                "Forced trim must release the detached priority leaf."
+            );
+            handler.active = false;
+        }
+
+        [Test]
         public void RuntimeSettingsHotReloadUpdatesTrimAndIdleGates()
         {
             DxMessagingRuntimeSettings settings =
@@ -519,6 +737,11 @@ namespace DxMessaging.Tests.Runtime.MemoryReclaim
                     DefaultContext
                 );
                 token.RemoveRegistration(handle);
+                object retainedHandlerCache = bus.RecycledHandlerCacheForTesting;
+                Assert.IsNotNull(
+                    retainedHandlerCache,
+                    "Removing the sole handler must create the retained empty priority leaf."
+                );
                 List<object> pooled = DxPools.ObjectLists.Rent();
                 DxPools.ObjectLists.Return(pooled);
                 int cachedBefore = DxPools.DescribeAll().ObjectLists.Cached;
@@ -528,6 +751,11 @@ namespace DxMessaging.Tests.Runtime.MemoryReclaim
                 Assert.AreEqual(default(IMessageBus.TrimResult), result);
                 Assert.GreaterOrEqual(bus.OccupiedTypeSlots, 1);
                 Assert.AreEqual(cachedBefore, DxPools.DescribeAll().ObjectLists.Cached);
+                Assert.AreSame(
+                    retainedHandlerCache,
+                    bus.RecycledHandlerCacheForTesting,
+                    "Disabled Trim must preserve the retained empty priority leaf identity."
+                );
             }
             finally
             {

--- a/docs/guides/mcp-local-setup.md
+++ b/docs/guides/mcp-local-setup.md
@@ -35,8 +35,12 @@ npm run unity:mcp:configure
 npm run unity:mcp:probe
 ```
 
-`configure` discovers a live endpoint and writes every MCP client config in one transaction. `probe`
-confirms the endpoint completes an MCP `initialize` handshake.
+`configure` selects the first endpoint that completes MCP initialization, then writes every MCP
+client config in one transaction. If no candidate completes initialization, it writes the explicitly
+configured or default endpoint. `probe` follows `tools/list` pagination and requires a candidate to
+advertise `Unity_RunCommand`. Both commands pin MCP `2025-11-25`. A successful probe does not execute
+the tool or validate Unity's later heartbeat. A `not-ready` result means the required tool was not
+advertised; wait for the editor to finish refreshing, then run the probe again.
 
 Neither command needs a host or port supplied. Discovery tries `host.docker.internal`, `127.0.0.1`,
 the `/etc/resolv.conf` nameserver (the Windows host under WSL2), and the default-route gateway,
@@ -73,7 +77,8 @@ activity may still trigger the Unity defect.
 
 Reopen Unity on the latest available patch and follow the Unity issue for fixed-version status. Run
 `npm run unity:mcp:probe` separately after the editor restarts; its `unreachable`, `unauthorized`,
-`http-error`, or `malformed` result identifies an actual bridge connection failure.
+`transport-error`, `http-error`, `jsonrpc-error`, `malformed`, or `not-ready` result separates TCP,
+MCP transport, server-reported, protocol, and tool-advertisement failures.
 
 ## Notes
 
@@ -82,6 +87,9 @@ Reopen Unity on the latest available patch and follow the Unity issue for fixed-
 - A probe that reports `unauthorized` means a bridge is running but the token does not match, which
   is a different fix from `unreachable`. `configure` refuses to write anything in that case, because
   a fresh generated token would be guaranteed wrong; copy the host's token or pass `--token` first.
+- `--timeout` is one deadline for the MCP lifecycle, including every `tools/list` page. Session
+  cleanup uses a separate bounded request. HTTP 405 is allowed; other cleanup failures are warnings.
+  A session-bearing HTTP 404 restarts initialization once without resetting the lifecycle deadline.
 - `configure` owns the whole `unity-mcp` entry in each file, including the entire
   `[mcp_servers.unity-mcp]` table in `.codex/config.toml`. Keys added inside that table are dropped
   on the next run.

--- a/docs/guides/memory-reclamation.md
+++ b/docs/guides/memory-reclamation.md
@@ -39,6 +39,11 @@ Reclamation targets two kinds of state:
 - **Pooled collections** held by `DxPools` and the bus-owned context-dictionary
   pool. Pools cap their retained entries with either LRU or bounded LIFO
   retention.
+- **One detached empty priority leaf per bus.** Register/remove churn reuses this
+  leaf instead of rebuilding its dictionary and ordered list every cycle. Its
+  distinct-handler high-water must stay within `BufferMaxDistinctEntries`; a
+  cap of zero disables retention. Because the spare holds one leaf,
+  `BufferUseLruEviction` does not affect it.
 
 Active registrations are never reclaimed. A handler that has not been
 deregistered, an interceptor that is still wired up, or a typed-handler slot
@@ -186,7 +191,8 @@ are read-only counters for the work the sweep performed:
 - `TargetSlotsEvicted` is the number of bus-side target or source context
   entries removed across all reclaimed `InstanceId`s.
 - `PooledCollectionsEvicted` is the number of pooled collections dropped from
-  shared pools (`DxPools` plus the bus-owned context-dictionary pool).
+  shared pools (`DxPools` plus the bus-owned context-dictionary pool) and the
+  detached per-bus priority leaf.
 - `LiveTypeSlotsRemaining` is the count of occupied type slots remaining on
   the bus after the sweep. This is the same value `OccupiedTypeSlots` returns
   immediately after the sweep.

--- a/docs/ops/ambiguous-release-migration.md
+++ b/docs/ops/ambiguous-release-migration.md
@@ -101,7 +101,7 @@ organization lock.
     uses: ./.github/actions/validate-unity-license
 
   - name: Acquire organization Unity lock
-    uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@e6fa595a336e95d800c1139bdebf6d749ee6f186 # post-v1.10.0
+    uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@c054699118065984d49b97cce685da090d57ab37 # post-v1.10.0
     with:
       lock-name: wallstop-organization-builds
       runner-id: ${{ runner.name }}

--- a/docs/ops/ci-and-github-settings.md
+++ b/docs/ops/ci-and-github-settings.md
@@ -36,7 +36,7 @@ the central lock immediately before the licensed Unity section:
   uses: ./.github/actions/validate-unity-license
 
 - name: Acquire organization Unity lock
-  uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@e6fa595a336e95d800c1139bdebf6d749ee6f186 # post-v1.10.0
+  uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@c054699118065984d49b97cce685da090d57ab37 # post-v1.10.0
   with:
     lock-name: wallstop-organization-builds
     runner-id: ${{ runner.name }}
@@ -286,8 +286,9 @@ Protect the default branch and release tags:
 1. Require status checks. A required check must report on every pull request
    shape, or auto-merge hangs waiting for an absent check. Use only checks that
    the [Required Status Checks runbook](../runbooks/required-checks.md) lists as
-   applied or remediated, and verify new required checks on real PRs before
-   adding them to the ruleset.
+   applied or remediated. The live aggregate set is `CI Success`,
+   `Unity CI Success`, and `Devcontainer CI Success`; verify new required checks
+   on real PRs before adding them to the ruleset.
 1. Require signed tags or limit tag creation to release maintainers if the
    organization supports it.
 1. Protect `v*` tags from deletion or force updates.

--- a/docs/reference/runtime-settings.md
+++ b/docs/reference/runtime-settings.md
@@ -59,7 +59,7 @@ folder because `Resources.Load` would not find it there.
 | Name                           | C# property                   | Type  | Default                                      | Min | Tooltip                                                                                                                                                                                                                 | Hot-reload | When to change                                                                                                                |
 | ------------------------------ | ----------------------------- | ----- | -------------------------------------------- | --- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------- |
 | Idle Eviction Seconds          | `IdleEvictionSeconds`         | float | 30.0                                         | 0   | Idle threshold in seconds. Empty per-message-type slots are evicted only after going at least this long without a register/deregister/dispatch touch.                                                                   | Yes        | Lower for leak diagnosis or aggressive reclaim; raise for high-throughput scenarios where slots empty briefly between bursts. |
-| Buffer Max Distinct Entries    | `BufferMaxDistinctEntries`    | int   | 512                                          | 0   | Soft cap on the number of distinct entries each shared collection pool will retain. Excess entries are evicted (LRU or LIFO depending on BufferUseLruEviction).                                                         | Yes        | Lower on memory-constrained targets; raise when profiling shows pool churn from a small cap.                                  |
+| Buffer Max Distinct Entries    | `BufferMaxDistinctEntries`    | int   | 512                                          | 0   | Soft cap on distinct entries retained by shared collection pools and the per-bus empty priority-leaf spare. Zero disables retention; LRU selection does not affect the one-entry spare.                                 | Yes        | Lower on memory-constrained targets; raise when profiling shows pool churn from a small cap.                                  |
 | Buffer Use LRU Eviction        | `BufferUseLruEviction`        | bool  | true                                         | --  | When true, shared collection pools use LRU eviction; otherwise pools behave as a bounded LIFO stack.                                                                                                                    | Yes        | Switch to LIFO when access patterns are short-lived bursts; keep LRU for steady-state reuse.                                  |
 | Enable Trim API                | `EnableTrimApi`               | bool  | true                                         | --  | When true, IMessageBus.Trim performs its work; when false it is a no-op returning default. Lets shipped titles disable on-demand reclamation.                                                                           | Yes        | Disable in shipped titles that do not call Trim and do not want third-party code to force a sweep.                            |
 | Eviction Tick Interval Seconds | `EvictionTickIntervalSeconds` | float | 5.0                                          | 0   | Minimum interval in seconds between idle sweeps. Emit-time idle eviction samples the clock periodically instead of at the top of every Emit, and sweeps only when this much wall time has elapsed since the last sweep. | Yes        | Raise to reduce sweep frequency on busy hot paths; lower for tighter reclaim cadence.                                         |
@@ -77,12 +77,12 @@ zero before raising `SettingsChanged`.
 `DxMessagingRuntimeSettings` exposes four `public const` fields so scripts can
 reference the same defaults the asset ships with:
 
-| Constant                             | Type     | Value                          | Purpose                                                               |
-| ------------------------------------ | -------- | ------------------------------ | --------------------------------------------------------------------- |
-| `ResourceName`                       | `string` | `"DxMessagingRuntimeSettings"` | Resource name (no extension) used by `Resources.Load`.                |
-| `DefaultBufferMaxDistinctEntries`    | `int`    | 512                            | Default soft cap on per-pool retained entries.                        |
-| `DefaultIdleEvictionSeconds`         | `float`  | 30                             | Default idle threshold in seconds before an empty slot becomes stale. |
-| `DefaultEvictionTickIntervalSeconds` | `float`  | 5                              | Default minimum interval between idle sweeps, in seconds.             |
+| Constant                             | Type     | Value                          | Purpose                                                                                   |
+| ------------------------------------ | -------- | ------------------------------ | ----------------------------------------------------------------------------------------- |
+| `ResourceName`                       | `string` | `"DxMessagingRuntimeSettings"` | Resource name (no extension) used by `Resources.Load`.                                    |
+| `DefaultBufferMaxDistinctEntries`    | `int`    | 512                            | Default soft cap on retained entries in shared pools and the per-bus priority-leaf spare. |
+| `DefaultIdleEvictionSeconds`         | `float`  | 30                             | Default idle threshold in seconds before an empty slot becomes stale.                     |
+| `DefaultEvictionTickIntervalSeconds` | `float`  | 5                              | Default minimum interval between idle sweeps, in seconds.                                 |
 
 Reference these constants from test fixtures and bootstrap code rather than
 duplicating literal values.
@@ -153,12 +153,12 @@ public readonly struct TrimResult : IEquatable<TrimResult>
 }
 ```
 
-| Field                      | Description                                                                                                    |
-| -------------------------- | -------------------------------------------------------------------------------------------------------------- |
-| `TypeSlotsEvicted`         | Number of typed-handler slots reset across all reclaimed message types.                                        |
-| `TargetSlotsEvicted`       | Number of bus target or source context entries removed.                                                        |
-| `PooledCollectionsEvicted` | Number of pooled collections dropped from shared pools (`DxPools` plus the bus-owned context-dictionary pool). |
-| `LiveTypeSlotsRemaining`   | Number of occupied type slots remaining after the trim; equal to a post-trim read of `OccupiedTypeSlots`.      |
+| Field                      | Description                                                                                                                                              |
+| -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `TypeSlotsEvicted`         | Number of typed-handler slots reset across all reclaimed message types.                                                                                  |
+| `TargetSlotsEvicted`       | Number of bus target or source context entries removed.                                                                                                  |
+| `PooledCollectionsEvicted` | Number of pooled collections dropped from shared pools (`DxPools` plus the bus-owned context-dictionary pool) and the per-bus empty priority-leaf spare. |
+| `LiveTypeSlotsRemaining`   | Number of occupied type slots remaining after the trim; equal to a post-trim read of `OccupiedTypeSlots`.                                                |
 
 The struct overrides `ToString()` and implements equality on all four fields.
 
@@ -179,9 +179,10 @@ public static event Action<DxMessagingRuntimeSettings> SettingsChanged;
 Existing buses subscribe to the event and call `ApplyRuntimeSettings`, which
 re-applies the eviction toggles, idle threshold, tick interval, pool caps,
 retention mode, and message buffer size without recreating the bus. The
-shared `DxPools` pools and the bus-owned context-dictionary pool reapply the
-new caps on the next reclaim opportunity. Live registrations are not
-disturbed.
+shared `DxPools` pools, the bus-owned context-dictionary pool, and the one-entry
+per-bus empty priority-leaf spare reapply the new cap. Lowering the cap below the
+spare's distinct-handler high-water drains it immediately. LRU selection does
+not affect a one-entry spare. Live registrations are not disturbed.
 
 The `RuntimeInitializeOnLoadMethod(SubsystemRegistration)` hook clears
 `SettingsChanged` subscribers when a new domain loads, preventing stale

--- a/docs/runbooks/required-checks.md
+++ b/docs/runbooks/required-checks.md
@@ -26,12 +26,14 @@ non-matching pull requests and cannot be required as written.
 ## Current state
 
 Auto-merge is enabled. The aggregate CI gate is **applied and live
-(2026-07-30)**: repository ruleset `Required CI - Unity Tests (default branch)`
-(id `17663217`, active, `~DEFAULT_BRANCH`) requires exactly `CI Success` and
-`Unity CI Success`. PR #316 verified both aggregates before merge, and the
-`CI Success` aggregate also reported on the default branch after merge. The 14
-individual static contexts remain dependencies of `CI Success`, but the
-ruleset does not require their literal names.
+(2026-08-20)**: repository ruleset `Required CI - Unity Tests (default branch)`
+(id `17663217`, active, `~DEFAULT_BRANCH`) requires exactly `CI Success`,
+`Unity CI Success`, and `Devcontainer CI Success`. PR #316 verified the first
+two aggregates before their 2026-07-30 switch. PR #382 verified the devcontainer
+aggregate with both architecture jobs relevant and successful; PR #385 verified
+the unrelated-change path with both architecture jobs skipped and the aggregate
+successful. The 14 individual static contexts remain dependencies of
+`CI Success`, but the ruleset does not require their literal names.
 
 The `bot-auto-commit` App (id `3977200`) stays in `bypass_actors` (mode
 `always`) so the perf-doc and generated-doc auto-commits can still push to
@@ -44,6 +46,7 @@ The target ruleset requires exactly these stable aggregate contexts:
 ```text
 CI Success
 Unity CI Success
+Devcontainer CI Success
 ```
 
 Do not add individual static job names or Unity matrix names to the ruleset
@@ -124,6 +127,26 @@ skipped check with the literal name
 `Unity ${{ matrix.unity-version }} all modes`, so requiring the
 expanded names leaves auto-merge waiting for absent checks.
 
+### Devcontainer CI Success
+
+[`devcontainer-test.yml`](https://github.com/Ambiguous-Interactive/DxMessaging/blob/master/.github/workflows/devcontainer-test.yml)
+always starts for pull requests. Its `changes` job determines whether
+devcontainer files changed. The x64 and native ARM64 smoke jobs run when they
+are relevant and otherwise report `skipped`; the final `Devcontainer CI Success`
+job uses `if: ${{ always() }}` and fails closed unless change detection succeeded
+with an explicit result. PR #382 proved the relevant path with both smoke jobs
+successful. PR #385 proved the unrelated path with both smoke jobs skipped and
+the aggregate successful.
+
+Require only the stable aggregate:
+
+```text
+Devcontainer CI Success
+```
+
+Do not require either architecture job directly. The aggregate is the literal
+branch-protection API and remains present for both change shapes.
+
 ## Retired Individual Static Contexts
 
 Before the aggregate switch, ruleset `17663217` required these 14 static
@@ -146,10 +169,6 @@ Script tests (windows-latest)
 Validate Documentation Build
 Lint docs links
 ```
-
-`devcontainer-test.yml` reports the always-present `Devcontainer CI Success`
-aggregate across the x64 and native ARM64 smoke jobs. Require that aggregate
-only if devcontainer changes must gate merges.
 
 ## Must NOT be required
 
@@ -287,7 +306,8 @@ gh api repos/Ambiguous-Interactive/DxMessaging/rulesets/17663217 \
       | if .type == "required_status_checks" then
           .parameters.required_status_checks = [
             {"context": "CI Success"},
-            {"context": "Unity CI Success"}
+            {"context": "Unity CI Success"},
+            {"context": "Devcontainer CI Success"}
           ]
         else
           .
@@ -347,9 +367,6 @@ Validate Documentation Build
 Lint docs links
 ```
 
-If devcontainer image changes should gate merges, also add
-`Devcontainer CI Success` after verifying its run-or-skip behavior on real PRs.
-
 ```bash
 # PUT the existing ruleset with the augmented contexts (keep target/conditions/
 # bypass_actors; extend required_status_checks). Two jobs were renamed to get a
@@ -358,14 +375,17 @@ If devcontainer image changes should gate merges, also add
 gh api repos/OWNER/REPO/rulesets/<id> -X PUT --input augmented-ruleset.json
 ```
 
-## Aggregate ruleset switch (DONE 2026-07-30)
+## Aggregate ruleset switches (DONE 2026-08-20)
 
 PR #316 verified `CI Success` and `Unity CI Success` on a real workflow and
-documentation change. Ruleset `17663217` now contains only:
+documentation change before the 2026-07-30 switch. PRs #382 and #385 verified
+the relevant and unrelated paths for `Devcontainer CI Success` before its
+2026-08-20 addition. Ruleset `17663217` now contains only:
 
 ```text
 CI Success
 Unity CI Success
+Devcontainer CI Success
 ```
 
 The switch preserved the existing `conditions`, `bypass_actors`, enforcement
@@ -404,24 +424,26 @@ When the required set or a workflow changes, keep them in sync:
    `scripts/__tests__/ci-aggregate-workflow.test.js`.
 1. Renaming a static job's `name:`: keep `CI Success` unchanged, and update docs
    that list the human-readable job name.
-1. Renaming `CI Success` or `Unity CI Success`: update the ruleset in the same
-   change after the new name has reported on real PRs.
+1. Renaming `CI Success`, `Unity CI Success`, or `Devcontainer CI Success`:
+   update the ruleset in the same change after the new name has reported on real
+   PRs.
 1. Bumping `.github/unity-versions.json`: do not edit the ruleset while it
    requires `Unity CI Success`; verify the aggregate still reports on a real PR
    or dispatch run after the version change merges.
 1. Drift check: compare the ruleset's `required_status_checks` contexts against
-   `CI Success` and `Unity CI Success`. `gh api .../rulesets/<id>` lists the
-   configured contexts; aggregate job `name:` fields are the source of truth.
+   `CI Success`, `Unity CI Success`, and `Devcontainer CI Success`.
+   `gh api .../rulesets/<id>` lists the configured contexts; aggregate job
+   `name:` fields are the source of truth.
 
 ## Verification
 
 After applying the ruleset:
 
-1. Open a throwaway doc-only pull request and a code-only pull request.
-1. Confirm every required check reports (runs or skips) on both, so neither
-   hangs waiting for an absent check.
-1. Confirm auto-merge completes only once all required checks are green.
-1. Delete the throwaway pull requests.
+1. Observe the next unrelated pull request and the next pull request that touches the gate's
+   relevant inputs. For the devcontainer gate, use `.devcontainer/**` or `.github/**`.
+1. Confirm every required check reports (runs or skips) on both, so neither hangs waiting for an
+   absent check.
+1. Confirm auto-merge waits for every required check, then completes only after all are green.
 
 ## See Also
 

--- a/scripts/__tests__/unity-mcp.test.js
+++ b/scripts/__tests__/unity-mcp.test.js
@@ -1,5 +1,4 @@
 "use strict";
-
 const assert = require("node:assert/strict");
 const { EventEmitter } = require("node:events");
 const fs = require("node:fs");
@@ -10,16 +9,7 @@ const path = require("node:path");
 const { PassThrough, Writable } = require("node:stream");
 const { before, test } = require("node:test");
 const { pathToFileURL } = require("node:url");
-
-/**
- * `scripts/mcp/unity-mcp.mjs` is ESM because the MCP SDK and smol-toml are ESM-only, while
- * `scripts/index.js` (the entry point `node --test scripts/` resolves to on Node 21+) can only
- * `require` CJS `*.test.js` files. Loading the module lazily inside each test keeps registration
- * synchronous, so the suite is discovered exactly like the rest of the repository's tests.
- * ESM module caching makes every call after the first free.
- */
 const MODULE_URL = pathToFileURL(path.join(__dirname, "..", "mcp", "unity-mcp.mjs")).href;
-
 let DEFAULTS;
 let assertPortAvailable;
 let buildRelayArgs;
@@ -49,7 +39,6 @@ let stripJsonComments;
 let transactionalWrite;
 let validateEndpointPath;
 let validateHost;
-
 before(async () => {
   ({
     DEFAULTS,
@@ -83,24 +72,16 @@ before(async () => {
     validateHost
   } = await import(MODULE_URL));
 });
-
-// Duplicated deliberately: the data-driven cases below are built at registration time, before the
-// module can be awaited. The `DEFAULTS.protocolVersion` test guards the duplication from drifting.
 const PROTOCOL_VERSION = "2025-11-25";
-
 function temporaryDirectory() {
   return fs.mkdtempSync(path.join(os.tmpdir(), "unity-mcp-test-"));
 }
-
-/** A closed-on-cleanup TCP listener, so reachability is exercised for real rather than stubbed. */
 async function listeningPort(t) {
   const server = net.createServer();
   await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
   t.after(() => new Promise((resolve) => server.close(resolve)));
   return server.address().port;
 }
-
-/** A port nothing listens on: bind it, record the number, release it. */
 async function closedPort() {
   const server = net.createServer();
   await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
@@ -108,8 +89,6 @@ async function closedPort() {
   await new Promise((resolve) => server.close(resolve));
   return port;
 }
-
-/** Swap a console method out for the duration of one test and collect what it was given. */
 function captureConsole(t, method) {
   const captured = [];
   const original = console[method];
@@ -119,7 +98,6 @@ function captureConsole(t, method) {
   });
   return captured;
 }
-
 function probeOptions(overrides = {}) {
   return {
     protocolVersion: PROTOCOL_VERSION,
@@ -129,41 +107,85 @@ function probeOptions(overrides = {}) {
     ...overrides
   };
 }
-
 function initializeResponse(
   body,
   { status = 200, contentType = "application/json", sessionId } = {}
 ) {
-  const headers = new Map([["content-type", contentType]]);
-  if (sessionId) {
-    headers.set("mcp-session-id", sessionId);
-  }
-  return {
-    ok: status >= 200 && status < 300,
-    status,
-    headers: { get: (key) => headers.get(key.toLowerCase()) ?? null },
-    text: async () => body
+  const headers = { "content-type": contentType };
+  if (sessionId) headers["mcp-session-id"] = sessionId;
+  return new Response(body, { status, headers });
+}
+const OK_PAYLOAD = `{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"${PROTOCOL_VERSION}","capabilities":{"tools":{}},"serverInfo":{"name":"unity","version":"1"}}}`;
+const TOOLS_PAYLOAD =
+  '{"jsonrpc":"2.0","id":2,"result":{"tools":[{"name":"Unity_RunCommand","inputSchema":{"type":"object"}}]}}';
+// prettier-ignore
+function readyProbeFetch(options = {}) {
+  const contentType = options.contentType ?? "application/json";
+  const encode = (payload, ping) => contentType !== "text/event-stream" ? payload :
+    new ReadableStream({ start: (controller) => [ping ? `event: message\ndata: {"jsonrpc":"2.0","id":"ping-1","method":"ping"}\n\n` : "", `event: message\ndata: ${payload.replace(/,"/, ',\ndata: "')}\n\n`].filter(Boolean).forEach((chunk) => controller.enqueue(new TextEncoder().encode(chunk))) });
+  return async (_url, init) => {
+    options.requests?.push(init);
+    if (init.method === "GET") {
+      const lastEventId = new Headers(init.headers).get("last-event-id");
+      if (!lastEventId || !options.resumePayload) return initializeResponse("", { status: 405 });
+      if ((options.resume404s ?? 0) < (options.resumeNotFoundCount ?? 0)) {
+        options.resume404s = (options.resume404s ?? 0) + 1;
+        options.resumePayload = undefined;
+        return initializeResponse("expired", { status: 404, sessionId: "session-1" });
+      }
+      options.resumedId = lastEventId;
+      return initializeResponse(encode(options.resumePayload, true), { contentType: options.resumeContentType ?? contentType, status: options.resumeStatus ?? 200 });
+    }
+    if (init.method === "DELETE") {
+      if (options.deleteError) throw options.deleteError;
+      return initializeResponse("", { status: options.deleteStatus ?? 202 });
+    }
+    const request = JSON.parse(init.body);
+    if (!request.method) {
+      options.pongs?.push(request);
+      return initializeResponse("", { status: 202 });
+    }
+    if (options.hang === request.method) {
+      return new Promise((resolve, reject) => {
+        const abort = () => reject(init.signal.reason);
+        init.signal.aborted ? abort() : init.signal.addEventListener("abort", abort, { once: true });
+      });
+    }
+    if (options.notFoundOnce === request.method && (options.didReturn404 ?? 0) < (options.notFoundCount ?? 1)) {
+      options.didReturn404 = (options.didReturn404 ?? 0) + 1;
+      return initializeResponse("expired", { status: 404 });
+    }
+    if (request.method === "initialize") {
+      if (options.bodyError) {
+        const body = new ReadableStream({ start: (controller) => controller.error(options.bodyError) });
+        return initializeResponse(body, { contentType, sessionId: "session-1" });
+      }
+      const payload = JSON.parse(options.initialize ?? OK_PAYLOAD);
+      payload.id = request.id;
+      return initializeResponse(encode(JSON.stringify(payload)), {
+        contentType,
+        status: options.initializeStatus ?? 200,
+        sessionId: Object.hasOwn(options, "sessionId") ? options.sessionId : "session-1"
+      });
+    }
+    if (request.method === "notifications/initialized") {
+      if (options.initializedError) throw options.initializedError;
+      return initializeResponse("", { status: options.initializedStatus ?? 202 });
+    }
+    const tools = typeof options.tools === "function" ? options.tools(request) : options.tools;
+    const payload = JSON.parse(tools ?? TOOLS_PAYLOAD);
+    payload.id = request.id;
+    const encoded = JSON.stringify(payload);
+    if (options.resume && !options.resumePayload) {
+      options.resumePayload = encoded;
+      return initializeResponse('id: resume-1\nretry: 0\nevent: message\ndata: {"jsonrpc":"2.0","id":"ping-resume","method":"ping"}\n\n', { contentType });
+    }
+    return initializeResponse(encode(encoded), { contentType });
   };
 }
-
-const OK_PAYLOAD = JSON.stringify({
-  jsonrpc: "2.0",
-  id: 1,
-  result: {
-    protocolVersion: PROTOCOL_VERSION,
-    capabilities: {},
-    serverInfo: { name: "unity", version: "1" }
-  }
-});
-
-// ---------------------------------------------------------------------------
-// Argument and environment parsing
-// ---------------------------------------------------------------------------
-
 test("DEFAULTS.protocolVersion matches the protocol version pinned in this suite", () => {
   assert.equal(DEFAULTS.protocolVersion, PROTOCOL_VERSION);
 });
-
 test("parseArgs accepts values, equals form, and flags", () => {
   const parsed = parseArgs(["--host", "1.2.3.4", "--port=9100", "--no-discover"]);
   assert.equal(parsed.host, "1.2.3.4");
@@ -171,13 +193,11 @@ test("parseArgs accepts values, equals form, and flags", () => {
   assert.equal(parsed["no-discover"], true);
   assert.deepEqual(parsed._, []);
 });
-
 for (const [label, argv, message] of [
   ["unknown option", ["--nope", "x"], /Unknown option: --nope/],
   ["missing value", ["--host"], /Missing value for --host/],
   ["value that looks like an option", ["--host", "--port"], /Missing value for --host/],
   ["value given to a flag", ["--no-discover=1"], /--no-discover does not take a value/],
-  // `--host=` used to resolve to "" and then silently fall back to the default host.
   ["empty equals-form value", ["--host="], /--host requires a non-empty value/],
   ["empty separate value", ["--host", ""], /--host requires a non-empty value/]
 ]) {
@@ -185,7 +205,6 @@ for (const [label, argv, message] of [
     assert.throws(() => parseArgs(argv), message);
   });
 }
-
 test("parseDotEnv handles quoting, comments, and export prefixes", () => {
   const parsed = parseDotEnv(
     [
@@ -203,14 +222,10 @@ test("parseDotEnv handles quoting, comments, and export prefixes", () => {
     B: "single"
   });
 });
-
 test("parseDotEnv rejects malformed entries", () => {
   assert.throws(() => parseDotEnv("not an assignment"), /Invalid .* entry on line 1/);
   assert.throws(() => parseDotEnv('A="unterminated'), /Invalid quoted value/);
 });
-
-// A quoted Windows path ends in a backslash, which a naive scanner reads as escaping the closing
-// quote; the docs recommend exactly that shape for UNITY_PROJECT_PATH.
 for (const [label, line, expected] of [
   ["a trailing backslash", 'A="D:\\Program Files\\Proj\\"', "D:\\Program Files\\Proj\\"],
   ["an escaped quote", 'A="say \\"hi\\""', 'say "hi"'],
@@ -223,7 +238,6 @@ for (const [label, line, expected] of [
     assert.deepEqual(parseDotEnv(line), { A: expected });
   });
 }
-
 test("readLocalEnv skips unparsable lines instead of aborting every command", (t) => {
   const repoRoot = temporaryDirectory();
   fs.writeFileSync(
@@ -233,37 +247,26 @@ test("readLocalEnv skips unparsable lines instead of aborting every command", (t
     )
   );
   const warnings = captureConsole(t, "warn");
-
   assert.deepEqual(readLocalEnv(repoRoot), { UNITY_MCP_BRIDGE_HOST: "10.0.0.5", C: "3" });
   assert.equal(warnings.length, 2, "each bad line is reported once");
   assert.match(warnings[0], /line 2/);
   assert.match(warnings[1], /line 3/);
   assert.deepEqual(readLocalEnv(path.join(repoRoot, "absent")), {});
 });
-
-// ---------------------------------------------------------------------------
-// Validation
-// ---------------------------------------------------------------------------
-
 for (const value of ["127.0.0.1", "host.docker.internal", "::1", "example.com.", "a-b.example"]) {
   test(`validateHost accepts ${value}`, () => assert.equal(validateHost(value), value));
 }
-
 for (const value of ["", "-bad.example", "bad-.example", "a..b", "has space", "has\nnewline"]) {
   test(`validateHost rejects ${JSON.stringify(value)}`, () =>
     assert.throws(() => validateHost(value)));
 }
-
 test("validateEndpointPath normalizes and rejects traversal", () => {
   assert.equal(validateEndpointPath("mcp"), "/mcp");
   assert.equal(validateEndpointPath("/mcp"), "/mcp");
-  // /%FF is a syntactically valid escape that is not valid UTF-8: decodeURIComponent throws a raw
-  // URIError, which used to escape as "URI malformed" instead of the normal message.
   for (const bad of ["/a//b", "/../etc", "/a/./b", "/%zz", "/%FF", "/%C3%28"]) {
     assert.throws(() => validateEndpointPath(bad), /Invalid MCP endpoint path/);
   }
 });
-
 test("endpointUrl brackets IPv6 literals", () => {
   assert.equal(
     endpointUrl({ host: "10.0.0.5", port: 9020, endpointPath: "/mcp" }),
@@ -274,35 +277,25 @@ test("endpointUrl brackets IPv6 literals", () => {
     "http://[::1]:9020/mcp"
   );
 });
-
-// ---------------------------------------------------------------------------
-// Option resolution
-// ---------------------------------------------------------------------------
-
 test("resolveOptions prefers args over env over .env.local over defaults", () => {
   const local = { UNITY_MCP_BRIDGE_HOST: "local.example", UNITY_MCP_BRIDGE_PORT: "9001" };
   const environment = { UNITY_MCP_BRIDGE_HOST: "env.example" };
-
   const fromArgs = resolveOptions({ host: "arg.example" }, environment, local, "/repo");
   assert.equal(fromArgs.host, "arg.example");
   assert.equal(fromArgs.port, 9001, "port still falls through to .env.local");
-
   const fromEnv = resolveOptions({}, environment, local, "/repo");
   assert.equal(fromEnv.host, "env.example");
-
   const fromDefaults = resolveOptions({}, {}, {}, "/repo");
   assert.equal(fromDefaults.host, DEFAULTS.host);
   assert.equal(fromDefaults.port, DEFAULTS.port);
   assert.equal(fromDefaults.explicitHost, undefined, "an unset host must not look explicit");
   assert.equal(fromDefaults.explicitPort, undefined);
 });
-
 test("resolveOptions does not require a Unity project path", () => {
   const options = resolveOptions({}, {}, {}, "/repo");
   assert.equal(options.projectPath, undefined);
   assert.throws(() => requireProjectPath(options), /Unity project path is required/);
 });
-
 test("requireProjectPath rejects a path that is not a directory", () => {
   const directory = temporaryDirectory();
   const file = path.join(directory, "not-a-directory");
@@ -313,14 +306,17 @@ test("requireProjectPath rejects a path that is not a directory", () => {
   );
   assert.equal(requireProjectPath({ projectPath: directory }), directory);
 });
-
 test("resolveOptions rejects invalid scalars", () => {
   assert.throws(() => resolveOptions({ port: "70000" }, {}, {}, "/repo"), /Port must be between/);
   assert.throws(
     () => resolveOptions({ "log-level": "loud" }, {}, {}, "/repo"),
     /Log level must be/
   );
-  assert.throws(() => resolveOptions({ "protocol-version": "v1" }, {}, {}, "/repo"), /YYYY-MM-DD/);
+  assert.throws(() => resolveOptions({ "protocol-version": "v1" }, {}, {}, "/repo"), /2025-11-25/);
+  assert.throws(
+    () => resolveOptions({ "protocol-version": "2025-06-18" }, {}, {}, "/repo"),
+    /2025-11-25/
+  );
   assert.throws(() => resolveOptions({ token: "short" }, {}, {}, "/repo"), /Bearer token must be/);
   assert.throws(
     () => resolveOptions({ "max-sessions": "0" }, {}, {}, "/repo"),
@@ -329,11 +325,6 @@ test("resolveOptions rejects invalid scalars", () => {
   assert.equal(resolveOptions({}, {}, {}, "/repo").maxSessions, DEFAULTS.maxSessions);
   assert.equal(resolveOptions({ "max-sessions": "3" }, {}, {}, "/repo").maxSessions, 3);
 });
-
-// ---------------------------------------------------------------------------
-// Endpoint discovery
-// ---------------------------------------------------------------------------
-
 test("resolvConfHosts extracts IPv4 nameservers only", () => {
   const raw = [
     "# generated",
@@ -344,7 +335,6 @@ test("resolvConfHosts extracts IPv4 nameservers only", () => {
   assert.deepEqual(resolvConfHosts(raw), ["10.255.255.254"]);
   assert.deepEqual(resolvConfHosts(""), []);
 });
-
 test("procNetRouteGateways decodes little-endian default routes", () => {
   const raw = [
     "Iface\tDestination\tGateway\tFlags\tRefCnt\tUse\tMetric\tMask\tMTU\tWindow\tIRTT",
@@ -354,12 +344,8 @@ test("procNetRouteGateways decodes little-endian default routes", () => {
   assert.deepEqual(procNetRouteGateways(raw), ["192.168.0.1"]);
   assert.deepEqual(procNetRouteGateways(""), []);
 });
-
 const RESOLV_CONF = (filePath) =>
   filePath === "/etc/resolv.conf" ? "nameserver 10.255.255.254\n" : "";
-
-// An explicit host or port is a deliberate setting, so it is the ONLY candidate on that axis.
-// Cross-producing it with the fallbacks used to probe host.docker.internal even for --host X.
 for (const [label, options, expected] of [
   ["host and port", { explicitHost: "10.0.0.5", explicitPort: 9500 }, ["10.0.0.5:9500"]],
   ["host only", { explicitHost: "10.0.0.5" }, ["10.0.0.5:9020", "10.0.0.5:9003"]],
@@ -381,7 +367,6 @@ for (const [label, options, expected] of [
     assert.ok(candidates.every((candidate) => candidate.endpointPath === "/mcp"));
   });
 }
-
 test("endpointCandidates without explicit settings still covers the fallbacks", () => {
   const candidates = endpointCandidates({ endpointPath: "/mcp" }, { readFile: RESOLV_CONF });
   assert.deepEqual(candidates[0], {
@@ -404,7 +389,6 @@ test("endpointCandidates without explicit settings still covers the fallbacks", 
     "the legacy supergateway port stays reachable"
   );
 });
-
 test("probeEndpoint reports an unreachable port without issuing a request", async () => {
   let called = false;
   const result = await probeEndpoint(
@@ -418,18 +402,23 @@ test("probeEndpoint reports an unreachable port without issuing a request", asyn
   assert.equal(result.status, "unreachable");
   assert.equal(called, false, "a closed port must not cost an HTTP round trip");
 });
-
-for (const [label, response, expected] of [
-  ["a healthy handshake", initializeResponse(OK_PAYLOAD), "ok"],
-  ["a rejected token", initializeResponse("nope", { status: 401 }), "unauthorized"],
-  ["a server error", initializeResponse("boom", { status: 500 }), "http-error"],
-  ["a non-JSON body", initializeResponse("<html>", { status: 200 }), "malformed"],
+// prettier-ignore
+for (const [label, fetchImpl, expected] of [
+  ["a healthy handshake", readyProbeFetch(), "ok"],
+  ["a rejected token", async () => initializeResponse("nope", { status: 401 }), "unauthorized"],
+  ["a server error", async () => initializeResponse("boom", { status: 500 }), "http-error"],
+  ["a non-JSON body", async () => initializeResponse("<html>", { status: 200 }), "malformed"],
+  ["an invalid media type", readyProbeFetch({ contentType: "text/plain" }), "malformed"],
+  ["an invalid initialize status", readyProbeFetch({ initializeStatus: 201 }), "malformed"],
+  [
+    "an incomplete InitializeResult",
+    readyProbeFetch({ initialize: `{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"${PROTOCOL_VERSION}","capabilities":{}}}` }),
+    "malformed"
+  ],
   [
     "a JSON-RPC error",
-    initializeResponse(
-      JSON.stringify({ jsonrpc: "2.0", id: 1, error: { code: -1, message: "no" } })
-    ),
-    "malformed"
+    readyProbeFetch({ initialize: '{"jsonrpc":"2.0","id":1,"error":{"code":-32603,"message":"no"}}' }),
+    "jsonrpc-error"
   ]
 ]) {
   test(`probeEndpoint classifies ${label}`, async (t) => {
@@ -437,88 +426,198 @@ for (const [label, response, expected] of [
     const result = await probeEndpoint(
       { host: "127.0.0.1", port, endpointPath: "/mcp" },
       probeOptions(),
-      async () => response
+      fetchImpl
     );
-    assert.equal(result.status, expected);
+    assert.equal(result.status, expected, result.detail);
     assert.equal(result.ok, expected === "ok");
+    if (expected === "jsonrpc-error") assert.match(result.detail, /-32603.*no/);
   });
 }
-
-test("probeEndpoint parses server-sent event payloads and closes the session it opened", async (t) => {
-  const port = await listeningPort(t);
-  const methods = [];
-  const fetchImpl = async (_url, init) => {
-    methods.push(init.method);
-    return init.method === "POST"
-      ? initializeResponse(`event: message\ndata: ${OK_PAYLOAD}\n\n`, {
-          contentType: "text/event-stream",
-          sessionId: "session-1"
-        })
-      : initializeResponse("", { status: 202 });
-  };
-
-  const result = await probeEndpoint(
-    { host: "127.0.0.1", port, endpointPath: "/mcp" },
-    probeOptions(),
-    fetchImpl
-  );
-  assert.equal(result.ok, true);
-  assert.equal(result.protocolVersion, DEFAULTS.protocolVersion);
-  assert.deepEqual(methods, ["POST", "DELETE"], "the probe must not leak a relay session");
-});
-
-// A bridge only answers an authenticated probe, so a probe that forgets the header reports
-// `unauthorized` for a perfectly healthy endpoint.
-for (const [label, token, expected] of [
-  ["sends the configured bearer token", "t".repeat(32), `Bearer ${"t".repeat(32)}`],
-  ["sends no Authorization header when no token is configured", undefined, undefined]
-]) {
-  test(`probeEndpoint ${label}`, async (t) => {
+// prettier-ignore
+test("probeEndpoint verifies editor tools over JSON and server-sent events", async (t) => {
+  for (const contentType of ["application/json", "text/event-stream"]) {
     const port = await listeningPort(t);
-    const seen = [];
-    const fetchImpl = async (_url, init) => {
-      seen.push(init.headers);
-      return init.method === "POST"
-        ? initializeResponse(OK_PAYLOAD, { sessionId: "session-1" })
-        : initializeResponse("", { status: 202 });
-    };
-
+    const requests = [];
+    const pongs = [];
+    const token = "t".repeat(32);
     const result = await probeEndpoint(
       { host: "127.0.0.1", port, endpointPath: "/mcp" },
       probeOptions({ bearerToken: token }),
-      fetchImpl
+      readyProbeFetch({ contentType, requests, pongs, resume: contentType === "text/event-stream" }),
+      true
     );
-    assert.equal(result.ok, true);
-    assert.equal(seen.length, 2, "the handshake POST and the cleanup DELETE");
-    assert.equal(seen[0].Authorization, expected);
-    assert.equal(seen[1].Authorization, expected, "the cleanup DELETE is authenticated too");
+    assert.equal(result.ok, true, result.detail);
+    assert.equal(result.toolCount, 1);
+    assert.deepEqual(
+      requests.filter((request) => request.method !== "GET").map((request) =>
+        request.method === "DELETE" ? "DELETE" : JSON.parse(request.body).method
+      ).filter(Boolean),
+      ["initialize", "notifications/initialized", "tools/list", "DELETE"]
+    );
+    const initialHeaders = new Headers(requests[0].headers);
+    assert.equal(initialHeaders.get("Authorization"), `Bearer ${token}`);
+    assert.equal(initialHeaders.get("MCP-Protocol-Version"), null);
+    assert.equal(initialHeaders.get("Mcp-Session-Id"), null);
+    if (contentType === "text/event-stream") {
+      assert.deepEqual(pongs.find((pong) => pong.id === "ping-1"), { jsonrpc: "2.0", id: "ping-1", result: {} });
+      assert.equal(requests.some((request) => new Headers(request.headers).get("last-event-id") === "resume-1"), true);
+    }
+    for (const request of requests.filter((item) => item.method === "GET" || item.method !== "DELETE" && JSON.parse(item.body).method).slice(1)) {
+      const headers = new Headers(request.headers);
+      assert.equal(headers.get("Authorization"), `Bearer ${token}`);
+      assert.equal(headers.get("Mcp-Session-Id"), "session-1");
+      assert.equal(headers.get("MCP-Protocol-Version"), PROTOCOL_VERSION);
+    }
+  }
+});
+test("probeEndpoint stops dispatch when the lifecycle deadline expires", async (t) => {
+  const requests = [];
+  const candidate = { host: "127.0.0.1", port: await listeningPort(t), endpointPath: "/mcp" };
+  const result = await probeEndpoint(
+    candidate,
+    probeOptions({ timeout: 25 }),
+    readyProbeFetch({ hang: "tools/list", requests }),
+    true
+  );
+  assert.equal(result.status, "transport-error");
+  assert.equal(requests.filter((request) => request.method === "POST").length, 3);
+});
+// prettier-ignore
+for (const [label, fetchOptions, expected] of [
+  [
+    "missing tools capability",
+    { initialize: OK_PAYLOAD.replace('{"tools":{}}', "{}") },
+    "not-ready"
+  ],
+  ["empty tool registry", { tools: TOOLS_PAYLOAD.replace(/\[.*\]/, "[]") }, "not-ready"],
+  ["tools/list JSON-RPC error", { tools: '{"jsonrpc":"2.0","id":2,"error":{"code":-32603,"message":"failed"}}' }, "jsonrpc-error"],
+  ["malformed tools/list result", { tools: '{"jsonrpc":"2.0","id":2,"result":{}}' }, "malformed"],
+  ["malformed tool schema", { tools: '{"jsonrpc":"2.0","id":2,"result":{"tools":[{"name":"bad"}]}}' }, "malformed"],
+  ["rejected initialized notification", { initializedStatus: 500 }, "http-error"],
+  ["wrong initialized status", { initializedStatus: 200 }, "malformed"],
+  ["wrong resumed GET status", { contentType: "text/event-stream", resume: true, resumeStatus: 202 }, "malformed"],
+  ["wrong resumed GET media type", { contentType: "text/event-stream", resume: true, resumeContentType: "application/json" }, "malformed"],
+  ["post-initialize transport failure", { initializedError: new Error("reset") }, "transport-error"]
+]) {
+  test(`probeEndpoint classifies ${label} and closes its session`, async (t) => {
+    const requests = [];
+    const result = await probeEndpoint(
+      { host: "127.0.0.1", port: await listeningPort(t), endpointPath: "/mcp" },
+      probeOptions(),
+      readyProbeFetch({ ...fetchOptions, requests }),
+      true
+    );
+    assert.equal(result.status, expected);
+    assert.equal(result.host, "127.0.0.1");
+    assert.equal(result.port > 0, true);
+    assert.equal(requests.at(-1).method, "DELETE");
   });
 }
-
-test("probeEndpoint failures name the endpoint that produced them", async (t) => {
-  const port = await listeningPort(t);
+test("probeEndpoint follows opaque tools/list cursors and rejects cursor cycles", async (t) => {
+  const tools = (request) =>
+    JSON.stringify({
+      jsonrpc: "2.0",
+      id: request.id,
+      result:
+        request.params.cursor === "page-2"
+          ? { tools: [{ name: "Unity_RunCommand", inputSchema: { type: "object" } }] }
+          : { tools: [], nextCursor: "page-2" }
+    });
+  const requests = [];
+  const candidate = { host: "127.0.0.1", port: await listeningPort(t), endpointPath: "/mcp" };
   const result = await probeEndpoint(
-    { host: "127.0.0.1", port, endpointPath: "/mcp" },
+    candidate,
     probeOptions(),
-    async () => initializeResponse("nope", { status: 401 })
+    readyProbeFetch({ tools, requests }),
+    true
   );
-  assert.equal(result.status, "unauthorized");
-  assert.equal(result.host, "127.0.0.1");
-  assert.equal(result.port, port);
+  assert.equal(result.ok, true);
+  assert.deepEqual(
+    requests
+      .filter((r) => JSON.parse(r.body ?? "{}").method === "tools/list")
+      .map((r) => JSON.parse(r.body).params.cursor),
+    [undefined, "page-2"]
+  );
+  const cycle = (request) =>
+    JSON.stringify({ jsonrpc: "2.0", id: request.id, result: { tools: [], nextCursor: "same" } });
+  assert.equal(
+    (await probeEndpoint(candidate, probeOptions(), readyProbeFetch({ tools: cycle }), true))
+      .status,
+    "malformed"
+  );
 });
-
+for (const [label, options, expectedWarning, deletes] of [
+  ["sessionless responses", { sessionId: undefined }, undefined, 0],
+  ["DELETE 405", { deleteStatus: 405 }, undefined, 1],
+  ["DELETE failure", { deleteStatus: 500 }, /HTTP 500/, 1],
+  ["DELETE transport failure", { deleteError: new Error("reset") }, /reset/, 1]
+]) {
+  test(`probeEndpoint bounds and reports cleanup for ${label}`, async (t) => {
+    const requests = [];
+    const result = await probeEndpoint(
+      { host: "127.0.0.1", port: await listeningPort(t), endpointPath: "/mcp" },
+      probeOptions(),
+      readyProbeFetch({ ...options, requests })
+    );
+    assert.equal(result.ok, true);
+    expectedWarning
+      ? assert.match(result.cleanupWarning, expectedWarning)
+      : assert.equal(result.cleanupWarning, undefined);
+    assert.equal(requests.filter((r) => r.method === "DELETE").length, deletes);
+  });
+}
+// prettier-ignore
+test("probeEndpoint rejects an unsupported negotiated protocol and closes its session", async (t) => {
+  const requests = [];
+  const initialize = OK_PAYLOAD.replace(PROTOCOL_VERSION, "2025-06-18");
+  const result = await probeEndpoint(
+    { host: "127.0.0.1", port: await listeningPort(t), endpointPath: "/mcp" },
+    probeOptions(),
+    readyProbeFetch({ initialize, requests })
+  );
+  assert.equal(result.status, "malformed");
+  assert.deepEqual(
+    requests.filter((r) => r.method !== "GET").map((r) => (r.method === "DELETE" ? "DELETE" : JSON.parse(r.body).method)),
+    ["initialize", "notifications/initialized", "DELETE"]
+  );
+});
+test("probeEndpoint cleans a captured session when response body consumption fails", async (t) => {
+  const requests = [];
+  const result = await probeEndpoint(
+    { host: "127.0.0.1", port: await listeningPort(t), endpointPath: "/mcp" },
+    probeOptions(),
+    readyProbeFetch({ bodyError: new Error("body failed"), requests })
+  );
+  assert.equal(result.status, "transport-error");
+  assert.equal(requests.at(-1).method, "DELETE");
+});
+// prettier-ignore
+test("probeEndpoint retries one session-bearing HTTP 404 within its lifecycle", async (t) => {
+  const requests = [];
+  const result = await probeEndpoint(
+    { host: "127.0.0.1", port: await listeningPort(t), endpointPath: "/mcp" },
+    probeOptions(),
+    readyProbeFetch({ contentType: "text/event-stream", resume: true, resumeNotFoundCount: 1, requests }),
+    true
+  );
+  assert.equal(result.ok, true);
+  assert.equal(requests.filter((r) => JSON.parse(r.body ?? "{}").method === "initialize").length, 2);
+  assert.equal(requests.filter((r) => r.method === "DELETE").length, 2);
+  requests.length = 0;
+  const failed = await probeEndpoint({ host: "127.0.0.1", port: await listeningPort(t), endpointPath: "/mcp" }, probeOptions(), readyProbeFetch({ contentType: "text/event-stream", resume: true, resumeNotFoundCount: 2, requests }), true);
+  assert.equal(failed.status, "http-error");
+  assert.match(failed.detail, /tools\/list.*404/);
+  assert.equal(requests.filter((r) => JSON.parse(r.body ?? "{}").method === "initialize").length, 2);
+});
 test("discoverEndpoint walks candidates in order and stops at the first success", async (t) => {
   const livePort = await listeningPort(t);
   const deadPort = await closedPort();
-  // An explicit candidate list keeps this hermetic: the real fallbacks include host.docker.internal,
-  // which may genuinely be listening on the developer machine running these tests.
   const candidates = [
     { host: "127.0.0.1", port: deadPort, endpointPath: "/mcp" },
     { host: "127.0.0.1", port: livePort, endpointPath: "/mcp" },
     { host: "127.0.0.1", port: livePort, endpointPath: "/never-reached" }
   ];
-  const runtime = { candidates, fetchImpl: async () => initializeResponse(OK_PAYLOAD) };
-
+  const runtime = { candidates, fetchImpl: readyProbeFetch() };
   const { found, attempts } = await discoverEndpoint(probeOptions(), runtime);
   assert.equal(found?.ok, true);
   assert.equal(found.port, livePort);
@@ -526,7 +625,21 @@ test("discoverEndpoint walks candidates in order and stops at the first success"
   assert.equal(attempts.length, 2, "discovery stops before the third candidate");
   assert.equal(attempts[0].status, "unreachable");
 });
-
+// prettier-ignore
+test("discoverEndpoint reports cleanup warnings before a later candidate succeeds", async (t) => {
+  const first = await listeningPort(t);
+  const second = await listeningPort(t);
+  const warnings = captureConsole(t, "warn");
+  const firstFetch = readyProbeFetch({ tools: TOOLS_PAYLOAD.replace(/\[.*\]/, "[]"), deleteStatus: 500 });
+  const secondFetch = readyProbeFetch();
+  const { found } = await discoverEndpoint(probeOptions(), {
+    requireTools: true,
+    candidates: [first, second].map((port) => ({ host: "127.0.0.1", port, endpointPath: "/mcp" })),
+    fetchImpl: (target, init) => String(target).includes(`:${first}/`) ? firstFetch(target, init) : secondFetch(target, init)
+  });
+  assert.equal(found.port, second);
+  assert.match(warnings.join("\n"), /cleanup returned HTTP 500/);
+});
 test("discoverEndpoint reports every attempt when nothing responds", async () => {
   const deadPort = await closedPort();
   const candidates = [
@@ -541,23 +654,17 @@ test("discoverEndpoint reports every attempt when nothing responds", async () =>
   assert.equal(attempts.length, 2);
   assert.ok(attempts.every((attempt) => attempt.ok === false));
 });
-
-// --log-level debug used to be accepted and then never emit anything, because nothing called log()
-// at the debug level.
 test("discoverEndpoint emits per-candidate detail only at log level debug", async (t) => {
   const dead = await closedPort();
   const candidates = [{ host: "127.0.0.1", port: dead, endpointPath: "/mcp" }];
   const runtime = { candidates, fetchImpl: async () => initializeResponse(OK_PAYLOAD) };
-
   const quiet = captureConsole(t, "log");
   await discoverEndpoint(probeOptions({ logLevel: "info" }), runtime);
   assert.deepEqual(quiet, [], "info level stays quiet");
-
   await discoverEndpoint(probeOptions({ logLevel: "debug" }), runtime);
   assert.match(quiet.join("\n"), new RegExp(`Probing http://127\\.0\\.0\\.1:${dead}/mcp`));
   assert.match(quiet.join("\n"), /unreachable/);
 });
-
 test("describeAttempts surfaces classified failures ahead of plain unreachability", () => {
   const description = describeAttempts([
     { url: "http://a:1/mcp", status: "unreachable", detail: "no TCP listener" },
@@ -570,21 +677,14 @@ test("describeAttempts surfaces classified failures ahead of plain unreachabilit
     "noise from dead ports is dropped when a real failure exists"
   );
 });
-
-// ---------------------------------------------------------------------------
-// Client configuration
-// ---------------------------------------------------------------------------
-
 test("prepareJsonServer creates, merges, and rejects malformed documents", () => {
   const directory = temporaryDirectory();
   const filePath = path.join(directory, "mcp.json");
   const server = { type: "http", url: "http://h:1/mcp" };
-
   assert.equal(
     JSON.parse(prepareJsonServer(filePath, "mcpServers", server)).mcpServers["unity-mcp"].url,
     "http://h:1/mcp"
   );
-
   fs.writeFileSync(
     filePath,
     JSON.stringify({ mcpServers: { other: { url: "keep" } }, unrelated: 1 })
@@ -592,19 +692,14 @@ test("prepareJsonServer creates, merges, and rejects malformed documents", () =>
   const merged = JSON.parse(prepareJsonServer(filePath, "mcpServers", server));
   assert.equal(merged.mcpServers.other.url, "keep", "sibling servers survive");
   assert.equal(merged.unrelated, 1, "unrelated keys survive");
-
   fs.writeFileSync(filePath, JSON.stringify({ mcpServers: [] }));
   assert.throws(
     () => prepareJsonServer(filePath, "mcpServers", server),
     /Expected mcpServers to be an object/
   );
-
   fs.writeFileSync(filePath, "{ not json");
   assert.throws(() => prepareJsonServer(filePath, "mcpServers", server), /Invalid JSON/);
 });
-
-// .vscode/mcp.json is JSONC and VS Code's own "MCP: Add Server" scaffolding writes a comment into
-// it, so refusing comments meant `configure` could not run at all for those users.
 for (const [label, raw, expected] of [
   ["a line comment", '{\n  // hint\n  "a": 1\n}', { a: 1 }],
   ["a block comment", '{\n  /* hint\n     more */\n  "a": 1\n}', { a: 1 }],
@@ -626,21 +721,14 @@ for (const [label, raw, expected] of [
     assert.deepEqual(JSON.parse(stripJsonComments(raw)), expected);
   });
 }
-
 test("stripJsonComments stays linear in the number of closing brackets", () => {
-  // Re-scanning the accumulated output on every `}` or `]` (or indexing into it) flattens the rope
-  // V8 builds from repeated concatenation, making the pass quadratic: this input took 150 seconds
-  // before, and a few hundred KB of real `.mcp.json` was enough to make `configure` look hung.
-  // The bound is deliberately loose; only a return to quadratic can breach it.
   const document = `[${Array.from({ length: 64_000 }, () => "{}").join(",")}]`;
   const started = process.hrtime.bigint();
   const stripped = stripJsonComments(document);
   const elapsedMs = Number(process.hrtime.bigint() - started) / 1e6;
-
   assert.equal(stripped, document, "comment-free JSON must round-trip unchanged");
   assert.ok(elapsedMs < 2_000, `took ${elapsedMs.toFixed(0)}ms; expected well under 2000ms`);
 });
-
 test("prepareJsonServer merges into a JSONC document", () => {
   const filePath = path.join(temporaryDirectory(), "mcp.json");
   fs.writeFileSync(
@@ -652,12 +740,10 @@ test("prepareJsonServer merges into a JSONC document", () => {
   );
   assert.equal(merged.servers["unity-mcp"].url, "http://h:1/mcp");
 });
-
 test("mergeCodexToml appends, replaces in place, and preserves neighbours", () => {
   const fresh = mergeCodexToml("", "http://h:1/mcp", "t".repeat(32));
   assert.match(fresh, /\[mcp_servers\.unity-mcp\]/);
   assert.match(fresh, /Authorization = "Bearer t{32}"/);
-
   const withNeighbour = `[other]\nkeep = true\n\n${fresh}`;
   const replaced = mergeCodexToml(withNeighbour, "http://h:2/mcp", "u".repeat(32));
   assert.match(replaced, /keep = true/, "neighbouring tables survive");
@@ -668,8 +754,6 @@ test("mergeCodexToml appends, replaces in place, and preserves neighbours", () =
   );
   assert.match(replaced, /http:\/\/h:2\/mcp/);
   assert.doesNotMatch(replaced, /http:\/\/h:1\/mcp/);
-
-  // A table following ours must not be swallowed by the replacement.
   const trailing = mergeCodexToml(
     `${fresh}\n[after]\nvalue = 1\n`,
     "http://h:3/mcp",
@@ -678,7 +762,6 @@ test("mergeCodexToml appends, replaces in place, and preserves neighbours", () =
   assert.match(trailing, /\[after\]/);
   assert.match(trailing, /value = 1/);
 });
-
 test("mergeCodexToml refuses inputs it cannot safely rewrite", () => {
   assert.throws(
     () => mergeCodexToml("[unclosed", "http://h:1/mcp", "t".repeat(32)),
@@ -688,13 +771,8 @@ test("mergeCodexToml refuses inputs it cannot safely rewrite", () => {
     () => mergeCodexToml('mcp_servers.unity-mcp = { url = "x" }', "http://h:1/mcp", "t".repeat(32)),
     /Unsupported inline or dotted/
   );
-  // A literally duplicated table is already invalid TOML, so the parser rejects it first.
   const duplicated = `[mcp_servers.unity-mcp]\nurl = "a"\n\n[mcp_servers.unity-mcp]\nurl = "b"\n`;
   assert.throws(() => mergeCodexToml(duplicated, "http://h:1/mcp", "t".repeat(32)), /Invalid TOML/);
-
-  // The duplicate guard covers what line scanning alone cannot see: a header-shaped line inside a
-  // multi-line string. The document parses, but two lines look like our table, so the rewrite region
-  // is ambiguous and the only safe move is to refuse rather than splice over a string literal.
   const ambiguous = [
     'note = """',
     "[mcp_servers.unity-mcp]",
@@ -709,9 +787,6 @@ test("mergeCodexToml refuses inputs it cannot safely rewrite", () => {
     /Duplicate unity-mcp table/
   );
 });
-
-// With exactly ONE header-shaped line inside a multi-line string the duplicate guard never fires,
-// so the line scanner used to splice across the string literal and then blame its own generator.
 test("mergeCodexToml refuses a lone header-shaped line inside a multi-line value", () => {
   const raw = ['note = """', "[mcp_servers.unity-mcp]", '"""', ""].join("\n");
   assert.throws(
@@ -724,7 +799,6 @@ test("mergeCodexToml refuses a lone header-shaped line inside a multi-line value
     }
   );
 });
-
 test("mergeCodexToml normalizes CRLF input so a second run is a no-op", () => {
   const appended = mergeCodexToml("[other]\r\nkeep = true\r\n", "http://h:1/mcp", "t".repeat(32));
   assert.doesNotMatch(appended, /\r/, "the append path must not emit mixed line endings");
@@ -734,13 +808,11 @@ test("mergeCodexToml normalizes CRLF input so a second run is a no-op", () => {
     "configure converges on run 2, not run 3"
   );
 });
-
 test("transactionalWrite commits every file or none", () => {
   const directory = temporaryDirectory();
   const first = path.join(directory, "first.json");
   const second = path.join(directory, "nested", "second.json");
   fs.writeFileSync(first, "original\n");
-
   const written = transactionalWrite([
     [first, "updated\n"],
     [second, "created\n"]
@@ -748,13 +820,11 @@ test("transactionalWrite commits every file or none", () => {
   assert.deepEqual(written.sort(), [first, second].sort());
   assert.equal(fs.readFileSync(first, "utf8"), "updated\n");
   assert.equal(fs.readFileSync(second, "utf8"), "created\n");
-
   assert.deepEqual(
     transactionalWrite([[first, "updated\n"]]),
     [],
     "unchanged content is not rewritten"
   );
-
   assert.throws(
     () =>
       transactionalWrite(
@@ -773,12 +843,10 @@ test("transactionalWrite commits every file or none", () => {
   assert.equal(fs.readFileSync(first, "utf8"), "updated\n", "the committed file is rolled back");
   assert.equal(fs.readFileSync(second, "utf8"), "created\n");
 });
-
 test("transactionalWrite removes files it created when a later commit fails", () => {
   const directory = temporaryDirectory();
   const created = path.join(directory, "created.json");
   const other = path.join(directory, "other.json");
-
   assert.throws(
     () =>
       transactionalWrite(
@@ -800,10 +868,6 @@ test("transactionalWrite removes files it created when a later commit fails", ()
     "a file that did not exist before is removed on rollback"
   );
 });
-
-// Windows returns EPERM from rename whenever an editor holds the destination open, which is exactly
-// what these four config files are. A rollback that throws must not replace the original error nor
-// abandon the files it has not restored yet.
 test("transactionalWrite finishes rollback and rethrows the original error", () => {
   const directory = temporaryDirectory();
   const first = path.join(directory, "first.json");
@@ -812,9 +876,7 @@ test("transactionalWrite finishes rollback and rethrows the original error", () 
   for (const filePath of [first, second, third]) {
     fs.writeFileSync(filePath, "original\n");
   }
-
   const originalChmod = fs.chmodSync;
-  // atomicWrite is the rollback primitive; failing its chmod fails exactly one restore.
   fs.chmodSync = (target, mode) => {
     if (String(target).includes("second.json")) {
       throw new Error("rollback failure");
@@ -840,7 +902,6 @@ test("transactionalWrite finishes rollback and rethrows the original error", () 
   } finally {
     fs.chmodSync = originalChmod;
   }
-
   assert.equal(thrown?.message, "commit failure", "the original error survives");
   assert.ok(thrown.cause instanceof AggregateError, "rollback failures are attached, not thrown");
   assert.equal(thrown.cause.errors.length, 1);
@@ -851,13 +912,11 @@ test("transactionalWrite finishes rollback and rethrows the original error", () 
   );
   assert.equal(fs.readFileSync(third, "utf8"), "original\n", "third was never committed");
 });
-
 test("transactionalWrite cleans up temporaries when staging itself fails", () => {
   const directory = temporaryDirectory();
   const good = path.join(directory, "good.json");
   const blocker = path.join(directory, "blocker");
   fs.writeFileSync(blocker, "");
-  // Staging the second write must fail: its parent directory cannot be created over a file.
   assert.throws(() =>
     transactionalWrite([
       [good, "new\n"],
@@ -871,8 +930,6 @@ test("transactionalWrite cleans up temporaries when staging itself fails", () =>
   );
   assert.equal(fs.existsSync(good), false, "nothing is committed when staging fails");
 });
-
-// Only POSIX carries a meaningful permission bit; on Windows chmod moves the read-only flag alone.
 test(
   "transactionalWrite rollback restores the original file mode",
   { skip: process.platform === "win32" },
@@ -883,7 +940,6 @@ test(
     fs.writeFileSync(first, "original\n", { mode: 0o644 });
     fs.chmodSync(first, 0o644);
     fs.writeFileSync(second, "original\n");
-
     assert.throws(
       () =>
         transactionalWrite(
@@ -906,17 +962,14 @@ test(
     );
   }
 );
-
 test("configure writes every client config and is idempotent", () => {
   const repoRoot = temporaryDirectory();
   const options = { repoRoot, bearerToken: "a".repeat(32) };
   const endpoint = { host: "10.0.0.5", port: 9020, endpointPath: "/mcp" };
-
   const firstRun = configure(options, endpoint);
   assert.equal(firstRun.url, "http://10.0.0.5:9020/mcp");
   const paths = clientConfigPaths(repoRoot);
   assert.deepEqual(firstRun.written.sort(), Object.values(paths).sort());
-
   assert.equal(
     JSON.parse(fs.readFileSync(paths.claudeCode, "utf8")).mcpServers["unity-mcp"].headers
       .Authorization,
@@ -931,21 +984,14 @@ test("configure writes every client config and is idempotent", () => {
     firstRun.url
   );
   assert.match(fs.readFileSync(paths.codex, "utf8"), /\[mcp_servers\.unity-mcp\]/);
-
   assert.deepEqual(configure(options, endpoint).written, [], "a second run changes nothing");
 });
-
 test("configure generates and persists a bearer token when none is supplied", () => {
   const repoRoot = temporaryDirectory();
   configure({ repoRoot, bearerToken: undefined }, { host: "h", port: 1, endpointPath: "/mcp" });
   const envLocal = fs.readFileSync(path.join(repoRoot, ".env.local"), "utf8");
   assert.match(envLocal, /^UNITY_MCP_BEARER_TOKEN=[0-9a-f]{64}$/m);
 });
-
-// ---------------------------------------------------------------------------
-// Relay discovery
-// ---------------------------------------------------------------------------
-
 test("relayCandidates is platform specific", () => {
   const windows = relayCandidates({ platform: "win32", home: "/home/u" });
   assert.ok(windows[0].endsWith("relay_win.exe"));
@@ -953,25 +999,19 @@ test("relayCandidates is platform specific", () => {
   assert.ok(linux[0].endsWith("relay_linux_x64"));
   assert.deepEqual(relayCandidates({ platform: "aix", home: "/home/u" }), []);
 });
-
 test("findRelay requires an existing file and reports what it searched", () => {
   const directory = temporaryDirectory();
   const relay = path.join(directory, "relay_linux_x64");
   assert.throws(() => findRelay(relay, { platform: "linux" }), /Unity MCP relay not found/);
   assert.throws(() => findRelay(directory, { platform: "linux" }), /Unity MCP relay not found/);
-
   fs.writeFileSync(relay, "#!/bin/sh\n", { mode: 0o755 });
   assert.equal(findRelay(relay, { platform: "linux" }), relay);
 });
-
-// Windows has no execute bit: fs.accessSync(X_OK) succeeds for any existing file, so this
-// assertion is only meaningful on a POSIX filesystem.
 test("findRelay rejects a non-executable relay", { skip: process.platform === "win32" }, () => {
   const relay = path.join(temporaryDirectory(), "relay_linux_x64");
   fs.writeFileSync(relay, "#!/bin/sh\n", { mode: 0o644 });
   assert.throws(() => findRelay(relay, { platform: "linux" }), /not found or not executable/);
 });
-
 test("buildRelayArgs passes the resolved project path", () => {
   assert.deepEqual(buildRelayArgs("/tmp/project"), [
     "--mcp",
@@ -979,7 +1019,6 @@ test("buildRelayArgs passes the resolved project path", () => {
     path.resolve("/tmp/project")
   ]);
 });
-
 test("assertPortAvailable rejects a port that is already bound", async (t) => {
   const port = await listeningPort(t);
   await assert.rejects(
@@ -988,13 +1027,7 @@ test("assertPortAvailable rejects a port that is already bound", async (t) => {
   );
   await assertPortAvailable(await closedPort(), "127.0.0.1");
 });
-
-// ---------------------------------------------------------------------------
-// Bridge server
-// ---------------------------------------------------------------------------
-
 const BRIDGE_TOKEN = "b".repeat(32);
-
 /**
  * A relay stand-in: it speaks the same newline-delimited JSON-RPC over stdio that the real Unity
  * relay does, so the bridge is exercised end to end without a Unity install or a network dependency.
@@ -1042,14 +1075,12 @@ function createFakeRelay() {
   };
   return child;
 }
-
 async function startTestBridge(t, overrides = {}) {
   const repoRoot = temporaryDirectory();
   const projectPath = path.join(repoRoot, "project");
   fs.mkdirSync(projectPath);
   const relayPath = path.join(repoRoot, "relay");
   fs.writeFileSync(relayPath, "#!/bin/sh\n", { mode: 0o755 });
-
   const relays = [];
   const running = await startBridge(
     {
@@ -1057,7 +1088,6 @@ async function startTestBridge(t, overrides = {}) {
       projectPath,
       relayPath,
       bindHost: "127.0.0.1",
-      // Port 0 lets the OS pick a free port, which keeps parallel test runs hermetic.
       port: 0,
       endpointPath: "/mcp",
       bearerToken: BRIDGE_TOKEN,
@@ -1078,7 +1108,6 @@ async function startTestBridge(t, overrides = {}) {
   t.after(() => running.close());
   return { running, relays, repoRoot, port: running.httpServer.address().port };
 }
-
 /** `null` means "send no Authorization header at all", which is a distinct case from a bad token. */
 function mcpHeaders(token = BRIDGE_TOKEN, extra = {}) {
   return {
@@ -1088,7 +1117,6 @@ function mcpHeaders(token = BRIDGE_TOKEN, extra = {}) {
     ...extra
   };
 }
-
 function initializeBody(id = 1) {
   return JSON.stringify({
     jsonrpc: "2.0",
@@ -1101,7 +1129,6 @@ function initializeBody(id = 1) {
     }
   });
 }
-
 /** A raw HTTP request, for the cases fetch cannot express (a stalled or over-large body). */
 function rawRequest(port, { method = "POST", requestPath = "/mcp", headers = {}, body, stall }) {
   return new Promise((resolve, reject) => {
@@ -1131,7 +1158,6 @@ function rawRequest(port, { method = "POST", requestPath = "/mcp", headers = {},
     }
   });
 }
-
 async function openSession(port) {
   const response = await fetch(`http://127.0.0.1:${port}/mcp`, {
     method: "POST",
@@ -1140,7 +1166,6 @@ async function openSession(port) {
   });
   return { response, sessionId: response.headers.get("mcp-session-id") };
 }
-
 for (const [label, token, expected] of [
   ["no Authorization header", null, 401],
   ["a wrong bearer token", "z".repeat(32), 401],
@@ -1163,16 +1188,13 @@ for (const [label, token, expected] of [
     }
   });
 }
-
 test("startBridge completes a handshake, reuses the session, and tears it down", async (t) => {
   const { port, relays } = await startTestBridge(t);
-
   const { response, sessionId } = await openSession(port);
   assert.equal(response.status, 200);
   assert.ok(sessionId, "the transport assigns a session id");
   assert.equal(relays.length, 1, "one relay child per session");
   assert.equal(relays[0].received[0].method, "initialize", "the relay saw the handshake");
-
   const reused = await fetch(`http://127.0.0.1:${port}/mcp`, {
     method: "POST",
     headers: mcpHeaders(BRIDGE_TOKEN, {
@@ -1184,7 +1206,6 @@ test("startBridge completes a handshake, reuses the session, and tears it down",
   assert.equal(reused.status, 200);
   assert.deepEqual((await reused.json()).result, { echoed: "tools/list" });
   assert.equal(relays.length, 1, "an existing session must not spawn a second relay");
-
   const deleted = await fetch(`http://127.0.0.1:${port}/mcp`, {
     method: "DELETE",
     headers: mcpHeaders(BRIDGE_TOKEN, {
@@ -1194,7 +1215,6 @@ test("startBridge completes a handshake, reuses the session, and tears it down",
   });
   assert.ok(deleted.status < 300, `DELETE tears the session down (got ${deleted.status})`);
   assert.deepEqual(relays[0].signals, ["SIGTERM"], "DELETE reaps the relay child");
-
   const afterDelete = await fetch(`http://127.0.0.1:${port}/mcp`, {
     method: "POST",
     headers: mcpHeaders(BRIDGE_TOKEN, {
@@ -1206,21 +1226,17 @@ test("startBridge completes a handshake, reuses the session, and tears it down",
   assert.equal(afterDelete.status, 404);
   assert.equal((await afterDelete.json()).error.code, -32001);
 });
-
 test("startBridge close() reaps every relay child", async (t) => {
   const { port, relays, running } = await startTestBridge(t);
   await openSession(port);
   assert.equal(relays.length, 1);
   assert.equal(relays[0].exitCode, null);
-
   await running.close();
   assert.deepEqual(relays[0].signals, ["SIGTERM"]);
   assert.equal(relays[0].exitCode, 0, "the relay child is not left running");
   await running.close();
   await running.closed;
 });
-
-// /healthz reveals nothing, and a liveness probe an orchestrator has to authenticate is useless.
 for (const [label, token] of [
   ["without a token", undefined],
   ["with a token", BRIDGE_TOKEN]
@@ -1234,8 +1250,6 @@ for (const [label, token] of [
     assert.equal(await response.text(), "ok");
   });
 }
-
-// A client error reported as an internal server error makes well-behaved clients retry forever.
 for (const [label, body, status, code] of [
   ["malformed JSON", "{ not json", 400, -32700],
   ["a non-initialize first request", '{"jsonrpc":"2.0","id":1,"method":"tools/list"}', 400, -32001]
@@ -1250,7 +1264,6 @@ for (const [label, body, status, code] of [
     assert.equal(JSON.parse(response.text).error.code, code);
   });
 }
-
 test("startBridge answers an over-large body with 413 rather than a reset connection", async (t) => {
   const { port } = await startTestBridge(t);
   const response = await rawRequest(port, {
@@ -1260,16 +1273,13 @@ test("startBridge answers an over-large body with 413 rather than a reset connec
   assert.equal(response.status, 413);
   assert.match(JSON.parse(response.text).error.message, /too large/);
 });
-
 test("startBridge abandons a stalled body and still shuts down promptly", async (t) => {
-  // The body timeout is capped by the session timeout, so a short session timeout shortens it.
   const { port, running } = await startTestBridge(t, { sessionTimeout: 250 });
   const response = await rawRequest(port, {
     headers: mcpHeaders(BRIDGE_TOKEN, { "Content-Length": "4096" }),
     stall: true
   });
   assert.equal(response.status, 408);
-
   const started = Date.now();
   await running.close();
   assert.ok(
@@ -1277,13 +1287,10 @@ test("startBridge abandons a stalled body and still shuts down promptly", async 
     "close() must not wait out Node's 300s request timeout on a half-open connection"
   );
 });
-
 test("startBridge caps concurrent sessions, each of which owns a relay child", async (t) => {
   const { port, relays } = await startTestBridge(t, { maxSessions: 1 });
   const first = await openSession(port);
   assert.equal(first.response.status, 200);
-
-  // Concurrent initializes: the cap counts sessions still being created, not just registered ones.
   const rejected = await Promise.all(
     [2, 3].map((id) =>
       fetch(`http://127.0.0.1:${port}/mcp`, {
@@ -1301,7 +1308,6 @@ test("startBridge caps concurrent sessions, each of which owns a relay child", a
   }
   assert.equal(relays.length, 1, "a rejected initialize must not spawn a relay");
 });
-
 test("startBridge rejects unknown paths and methods", async (t) => {
   const { port } = await startTestBridge(t);
   for (const [requestPath, method] of [
@@ -1315,11 +1321,6 @@ test("startBridge rejects unknown paths and methods", async (t) => {
     assert.equal(response.status, 404, `${method} ${requestPath}`);
   }
 });
-
-// ---------------------------------------------------------------------------
-// Commands
-// ---------------------------------------------------------------------------
-
 function commandOptions(repoRoot, overrides = {}) {
   return {
     repoRoot,
@@ -1331,45 +1332,27 @@ function commandOptions(repoRoot, overrides = {}) {
     ...overrides
   };
 }
-
-test("runProbe reports the endpoint it handshook with", async (t) => {
+test("runProbe reports the endpoint advertising Unity_RunCommand", async (t) => {
   const port = await listeningPort(t);
   const logged = captureConsole(t, "log");
   const found = await runProbe(commandOptions(temporaryDirectory()), {
     candidates: [{ host: "127.0.0.1", port, endpointPath: "/mcp" }],
-    fetchImpl: async () => initializeResponse(OK_PAYLOAD)
+    fetchImpl: readyProbeFetch()
   });
   assert.equal(found.port, port);
-  assert.match(logged.join("\n"), /Unity MCP is reachable at http:\/\/127\.0\.0\.1:/);
-
-  const dead = await closedPort();
-  await assert.rejects(
-    () =>
-      runProbe(commandOptions(temporaryDirectory()), {
-        candidates: [{ host: "127.0.0.1", port: dead, endpointPath: "/mcp" }],
-        fetchImpl: async () => initializeResponse(OK_PAYLOAD)
-      }),
-    /No Unity MCP endpoint responded/
-  );
+  assert.match(logged.join("\n"), /advertises Unity_RunCommand/);
 });
-
-// Deliberately no injected `candidates`: passing one masks the narrowing --no-discover performs,
-// which is how `probe --no-discover` shipped always-failing with an empty attempts list. The
-// endpoint has to come from options.host/options.port.
-test("--no-discover probes the configured endpoint rather than skipping the handshake", async (t) => {
-  const runtime = { fetchImpl: async () => initializeResponse(OK_PAYLOAD) };
+test("--no-discover probes the configured endpoint rather than skipping readiness", async (t) => {
+  const runtime = { fetchImpl: readyProbeFetch() };
   captureConsole(t, "log");
   captureConsole(t, "warn");
-
   const live = { discover: false, host: "127.0.0.1", port: await listeningPort(t) };
   assert.equal(
     (await runProbe(commandOptions(temporaryDirectory(), live), runtime)).port,
     live.port
   );
-
   const repoRoot = temporaryDirectory();
   const dead = { discover: false, host: "127.0.0.1", port: await closedPort() };
-  // The regression was an EMPTY attempts list, so naming the endpoint is the assertion.
   await assert.rejects(
     () => runProbe(commandOptions(repoRoot, dead), runtime),
     (error) => {
@@ -1377,16 +1360,11 @@ test("--no-discover probes the configured endpoint rather than skipping the hand
       return true;
     }
   );
-
-  // configure still writes the endpoint the caller named when the probe finds nothing there.
   const url = await runConfigure(commandOptions(repoRoot, dead), runtime);
   assert.equal(url, `http://127.0.0.1:${dead.port}/mcp`);
   const written = JSON.parse(fs.readFileSync(clientConfigPaths(repoRoot).claudeCode, "utf8"));
   assert.equal(written.mcpServers["unity-mcp"].url, url);
 });
-
-// `unauthorized` means a bridge IS running there; only the token is wrong. Falling back to the
-// default endpoint and minting a fresh token guarantees a 401 and persists the bogus token.
 test("runConfigure refuses to write when a bridge rejects the token", async (t) => {
   const repoRoot = temporaryDirectory();
   const port = await listeningPort(t);
@@ -1415,26 +1393,31 @@ test("runConfigure refuses to write when a bridge rejects the token", async (t) 
     "no client config is written"
   );
 });
-
+// prettier-ignore
 test("runConfigure still configures when a later candidate handshakes", async (t) => {
   const repoRoot = temporaryDirectory();
   captureConsole(t, "log");
   const rejecting = await listeningPort(t);
   const accepting = await listeningPort(t);
+  const requests = [];
+  const acceptingFetch = readyProbeFetch({ requests });
   const url = await runConfigure(commandOptions(repoRoot, { logLevel: "none" }), {
     candidates: [
       { host: "127.0.0.1", port: rejecting, endpointPath: "/mcp" },
       { host: "127.0.0.1", port: accepting, endpointPath: "/mcp" }
     ],
-    fetchImpl: async (target) =>
-      target.includes(`:${rejecting}/`)
+    fetchImpl: async (target, init) =>
+      String(target).includes(`:${rejecting}/`)
         ? initializeResponse("nope", { status: 401 })
-        : initializeResponse(OK_PAYLOAD)
+        : acceptingFetch(target, init)
   });
   assert.equal(url, `http://127.0.0.1:${accepting}/mcp`);
   assert.ok(fs.existsSync(clientConfigPaths(repoRoot).claudeCode));
+  assert.deepEqual(
+    requests.filter((r) => r.method !== "GET").map((r) => (r.method === "DELETE" ? "DELETE" : JSON.parse(r.body).method)),
+    ["initialize", "notifications/initialized", "DELETE"]
+  );
 });
-
 test("runConfigure falls back to the configured endpoint when nothing is listening", async (t) => {
   const repoRoot = temporaryDirectory();
   const warnings = captureConsole(t, "warn");
@@ -1444,14 +1427,13 @@ test("runConfigure falls back to the configured endpoint when nothing is listeni
     fetchImpl: async () => initializeResponse(OK_PAYLOAD)
   });
   assert.equal(url, "http://10.0.0.5:9020/mcp");
-  assert.match(warnings.join("\n"), /No Unity MCP endpoint responded/);
+  assert.match(warnings.join("\n"), /No Unity MCP endpoint completed initialization/);
   assert.match(
     fs.readFileSync(path.join(repoRoot, ".env.local"), "utf8"),
     /^UNITY_MCP_BEARER_TOKEN=[0-9a-f]{64}$/m,
     "an unreachable endpoint is a fresh setup, so a token is generated"
   );
 });
-
 for (const [label, argv, expected] of [
   ["no command", [], /Usage: node scripts\/mcp\/unity-mcp\.mjs/],
   ["--help", ["--help"], /Usage: node scripts\/mcp\/unity-mcp\.mjs/],
@@ -1463,7 +1445,6 @@ for (const [label, argv, expected] of [
     assert.match(logged.join("\n"), expected);
   });
 }
-
 for (const [label, argv, expected] of [
   ["an unknown command", ["explode"], /Unknown command: explode/],
   ["a stray positional", ["probe", "extra"], /Unexpected argument: extra/],

--- a/scripts/mcp/README.md
+++ b/scripts/mcp/README.md
@@ -9,7 +9,7 @@ streamable HTTP and container clients point at that endpoint.
 | Command                       | Runs on | Purpose                                                   |
 | ----------------------------- | ------- | --------------------------------------------------------- |
 | `npm run unity:mcp:bridge`    | Host    | Spawn the relay and serve it over HTTP                    |
-| `npm run unity:mcp:probe`     | Agent   | Discover a live endpoint and complete an MCP handshake    |
+| `npm run unity:mcp:probe`     | Agent   | Find an endpoint that advertises `Unity_RunCommand`       |
 | `npm run unity:mcp:configure` | Agent   | Discover, then write every MCP client config in this repo |
 
 ## Start the bridge on the Windows host
@@ -59,8 +59,12 @@ npm run unity:mcp:configure
 npm run unity:mcp:probe
 ```
 
-Both commands probe before acting. Discovery walks every combination of candidate host and port
-until one completes an MCP `initialize` handshake:
+Discovery completes MCP initialization against each reachable candidate. `configure` selects the
+first initialized endpoint without inspecting its tools; if none completes initialization, it keeps
+the explicitly configured or default endpoint. `probe` instead fails unless a candidate advertises
+`Unity_RunCommand`. Both commands pin MCP `2025-11-25`.
+
+Discovery walks every combination of candidate host and port:
 
 - **Hosts** - the explicitly configured host if there is one; otherwise `host.docker.internal`,
   `127.0.0.1`, the `nameserver` entries in `/etc/resolv.conf` (the Windows host under WSL2), and the
@@ -71,16 +75,31 @@ An explicit `--host` or `--port` replaces the fallback list on that axis rather 
 to it, so discovery can never override a deliberate setting: `--host X` probes only `X` (against the
 fallback ports), and `--host X --port Y` yields exactly one candidate. Pass `--no-discover` to probe only
 the configured host and port without walking the fallbacks. It narrows the candidate list; it does
-not skip the handshake, so `probe --no-discover` still tells you whether that endpoint answers.
+not skip the protocol check.
 
 Failed attempts are reported with a classification, because the fixes differ:
 
-| Status         | Meaning                                                        |
-| -------------- | -------------------------------------------------------------- |
-| `unreachable`  | Nothing accepted a TCP connection                              |
-| `unauthorized` | A bridge is running but rejected the bearer token              |
-| `http-error`   | Something answered that is not an MCP streamable-HTTP endpoint |
-| `malformed`    | The endpoint answered but not with a valid `initialize` result |
+| Status            | Meaning                                                         |
+| ----------------- | --------------------------------------------------------------- |
+| `unreachable`     | Nothing accepted a TCP connection                               |
+| `transport-error` | An MCP request timed out or ended without an HTTP response      |
+| `unauthorized`    | A bridge is running but rejected the bearer token               |
+| `http-error`      | An MCP operation returned a non-success HTTP status             |
+| `jsonrpc-error`   | The server returned a valid JSON-RPC error                      |
+| `malformed`       | MCP returned an invalid result, status, version, or page cursor |
+| `not-ready`       | The endpoint did not advertise `Unity_RunCommand`               |
+
+`not-ready` detects the empty tool-registry window that can follow an editor refresh. A successful
+probe confirms only that `Unity_RunCommand` was advertised; it does not execute that tool or prove
+that Unity's discovery heartbeat remains fresh. The SDK transport validates response media types
+and result schemas, streams SSE events including pings and event IDs, rejects cursor cycles and
+more than 100 pages, and applies `--timeout` as one deadline across the full lifecycle. A
+session-bearing HTTP 404 restarts initialization once within that same deadline.
+
+When a server creates a session, the probe sends `DELETE` after every result and releases the
+response. HTTP 405 is an allowed refusal. Other cleanup failures produce a warning without changing
+the endpoint result, including when discovery later succeeds elsewhere; the server's idle-session
+timeout remains the cleanup fallback.
 
 `unauthorized` is special-cased by `configure`: a bridge IS running at that endpoint and only the
 token is wrong, so `configure` writes nothing, generates no token, and fails naming the endpoint it

--- a/scripts/mcp/unity-mcp.mjs
+++ b/scripts/mcp/unity-mcp.mjs
@@ -1,9 +1,8 @@
 #!/usr/bin/env node
-
 /**
  * Unity MCP endpoint discovery, client auto-configuration, and streamable-HTTP bridge.
  *
- *   node scripts/mcp/unity-mcp.mjs probe       Find a live Unity MCP endpoint and handshake with it.
+ *   node scripts/mcp/unity-mcp.mjs probe       Find an endpoint advertising Unity_RunCommand.
  *   node scripts/mcp/unity-mcp.mjs configure   Discover, then write every MCP client config.
  *   node scripts/mcp/unity-mcp.mjs bridge      Serve the Unity relay over authenticated HTTP.
  *
@@ -12,7 +11,6 @@
  * Unity project directory, which is why `--project` is validated for that command alone -- the
  * project path names a host filesystem location that does not exist inside the container.
  */
-
 import { spawn } from "node:child_process";
 import { randomBytes, randomUUID, timingSafeEqual } from "node:crypto";
 import fs from "node:fs";
@@ -22,14 +20,16 @@ import os from "node:os";
 import path from "node:path";
 import process from "node:process";
 import { fileURLToPath, pathToFileURL } from "node:url";
-
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import {
+  StreamableHTTPClientTransport,
+  StreamableHTTPError
+} from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
-import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
+import { isInitializeRequest, McpError } from "@modelcontextprotocol/sdk/types.js";
 import { parse as parseToml } from "smol-toml";
-
 export const REPO_ROOT = path.resolve(fileURLToPath(new URL("../..", import.meta.url)));
-
 export const DEFAULTS = Object.freeze({
   bindHost: "0.0.0.0",
   host: "host.docker.internal",
@@ -46,16 +46,13 @@ export const DEFAULTS = Object.freeze({
   bodyTimeout: 15_000,
   maxSessions: 8
 });
-
 // Ports tried during discovery, after any explicitly configured one. 9020 is the bridge default;
 // 9003 is the port the retired supergateway bridge used, kept so an already-running host keeps working.
 export const FALLBACK_PORTS = Object.freeze([9020, 9003]);
-
 // Hosts tried during discovery, after any explicitly configured one. host.docker.internal is the
 // Docker Desktop bridge; the resolv.conf nameserver and default gateway cover WSL2 and plain Linux
 // bridge networking respectively; localhost covers running the agent on the same box as Unity.
 export const FALLBACK_HOSTS = Object.freeze(["host.docker.internal", "127.0.0.1"]);
-
 const OPTION_NAMES = new Set([
   "bind",
   "host",
@@ -73,9 +70,7 @@ const OPTION_NAMES = new Set([
   "token",
   "no-discover"
 ]);
-
 const FLAG_NAMES = new Set(["no-discover"]);
-
 const ENV_KEYS = Object.freeze({
   bindHost: "UNITY_MCP_BIND_HOST",
   host: "UNITY_MCP_BRIDGE_HOST",
@@ -92,19 +87,13 @@ const ENV_KEYS = Object.freeze({
   logLevel: "UNITY_MCP_LOG_LEVEL",
   bearerToken: "UNITY_MCP_BEARER_TOKEN"
 });
-
 function fail(message) {
   throw new Error(message);
 }
-
 function first(...values) {
   return values.find((value) => value !== undefined && value !== "");
 }
-
-// ---------------------------------------------------------------------------
 // Argument and .env.local parsing
-// ---------------------------------------------------------------------------
-
 export function parseArgs(argv) {
   const result = { _: [] };
   for (let index = 0; index < argv.length; index += 1) {
@@ -136,7 +125,6 @@ export function parseArgs(argv) {
   }
   return result;
 }
-
 // A quoted value runs to the last quote that leaves only whitespace or a comment behind. The
 // alternation lets the engine backtrack over a trailing backslash, so a Windows path written as
 // "D:\Program Files\Proj\" parses while an escaped quote inside the value ("say \"hi\"") still does.
@@ -144,7 +132,6 @@ const QUOTED_VALUE = Object.freeze({
   '"': /^"((?:\\"|[^"])*)"\s*(?:#.*)?$/,
   "'": /^'((?:\\'|[^'])*)'\s*(?:#.*)?$/
 });
-
 export function parseDotEnv(raw, source = ".env.local") {
   const values = {};
   for (const [index, original] of raw.split(/\r?\n/).entries()) {
@@ -175,7 +162,6 @@ export function parseDotEnv(raw, source = ".env.local") {
   }
   return values;
 }
-
 /**
  * `.env.local` is shared with unrelated tooling, so one line this parser cannot read must not abort
  * `probe`, `configure`, or `bridge`. Each line is parsed on its own and a bad one is warned about and
@@ -196,11 +182,7 @@ export function readLocalEnv(repoRoot) {
   }
   return values;
 }
-
-// ---------------------------------------------------------------------------
 // Validation
-// ---------------------------------------------------------------------------
-
 function integer(value, name, minimum, maximum) {
   if (!/^\d+$/.test(String(value))) {
     fail(`${name} must be an integer`);
@@ -211,14 +193,12 @@ function integer(value, name, minimum, maximum) {
   }
   return parsed;
 }
-
 function validateText(value, name) {
   if (/[\0\r\n]/.test(value)) {
     fail(`${name} contains an invalid control character`);
   }
   return value;
 }
-
 export function validateHost(value, name = "Host") {
   validateText(value, name);
   if (net.isIP(value)) {
@@ -236,7 +216,6 @@ export function validateHost(value, name = "Host") {
   }
   return value;
 }
-
 export function validateEndpointPath(value) {
   const normalized = value.startsWith("/") ? value : `/${value}`;
   if (
@@ -258,7 +237,6 @@ export function validateEndpointPath(value) {
   }
   return normalized;
 }
-
 function validateToken(value) {
   if (value === undefined) {
     return undefined;
@@ -268,10 +246,7 @@ function validateToken(value) {
   }
   return value;
 }
-
-// ---------------------------------------------------------------------------
 // Option resolution
-// ---------------------------------------------------------------------------
 
 /**
  * `repoRoot` is where MCP client configs and `.env.local` live; it is always this repository.
@@ -341,8 +316,8 @@ export function resolveOptions(args, environment = process.env, localValues, rep
   if (!/^(?:debug|info|none)$/.test(options.logLevel)) {
     fail("Log level must be debug, info, or none");
   }
-  if (!/^\d{4}-\d{2}-\d{2}$/.test(options.protocolVersion)) {
-    fail("Protocol version must use YYYY-MM-DD format");
+  if (options.protocolVersion !== DEFAULTS.protocolVersion) {
+    fail(`Protocol version must be ${DEFAULTS.protocolVersion}`);
   }
   return options;
 }
@@ -362,9 +337,7 @@ export function endpointUrl({ host, port, endpointPath }) {
   return `http://${formatted}:${port}${endpointPath}`;
 }
 
-// ---------------------------------------------------------------------------
 // Endpoint discovery
-// ---------------------------------------------------------------------------
 
 /** Nameserver entries in /etc/resolv.conf. Under WSL2 this is the Windows host. */
 export function resolvConfHosts(raw) {
@@ -460,114 +433,164 @@ export function tcpReachable(host, port, timeout) {
   });
 }
 
-function parseProbePayload(contentType, body) {
-  const candidates = contentType.includes("text/event-stream")
-    ? body
-        .split(/\r?\n/)
-        .filter((line) => line.startsWith("data:"))
-        .map((line) => line.slice(5).trim())
-        .filter((line) => line && line !== "[DONE]")
-    : [body];
-  for (const candidate of candidates) {
-    try {
-      const message = JSON.parse(candidate);
-      if (message?.jsonrpc === "2.0" && message.id === 1) {
-        return message;
-      }
-    } catch {
-      /* Continue to the next server-sent event. */
-    }
-  }
-  return undefined;
-}
-
-/**
- * Complete an MCP `initialize` handshake against one endpoint. Returns a classified result rather
- * than throwing so discovery can report every attempt; `status: "unauthorized"` in particular means
- * a bridge is running but the local bearer token does not match it, which needs different advice
- * from "nothing is listening".
- */
-export async function probeEndpoint(candidate, options, fetchImpl = fetch) {
+/** Complete the pinned MCP lifecycle and optionally inspect the editor tool registry. */
+export async function probeEndpoint(candidate, options, fetchImpl = fetch, requireTools = false) {
   const url = endpointUrl(candidate);
-  // Failures carry the candidate too, so callers can act on the endpoint that produced them (an
-  // `unauthorized` attempt names the bridge whose token needs copying).
   const classify = (status, detail) => ({ ...candidate, url, ok: false, status, detail });
+  const succeed = (extra) => ({ ...candidate, url, ok: true, status: "ok", ...extra });
   if (!(await tcpReachable(candidate.host, candidate.port, options.connectTimeout))) {
     return classify("unreachable", "no TCP listener");
   }
-
-  const headers = {
-    Accept: "application/json, text/event-stream",
-    "Content-Type": "application/json",
-    "MCP-Protocol-Version": options.protocolVersion
+  const lifecycleSignal = AbortSignal.timeout(options.timeout);
+  const authorization = options.bearerToken
+    ? { Authorization: `Bearer ${options.bearerToken}` }
+    : {};
+  const cleanupWarnings = [];
+  const cleanup = async (sessionId, protocolVersion) => {
+    if (!sessionId) return;
+    try {
+      const response = await fetchImpl(url, {
+        method: "DELETE",
+        headers: {
+          ...authorization,
+          "Mcp-Session-Id": sessionId,
+          "MCP-Protocol-Version": protocolVersion
+        },
+        signal: AbortSignal.timeout(Math.min(options.timeout, 1_000))
+      });
+      await response.body?.cancel();
+      if (!response.ok && response.status !== 405) {
+        cleanupWarnings.push(`session cleanup returned HTTP ${response.status}`);
+      }
+    } catch (error) {
+      cleanupWarnings.push(`session cleanup failed: ${error.message}`);
+    }
   };
-  if (options.bearerToken) {
-    headers.Authorization = `Bearer ${options.bearerToken}`;
-  }
-
-  let response;
-  let body;
-  try {
-    response = await fetchImpl(url, {
-      method: "POST",
-      headers,
-      body: JSON.stringify({
-        jsonrpc: "2.0",
-        id: 1,
-        method: "initialize",
-        params: {
-          protocolVersion: options.protocolVersion,
-          capabilities: {},
-          clientInfo: { name: "unity-mcp-probe", version: "1.0.0" }
+  const failure = (error, operation) => {
+    const message = error?.message ?? String(error);
+    if (error?.probeStatus) return classify(error.probeStatus, message);
+    if (error instanceof StreamableHTTPError) {
+      const status = [401, 403].includes(error.code)
+        ? "unauthorized"
+        : error.code === -1
+          ? "malformed"
+          : "http-error";
+      return classify(status, `${operation}: HTTP ${error.code}: ${message}`);
+    }
+    if (error instanceof McpError) {
+      const status = lifecycleSignal.aborted ? "transport-error" : "jsonrpc-error";
+      return classify(status, `${operation}: ${message}`);
+    }
+    const malformed = error instanceof SyntaxError || Array.isArray(error?.issues);
+    return classify(malformed ? "malformed" : "transport-error", `${operation}: ${message}`);
+  };
+  let result;
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    result = undefined;
+    let operation = "initialize";
+    let sessionId;
+    const transport = new StreamableHTTPClientTransport(new URL(url), {
+      requestInit: { headers: authorization },
+      fetch: async (target, init = {}) => {
+        if (lifecycleSignal.aborted) throw lifecycleSignal.reason;
+        const request = init.body ? JSON.parse(init.body) : undefined;
+        operation = request?.method ?? operation;
+        const lastEventId = new Headers(init.headers).get("last-event-id");
+        if (init.method === "GET" && !lastEventId) return new Response(null, { status: 405 });
+        const signal = init.signal
+          ? AbortSignal.any([init.signal, lifecycleSignal])
+          : lifecycleSignal;
+        const response = await fetchImpl(target, { ...init, signal });
+        sessionId ||= response.headers.get("mcp-session-id") ?? undefined;
+        const responseType = response.headers.get("content-type") ?? "";
+        const isSse = /^text\/event-stream\s*(?:;|$)/i.test(responseType);
+        const resumeOk = response.status === 200 && isSse;
+        if (lastEventId && response.ok && !resumeOk) {
+          await response.body?.cancel();
+          const error = new Error(`resume GET returned HTTP ${response.status} ${responseType}`);
+          error.probeStatus = "malformed";
+          throw error;
         }
-      }),
-      signal: AbortSignal.timeout(options.timeout)
+        const messages = Array.isArray(request) ? request : [request];
+        const expectsResponse = messages.some((message) => message?.method && "id" in message);
+        const expectedStatus = expectsResponse ? 200 : 202;
+        if (request && response.ok && response.status !== expectedStatus) {
+          await response.body?.cancel();
+          const error = new Error(`${operation}: HTTP ${response.status}, want ${expectedStatus}`);
+          error.probeStatus = "malformed";
+          throw error;
+        }
+        return response;
+      }
     });
-    body = await response.text();
-  } catch (error) {
-    return classify("unreachable", error.message);
+    const client = new Client({ name: "unity-mcp-probe", version: "1.0.0" });
+    let reportTransportError;
+    const transportError = new Promise((_, reject) => (reportTransportError = reject));
+    client.onerror = reportTransportError;
+    const awaited = (promise) => Promise.race([promise, transportError]);
+    let retry = false;
+    try {
+      await awaited(client.connect(transport, { signal: lifecycleSignal }));
+      const protocolVersion = transport.protocolVersion;
+      if (protocolVersion !== options.protocolVersion) {
+        const error = new Error(`server negotiated unsupported protocol ${protocolVersion}`);
+        error.probeStatus = "malformed";
+        throw error;
+      }
+      if (!requireTools) {
+        result = succeed({ sessionId, protocolVersion });
+      } else if (!client.getServerCapabilities()?.tools) {
+        result = classify("not-ready", "server did not advertise MCP tools");
+      } else {
+        const cursors = new Set();
+        let cursor;
+        let toolCount = 0;
+        operation = "tools/list";
+        for (let page = 0; page < 100; page += 1) {
+          const params = cursor === undefined ? {} : { cursor };
+          const listed = await awaited(client.listTools(params, { signal: lifecycleSignal }));
+          toolCount += listed.tools.length;
+          if (listed.tools.some((tool) => tool.name === "Unity_RunCommand")) {
+            result = succeed({ sessionId, protocolVersion, toolCount });
+            break;
+          }
+          if (listed.nextCursor === undefined) {
+            result = classify("not-ready", "Unity_RunCommand was not advertised");
+            break;
+          }
+          if (cursors.has(listed.nextCursor)) {
+            result = classify("malformed", "tools/list returned a repeated cursor");
+            break;
+          }
+          cursors.add(listed.nextCursor);
+          cursor = listed.nextCursor;
+        }
+        result ??= classify("malformed", "tools/list exceeded 100 pages");
+      }
+    } catch (error) {
+      const expired = error instanceof StreamableHTTPError && error.code === 404;
+      retry = attempt === 0 && Boolean(sessionId) && expired;
+      result = failure(error, operation);
+    } finally {
+      await client.close().catch(() => {});
+      await cleanup(sessionId, transport.protocolVersion ?? options.protocolVersion);
+    }
+    if (!retry || lifecycleSignal.aborted) break;
   }
-
-  if (response.status === 401 || response.status === 403) {
-    return classify("unauthorized", `HTTP ${response.status}`);
-  }
-  if (!response.ok) {
-    return classify("http-error", `HTTP ${response.status} ${body.slice(0, 120)}`);
-  }
-
-  const message = parseProbePayload(response.headers.get("content-type") ?? "", body);
-  if (!message || message.error || typeof message.result?.protocolVersion !== "string") {
-    return classify("malformed", body.slice(0, 120) || "no JSON-RPC result");
-  }
-
-  const sessionId = response.headers.get("mcp-session-id");
-  const negotiated = message.result.protocolVersion;
-  if (sessionId) {
-    // Close the session we just opened so probing does not leak relay child processes on the host.
-    await fetchImpl(url, {
-      method: "DELETE",
-      headers: {
-        Accept: "application/json, text/event-stream",
-        ...(options.bearerToken ? { Authorization: `Bearer ${options.bearerToken}` } : {}),
-        "Mcp-Session-Id": sessionId,
-        "MCP-Protocol-Version": negotiated
-      },
-      signal: AbortSignal.timeout(options.timeout)
-    }).catch(() => {});
-  }
-
-  return { url, ok: true, status: "ok", sessionId, protocolVersion: negotiated, ...candidate };
+  if (cleanupWarnings.length) result.cleanupWarning = cleanupWarnings.join("; ");
+  return result;
 }
 
-/** Probe every candidate in order and return the first that completes a handshake. */
+/** Probe candidates in order and return the first that meets the requested readiness level. */
 export async function discoverEndpoint(options, runtime = {}) {
   const fetchImpl = runtime.fetchImpl ?? fetch;
   const candidates = runtime.candidates ?? endpointCandidates(options, runtime);
   const attempts = [];
   for (const candidate of candidates) {
     log(options, "debug", `Probing ${endpointUrl(candidate)}`);
-    const result = await probeEndpoint(candidate, options, fetchImpl);
+    const result = await probeEndpoint(candidate, options, fetchImpl, runtime.requireTools);
     log(options, "debug", `  ${result.status}: ${result.detail ?? "ok"}`);
+    if (result.cleanupWarning) console.warn(`${result.url}: ${result.cleanupWarning}`);
     attempts.push(result);
     if (result.ok) {
       return { found: result, attempts };
@@ -580,13 +603,14 @@ export function describeAttempts(attempts) {
   const interesting = attempts.filter((attempt) => attempt.status !== "unreachable");
   const shown = interesting.length > 0 ? interesting : attempts;
   return shown
-    .map((attempt) => `  ${attempt.url} - ${attempt.status} (${attempt.detail ?? "no detail"})`)
+    .map(
+      (attempt) =>
+        `  ${attempt.url} - ${attempt.status} (${[attempt.detail, attempt.cleanupWarning].filter(Boolean).join("; ") || "no detail"})`
+    )
     .join("\n");
 }
 
-// ---------------------------------------------------------------------------
 // Client configuration
-// ---------------------------------------------------------------------------
 
 function stageFile(filePath, content) {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
@@ -886,9 +910,7 @@ export function configure(inputOptions, endpoint, beforeCommit) {
   return { url, written };
 }
 
-// ---------------------------------------------------------------------------
 // Relay discovery and the bridge server
-// ---------------------------------------------------------------------------
 
 export function relayCandidates({
   platform = process.platform,
@@ -1328,13 +1350,11 @@ export async function startBridge(inputOptions, runtime = {}) {
   return { close, closed, httpServer, options, bearerToken: options.bearerToken };
 }
 
-// ---------------------------------------------------------------------------
 // Commands
-// ---------------------------------------------------------------------------
 
 /**
  * `--no-discover` narrows the candidate list to the configured endpoint; it does not skip the
- * handshake. Returning early without probing left `runProbe` with no `found` and an empty attempts
+ * readiness check. Returning early without probing left `runProbe` with no `found` and empty attempts
  * list, so `probe --no-discover` always failed and said nothing about why.
  */
 async function resolveEndpoint(options, runtime = {}) {
@@ -1361,11 +1381,15 @@ async function resolveEndpoint(options, runtime = {}) {
 }
 
 export async function runProbe(options, runtime = {}) {
-  const { found, attempts } = await resolveEndpoint(options, runtime);
+  const { found, attempts } = await resolveEndpoint(options, { ...runtime, requireTools: true });
   if (!found) {
-    fail(`No Unity MCP endpoint responded. Attempts:\n${describeAttempts(attempts)}`);
+    fail(
+      `No Unity MCP endpoint advertised Unity_RunCommand. Attempts:\n${describeAttempts(attempts)}`
+    );
   }
-  console.log(`Unity MCP is reachable at ${found.url} (protocol ${found.protocolVersion}).`);
+  console.log(
+    `Unity MCP at ${found.url} advertises Unity_RunCommand (protocol ${found.protocolVersion}).`
+  );
   return found;
 }
 
@@ -1390,7 +1414,7 @@ export async function runConfigure(options, runtime = {}) {
   };
   if (!found) {
     console.warn(
-      `No Unity MCP endpoint responded; configuring ${endpointUrl(target)} anyway. Attempts:\n${describeAttempts(attempts)}`
+      `No Unity MCP endpoint completed initialization; configuring ${endpointUrl(target)} anyway. Attempts:\n${describeAttempts(attempts)}`
     );
   }
   const { url, written } = configure(options, target);
@@ -1421,7 +1445,7 @@ function usage() {
   return [
     "Usage: node scripts/mcp/unity-mcp.mjs <probe|configure|bridge> [options]",
     "",
-    "  probe      Discover a live Unity MCP endpoint and complete an initialize handshake.",
+    "  probe      Discover an endpoint that advertises Unity_RunCommand.",
     "  configure  Discover, then write .mcp.json, .cursor/mcp.json, .vscode/mcp.json, .codex/config.toml.",
     "  bridge     Serve the Unity relay over authenticated streamable HTTP (run next to Unity).",
     "",
@@ -1434,7 +1458,7 @@ function usage() {
     "  --project PATH              Unity project directory (bridge only)",
     "  --relay PATH                Unity relay executable override",
     "  --token TOKEN               32-256 character bearer token (generated into .env.local if omitted)",
-    "  --timeout MS                Per-endpoint handshake timeout (default: 5000)",
+    "  --timeout MS                Per-endpoint MCP lifecycle deadline (default: 5000)",
     "  --connect-timeout MS        Per-endpoint TCP connect timeout (default: 750)",
     "  --session-timeout MS        Idle session timeout (default: 60000)",
     "  --request-timeout MS        Active-request hard limit (default: 300000)",


### PR DESCRIPTION
## Summary

- reuse one bounded detached empty handler-priority cache per `MessageBus`, eliminating six managed allocation calls per warmed subscribe/unsubscribe cycle
- harden `unity:mcp:probe` with the pinned MCP 2025-11-25 SDK lifecycle, schema validation, bounded pagination, strict deadlines, session-loss recovery, stream resumption, and truthful readiness diagnostics
- incorporate the open GitHub Actions dependency update from #430 and align the CI settings/runbook with the newly required `Devcontainer CI Success` aggregate

## Evidence

### Registration churn (#414)

Fresh Unity Mono candidate/control/candidate screening:

| Row | Candidate A | Control | Candidate A2 |
| --- | ---: | ---: | ---: |
| DirectBus, 131072 cycles | 51.935 ms | 95.384 ms | 56.305 ms |
| DirectHandler, 131072 cycles | 116.184 ms | 164.739 ms | 117.113 ms |
| TokenActive, 131072 cycles | 184.995 ms | 193.229 ms | 166.083 ms |
| DxMessaging SubUnsub | 690,929/s | 552,460/s | 764,049/s |

The warmed allocation probe changed DirectBus and DirectHandler from 60,000 calls to 0 over 10,000 cycles, and TokenActive from 80,000 to 20,000. PR #432 Standalone IL2CPP measured DxMessaging SubUnsub at 1,262,467/s versus the committed 942,479/s baseline (+34.0%); MessagePipe measured 2,140,992/s in the same run, so this PR does not claim parity.

Unity verification:

- MemoryReclamationTests: 66/66
- memory reclamation + reentrant mutation fixtures: 81/81
- stale deregistration + MessageBus invariants: 20/20
- registration lifecycle benchmark contracts: 47/47
- registration allocation fixture: 5/5

### Unity MCP diagnostics (#418)

The probe now uses the installed MCP SDK rather than a bespoke buffered SSE parser. Focused coverage includes initialization/configure sequencing, SDK schemas and media types, JSON-RPC errors, open SSE ping/pong and `Last-Event-ID` resumption, strict expiry, bounded pagination, one-time session reinitialization, and cleanup on failure.

This detects the transient empty-registry mode only. It does not repair the relay/editor boundary, validate the discovery heartbeat, or make an already-open client rediscover tools.

## Repository validation

- `npm test`: 441/441
- `npm run validate:all`
- `npm run format:check`
- `npm run check:spelling`
- `npm run lint:markdown`
- CSharpier check on all changed C# files
- live `npm run unity:mcp:probe`
- JavaScript LOC budget: 18,040/18,040
- exact-head PR CI green: all four Unity versions, both devcontainer architectures, static/docs checks, and both Standalone performance legs

## Issue status

- Advances #414 with a +34.0% Standalone IL2CPP SubUnsub result; keep open because MessagePipe remains 1.70x faster.
- Advances #418 with a diagnostic-only improvement; the two observed post-refresh availability modes remain unresolved at the relay/editor boundary.
- Advances #369; the live ruleset now requires `Devcontainer CI Success`, and this PR provides the first post-enforcement relevant-path merge shape. Keep open until an unrelated shape is also observed.
- #356 remains open: 40 completed workflow runs / 257 terminal jobs show no recurrence, but runner-host diagnostics required for RCA are unavailable.
- #406 remains open because the existing measurement confirms, rather than disproves, superseded-generation accumulation.

Incorporates #430 without closing the dependency PR before this aggregate PR is green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches MessageBus register/deregister recycling on the dispatch path, so snapshot and stale-deregistration bugs are possible. MCP probe and org-lock action SHA bumps affect CI/dev tooling, not product auth.
> 
> **Overview**
> Cuts warmed subscribe/unsubscribe churn by recycling **one** empty priority-leaf `HandlerCache` per `MessageBus` instead of allocating a new dictionary and insertion-order list each cycle. Retention follows `BufferMaxDistinctEntries` (zero disables it); forced `Trim`/`ResetState` and a lowered cap drain the spare.
> 
> `unity:mcp:probe` now requires `Unity_RunCommand` via the pinned MCP `2025-11-25` SDK lifecycle (schema/SSE, pagination, one session-404 retry, bounded DELETE cleanup). `configure` still writes the first initialized endpoint without inspecting tools. Failure classes add `transport-error`, `jsonrpc-error`, and `not-ready`.
> 
> Also retargets org Unity-lock GitHub Actions to SHA `c0546991…` and documents `Devcontainer CI Success` as a required aggregate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1d88e2014f254576ef4d0cc740f7de7b412dee6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->