### PR TITLE
perf: make diagnostic emission-site capture opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and 67 managed allocations per record, and every emission writes at least two records (one on the
   bus, one per token delivery), so turning diagnostics on dropped editor dispatch from tens of
   millions of emissions per second to about 1,100 and allocated roughly 143 KB per emission. Message
-  Monitor and Flow Graph emission-site links stay empty until capture is enabled
+  Monitor and Flow Graph now say when a call site is missing because capture is off and offer an
+  **Enable stack traces** button that applies immediately and is saved to project settings
   ([#433](https://github.com/Ambiguous-Interactive/DxMessaging/issues/433)).
 
 ## [3.3.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#426](https://github.com/Ambiguous-Interactive/DxMessaging/issues/426)).
 - Reduce repeated message-handler subscribe/unsubscribe churn by six managed allocation calls per
   cycle ([#414](https://github.com/Ambiguous-Interactive/DxMessaging/issues/414)).
+- **BREAKING (diagnostics output):** Diagnostic emission records no longer capture the emission-site
+  stack trace unless you opt in through `IMessageBus.GlobalDiagnosticsStackTraces` or the
+  **Capture Emission Stack Traces** project setting. Capturing a trace cost about 236 microseconds
+  and 67 managed allocations per record, and every emission writes at least two records (one on the
+  bus, one per token delivery), so turning diagnostics on dropped editor dispatch from tens of
+  millions of emissions per second to about 1,100 and allocated roughly 143 KB per emission. Message
+  Monitor and Flow Graph emission-site links stay empty until capture is enabled
+  ([#433](https://github.com/Ambiguous-Interactive/DxMessaging/issues/433)).
 
 ## [3.3.0]
 

--- a/Editor/CustomEditors/MessagingComponentEditor.cs
+++ b/Editor/CustomEditors/MessagingComponentEditor.cs
@@ -7,6 +7,7 @@ namespace DxMessaging.Editor.CustomEditors
     using Core.Diagnostics;
     using Core.MessageBus;
     using Core.Messages;
+    using DxMessaging.Editor;
     using DxMessaging.Editor.Testing;
     using DxMessaging.Unity;
     using UnityEditor;
@@ -295,7 +296,9 @@ namespace DxMessaging.Editor.CustomEditors
                                 GUIContent labelContent = new("Message Type");
                                 GUIContent valueContent = new(
                                     globalEmissionData.message.MessageType.Name,
-                                    globalEmissionData.stackTrace
+                                    DxMessagingEmissionCaptureNotice.DescribeCallSiteTooltip(
+                                        globalEmissionData.stackTrace
+                                    )
                                 );
 
                                 EditorGUILayout.LabelField(labelContent, valueContent, style);
@@ -404,7 +407,9 @@ namespace DxMessaging.Editor.CustomEditors
                                 GUIContent labelContent = new("Message Type");
                                 GUIContent valueContent = new(
                                     globalEmissionData.message.MessageType.Name,
-                                    globalEmissionData.stackTrace
+                                    DxMessagingEmissionCaptureNotice.DescribeCallSiteTooltip(
+                                        globalEmissionData.stackTrace
+                                    )
                                 );
 
                                 EditorGUILayout.LabelField(labelContent, valueContent);

--- a/Editor/DxMessagingEditorInitializer.cs
+++ b/Editor/DxMessagingEditorInitializer.cs
@@ -130,6 +130,7 @@ namespace DxMessaging.Editor
                 return;
             }
             IMessageBus.GlobalDiagnosticsTargets = settings.DiagnosticsTargets;
+            IMessageBus.GlobalDiagnosticsStackTraces = settings.DiagnosticsStackTraces;
             IMessageBus.GlobalMessageBufferSize = settings.MessageBufferSize;
         }
 

--- a/Editor/DxMessagingEmissionCaptureNotice.cs
+++ b/Editor/DxMessagingEmissionCaptureNotice.cs
@@ -1,0 +1,138 @@
+#if UNITY_EDITOR
+namespace DxMessaging.Editor
+{
+    using System;
+    using Core.MessageBus;
+    using DxMessaging.Editor.Settings;
+    using UnityEditor;
+    using UnityEngine.UIElements;
+
+    /// <summary>
+    /// One definition of how the editor surfaces explain a MISSING emission call site, and one
+    /// place that turns capture back on.
+    ///
+    /// <para>
+    /// Emission-site capture is opt-in (issue #433) because capturing a managed stack trace costs
+    /// hundreds of microseconds and tens of allocations per diagnostic record. That is the right
+    /// default, but it means the Message Monitor stack pane and the Flow Graph emission-site rows
+    /// are empty for most users, and an empty pane that does not say WHY reads as a broken tool.
+    /// Every surface that renders a call site routes its empty state through here so the reason and
+    /// the fix are identical wherever the user happens to be looking.
+    /// </para>
+    /// </summary>
+    internal static class DxMessagingEmissionCaptureNotice
+    {
+        /// <summary>Name of the enable button, so tests and surfaces can find it.</summary>
+        internal const string EnableButtonName = "dxmessaging-enable-emission-capture";
+
+        /// <summary>Short suffix for a collapsed header, e.g. "Stack trace (capture off)".</summary>
+        internal const string DisabledSummary = "capture off";
+
+        internal const string EnableButtonText = "Enable stack traces";
+
+        internal const string DisabledExplanation =
+            "Emission stack traces are off, so no call site was recorded. Capturing one walks the "
+            + "managed stack on every diagnostic record, which is why it is opt-in. Turning it on "
+            + "applies to emissions from here on; rows already recorded stay empty.";
+
+        internal const string SettingsPathHint =
+            "Project Settings > Wallstop Studios > DxMessaging > Capture Emission Stack Traces";
+
+        /// <summary>
+        /// Whether emission-site capture is currently recording call sites.
+        /// </summary>
+        internal static bool CaptureEnabled => IMessageBus.GlobalDiagnosticsStackTraces;
+
+        /// <summary>
+        /// Test seam mirroring the inspector overlay's: lets a test run the settings write inline
+        /// instead of waiting on <c>delayCall</c> plus an editor-idle tick.
+        /// </summary>
+        internal static Action<Action> AssetDatabaseMutationScheduler { get; set; }
+
+        /// <summary>
+        /// Turns capture on for this session immediately, then persists it to the settings asset so
+        /// it survives a domain reload. The in-memory flip is deliberately NOT deferred: the user
+        /// clicked a button and expects the next emission to carry a site, while the asset write
+        /// has to wait for an editor-idle tick like every other settings mutation.
+        /// </summary>
+        internal static void EnableCapture()
+        {
+            IMessageBus.GlobalDiagnosticsStackTraces = true;
+
+            Action<Action> schedule =
+                AssetDatabaseMutationScheduler
+                ?? DxMessagingEditorIdle.ScheduleAssetDatabaseMutation;
+            schedule(() =>
+            {
+                try
+                {
+                    DxMessagingSettings settings = DxMessagingSettings.GetOrCreateSettings();
+                    if (settings == null)
+                    {
+                        return;
+                    }
+
+                    if (settings.DiagnosticsStackTraces)
+                    {
+                        return;
+                    }
+
+                    settings.DiagnosticsStackTraces = true;
+                    EditorUtility.SetDirty(settings);
+                    AssetDatabase.SaveAssets();
+                }
+                catch (Exception ex)
+                {
+                    DxMessagingEditorLog.LogWarning(
+                        "Failed to persist the emission stack-trace capture setting.",
+                        ex
+                    );
+                }
+            });
+        }
+
+        /// <summary>
+        /// Tooltip text for a surface that can only show a string: the captured call site when
+        /// there is one, otherwise the reason it is missing and where the switch lives. Returns
+        /// empty when capture is on and the record simply predates it, so an IMGUI tooltip does
+        /// not assert something false.
+        /// </summary>
+        internal static string DescribeCallSiteTooltip(string stackTrace)
+        {
+            if (!string.IsNullOrWhiteSpace(stackTrace))
+            {
+                return stackTrace;
+            }
+
+            return CaptureEnabled
+                ? string.Empty
+                : $"{DisabledExplanation} Turn it on at {SettingsPathHint}.";
+        }
+
+        /// <summary>
+        /// Builds the "capture is off, here is the switch" block: the reason, where the setting
+        /// lives, and a one-click enable.
+        /// </summary>
+        internal static VisualElement CreateDisabledNotice(string explanationLabelName)
+        {
+            VisualElement notice = new();
+
+            Label explanation = new(DisabledExplanation) { name = explanationLabelName };
+            explanation.style.whiteSpace = WhiteSpace.Normal;
+            notice.Add(explanation);
+
+            Button enable = new(EnableCapture)
+            {
+                name = EnableButtonName,
+                text = EnableButtonText,
+                tooltip = SettingsPathHint,
+            };
+            enable.style.alignSelf = Align.FlexStart;
+            enable.style.marginTop = 4;
+            notice.Add(enable);
+
+            return notice;
+        }
+    }
+}
+#endif

--- a/Editor/DxMessagingEmissionCaptureNotice.cs.meta
+++ b/Editor/DxMessagingEmissionCaptureNotice.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 516d60b483f44fd5806f5949eb67c38f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Editor/Settings/DxMessagingSettings.cs
+++ b/Editor/Settings/DxMessagingSettings.cs
@@ -28,6 +28,9 @@ namespace DxMessaging.Editor.Settings
         internal bool _legacyEnableDiagnosticsInEditor;
 
         [SerializeField]
+        internal bool _diagnosticsStackTraces;
+
+        [SerializeField]
         internal int _messageBufferSize = IMessageBus.DefaultMessageBufferSize;
 
         [SerializeField]
@@ -53,6 +56,18 @@ namespace DxMessaging.Editor.Settings
                 _diagnosticsTargets = value;
                 _legacyEnableDiagnosticsInEditor = false;
             }
+        }
+
+        /// <summary>
+        /// Sets <see cref="IMessageBus.GlobalDiagnosticsStackTraces"/> for Editor sessions. Off by
+        /// default: capturing an emission-site stack trace costs hundreds of microseconds and tens
+        /// of allocations per diagnostic record, and every emission writes at least two records.
+        /// Turn it on only while chasing down where a message came from.
+        /// </summary>
+        public bool DiagnosticsStackTraces
+        {
+            get => _diagnosticsStackTraces;
+            set => _diagnosticsStackTraces = value;
         }
 
         /// <summary>
@@ -225,6 +240,7 @@ namespace DxMessaging.Editor.Settings
             {
                 settings = CreateInstance<DxMessagingSettings>();
                 settings._diagnosticsTargets = DiagnosticsTarget.Off;
+                settings._diagnosticsStackTraces = false;
                 settings._messageBufferSize = IMessageBus.DefaultMessageBufferSize;
                 settings._suppressDomainReloadWarning = true;
                 settings._baseCallCheckEnabled = true;

--- a/Editor/Settings/DxMessagingSettingsProvider.cs
+++ b/Editor/Settings/DxMessagingSettingsProvider.cs
@@ -24,10 +24,13 @@ namespace DxMessaging.Editor.Settings
 
         private const string DiagnosticsSectionTitle = "Diagnostics";
         private const string DiagnosticsSectionDescription =
-            "Controls how much message history the editor keeps when diagnostics are enabled.";
+            "Controls what the editor records when diagnostics are enabled, and how much message history it keeps.";
         private const string DiagnosticsTargetsLabel = "Diagnostics Targets";
         private const string DiagnosticsTargetsTooltip =
             "Select where global diagnostics should be enabled by default.";
+        private const string DiagnosticsStackTracesLabel = "Capture Emission Stack Traces";
+        private const string DiagnosticsStackTracesTooltip =
+            "Record the call site of every emission. Costs hundreds of microseconds and tens of allocations per diagnostic record; leave off unless you are tracing where a message came from.";
         private const string MessageBufferSizeLabel = "Message Buffer Size";
         private const string MessageBufferSizeTooltip =
             "Number of emissions kept per bus/token when diagnostics mode is active.";
@@ -93,6 +96,13 @@ namespace DxMessaging.Editor.Settings
             {
                 DrawSectionHeader(DiagnosticsSectionTitle, DiagnosticsSectionDescription);
                 DrawDiagnosticsTargetsField(_messagingSettings);
+                DrawSettingsToggle(
+                    _messagingSettings,
+                    nameof(DxMessagingSettings._diagnosticsStackTraces),
+                    DiagnosticsStackTracesLabel,
+                    DiagnosticsStackTracesTooltip,
+                    settings => settings.DiagnosticsStackTraces
+                );
                 DrawPropertyField(
                     _messagingSettings,
                     nameof(DxMessagingSettings._messageBufferSize),
@@ -182,6 +192,12 @@ namespace DxMessaging.Editor.Settings
                         nameof(DxMessagingSettings._diagnosticsTargets),
                         DiagnosticsTargetsLabel,
                         DiagnosticsTargetsTooltip
+                    ),
+                    CreatePropertyField(
+                        serializedSettings,
+                        nameof(DxMessagingSettings._diagnosticsStackTraces),
+                        DiagnosticsStackTracesLabel,
+                        DiagnosticsStackTracesTooltip
                     ),
                     CreatePropertyField(
                         serializedSettings,
@@ -430,6 +446,7 @@ namespace DxMessaging.Editor.Settings
                         "MessageBus",
                         "Targets",
                         DiagnosticsTargetsLabel,
+                        DiagnosticsStackTracesLabel,
                         MessageBufferSizeLabel,
                         EditorSafetySectionTitle,
                         SuppressDomainReloadWarningLabel,

--- a/Editor/Settings/DxMessagingSettingsProvider.cs
+++ b/Editor/Settings/DxMessagingSettingsProvider.cs
@@ -96,12 +96,11 @@ namespace DxMessaging.Editor.Settings
             {
                 DrawSectionHeader(DiagnosticsSectionTitle, DiagnosticsSectionDescription);
                 DrawDiagnosticsTargetsField(_messagingSettings);
-                DrawSettingsToggle(
+                DrawPropertyField(
                     _messagingSettings,
                     nameof(DxMessagingSettings._diagnosticsStackTraces),
                     DiagnosticsStackTracesLabel,
-                    DiagnosticsStackTracesTooltip,
-                    settings => settings.DiagnosticsStackTraces
+                    DiagnosticsStackTracesTooltip
                 );
                 DrawPropertyField(
                     _messagingSettings,
@@ -121,17 +120,17 @@ namespace DxMessaging.Editor.Settings
                 DrawSectionHeader(InspectorChecksSectionTitle, InspectorChecksSectionDescription);
                 DrawSettingsToggle(
                     _messagingSettings,
-                    nameof(DxMessagingSettings._baseCallCheckEnabled),
                     BaseCallCheckEnabledLabel,
                     BaseCallCheckEnabledTooltip,
-                    settings => settings.BaseCallCheckEnabled
+                    settings => settings.BaseCallCheckEnabled,
+                    (settings, value) => settings.BaseCallCheckEnabled = value
                 );
                 DrawSettingsToggle(
                     _messagingSettings,
-                    nameof(DxMessagingSettings._useConsoleBridge),
                     UseConsoleBridgeLabel,
                     UseConsoleBridgeTooltip,
-                    settings => settings.UseConsoleBridge
+                    settings => settings.UseConsoleBridge,
+                    (settings, value) => settings.UseConsoleBridge = value
                 );
                 DrawPropertyField(
                     _messagingSettings,
@@ -230,14 +229,16 @@ namespace DxMessaging.Editor.Settings
                         nameof(DxMessagingSettings._baseCallCheckEnabled),
                         BaseCallCheckEnabledLabel,
                         BaseCallCheckEnabledTooltip,
-                        settings => settings.BaseCallCheckEnabled
+                        settings => settings.BaseCallCheckEnabled,
+                        (settings, value) => settings.BaseCallCheckEnabled = value
                     ),
                     CreateSettingsToggle(
                         serializedSettings,
                         nameof(DxMessagingSettings._useConsoleBridge),
                         UseConsoleBridgeLabel,
                         UseConsoleBridgeTooltip,
-                        settings => settings.UseConsoleBridge
+                        settings => settings.UseConsoleBridge,
+                        (settings, value) => settings.UseConsoleBridge = value
                     ),
                     CreatePropertyField(
                         serializedSettings,
@@ -313,7 +314,8 @@ namespace DxMessaging.Editor.Settings
             string fieldName,
             string label,
             string tooltip,
-            Func<DxMessagingSettings, bool> getValue
+            Func<DxMessagingSettings, bool> getValue,
+            Action<DxMessagingSettings, bool> setValue
         )
         {
             if (serializedSettings.targetObject is not DxMessagingSettings settings)
@@ -329,7 +331,7 @@ namespace DxMessaging.Editor.Settings
             toggle.style.marginTop = 4;
             toggle.SetValueWithoutNotify(getValue(settings));
             toggle.RegisterValueChangedCallback(evt =>
-                ApplySettingsToggleValue(serializedSettings, fieldName, evt.newValue)
+                ApplySettingsToggleValue(serializedSettings, setValue, evt.newValue)
             );
             return toggle;
         }
@@ -373,10 +375,10 @@ namespace DxMessaging.Editor.Settings
 
         private static void DrawSettingsToggle(
             SerializedObject serializedSettings,
-            string fieldName,
             string label,
             string tooltip,
-            Func<DxMessagingSettings, bool> getValue
+            Func<DxMessagingSettings, bool> getValue,
+            Action<DxMessagingSettings, bool> setValue
         )
         {
             if (serializedSettings.targetObject is not DxMessagingSettings settings)
@@ -395,13 +397,19 @@ namespace DxMessaging.Editor.Settings
             if (updatedValue != currentValue)
             {
                 serializedSettings.ApplyModifiedProperties();
-                ApplySettingsToggleValue(serializedSettings, fieldName, updatedValue);
+                ApplySettingsToggleValue(serializedSettings, setValue, updatedValue);
             }
         }
 
+        /// <summary>
+        /// Applies a toggle change through the settings property that owns its side effects
+        /// (console-bridge rescans, base-call harvest scheduling), then marks the asset dirty.
+        /// The caller supplies the setter, so a new toggle cannot be added without one; an earlier
+        /// field-name switch here silently went stale and threw for any field it did not list.
+        /// </summary>
         internal static void ApplySettingsToggleValue(
             SerializedObject serializedSettings,
-            string fieldName,
+            Action<DxMessagingSettings, bool> setValue,
             bool value
         )
         {
@@ -413,18 +421,12 @@ namespace DxMessaging.Editor.Settings
                 );
             }
 
-            switch (fieldName)
+            if (setValue == null)
             {
-                case nameof(DxMessagingSettings._baseCallCheckEnabled):
-                    settings.BaseCallCheckEnabled = value;
-                    break;
-                case nameof(DxMessagingSettings._useConsoleBridge):
-                    settings.UseConsoleBridge = value;
-                    break;
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(fieldName), fieldName, null);
+                throw new ArgumentNullException(nameof(setValue));
             }
 
+            setValue(settings, value);
             EditorUtility.SetDirty(settings);
             serializedSettings.Update();
         }

--- a/Editor/Windows/DxMessagingEditorSourceLinks.cs
+++ b/Editor/Windows/DxMessagingEditorSourceLinks.cs
@@ -217,10 +217,27 @@ namespace DxMessaging.Editor.Windows
                 .ToArray();
         }
 
+        /// <summary>
+        /// Placeholder <see cref="CreateEmissionSite"/> returns when a record carries no usable
+        /// call site. Named because callers must be able to recognize it: a list of these means
+        /// "nothing was recorded", not "here are some call sites".
+        /// </summary>
+        internal const string UnknownCallSite = "<unknown call site>";
+
         internal static string CreateEmissionSite(string stackTrace)
         {
             IReadOnlyList<string> frames = ReadCallSiteFrames(stackTrace);
-            return frames.Count == 0 ? "<unknown call site>" : frames[0];
+            return frames.Count == 0 ? UnknownCallSite : frames[0];
+        }
+
+        /// <summary>
+        /// Whether <paramref name="value"/> is the "no call site was recorded" placeholder rather
+        /// than a real frame.
+        /// </summary>
+        internal static bool IsUnknownCallSite(string value)
+        {
+            return string.IsNullOrWhiteSpace(value)
+                || string.Equals(value.Trim(), UnknownCallSite, StringComparison.Ordinal);
         }
 
         internal static string CreateCompactCallSiteLabel(string value)

--- a/Editor/Windows/DxMessagingFlowGraphWindow.cs
+++ b/Editor/Windows/DxMessagingFlowGraphWindow.cs
@@ -177,6 +177,14 @@ namespace DxMessaging.Editor.Windows
             "dxmessaging-flow-graph-details-hierarchy-trail";
         internal const string DetailsHierarchySegmentClassName =
             "dxmessaging-flow-graph-details-hierarchy-segment";
+
+        /// <summary>
+        /// Name of the explanation label shown when emission-site capture is off, so tests and
+        /// callers can find it alongside the shared enable button.
+        /// </summary>
+        internal const string CaptureDisabledExplanationName =
+            "dxmessaging-flow-graph-capture-disabled";
+
         internal const string DetailsSourceRowClassName =
             "dxmessaging-flow-graph-details-source-row";
         internal const string DetailsRelationshipClassName =
@@ -8016,7 +8024,9 @@ namespace DxMessaging.Editor.Windows
             return row;
         }
 
-        private static void AddSourceDetailValues(
+        // internal for the capture-off notice tests: building a full snapshot and selecting a node
+        // to reach this empty state would test the graph, not the notice.
+        internal static void AddSourceDetailValues(
             VisualElement section,
             string firstLabel,
             IReadOnlyList<string> values
@@ -8024,6 +8034,24 @@ namespace DxMessaging.Editor.Windows
         {
             if (values.Count == 0)
             {
+                // "none captured" reads as "we looked and there was nothing", which is wrong when
+                // emission-site capture is simply off. Name the setting and carry its switch.
+                if (!DxMessagingEmissionCaptureNotice.CaptureEnabled)
+                {
+                    section.Add(
+                        CreateDetailsKeyValue(
+                            firstLabel,
+                            $"none captured ({DxMessagingEmissionCaptureNotice.DisabledSummary})"
+                        )
+                    );
+                    section.Add(
+                        DxMessagingEmissionCaptureNotice.CreateDisabledNotice(
+                            CaptureDisabledExplanationName
+                        )
+                    );
+                    return;
+                }
+
                 section.Add(CreateDetailsKeyValue(firstLabel, "none captured"));
                 return;
             }

--- a/Editor/Windows/DxMessagingFlowGraphWindow.cs
+++ b/Editor/Windows/DxMessagingFlowGraphWindow.cs
@@ -8032,6 +8032,21 @@ namespace DxMessaging.Editor.Windows
             IReadOnlyList<string> values
         )
         {
+            // CreateEmissionSite returns the UnknownCallSite placeholder for a record with no
+            // captured trace, so with capture off a node that HAS emitted still carries a full
+            // list -- of placeholders. Rendering those would say nothing and would hide the
+            // capture notice behind rows that look like data, so they are dropped first and a
+            // list left with nothing real is the same fact as an empty one.
+            List<string> resolved = new(values.Count);
+            for (int index = 0; index < values.Count; index++)
+            {
+                if (!DxMessagingEditorSourceLinks.IsUnknownCallSite(values[index]))
+                {
+                    resolved.Add(values[index]);
+                }
+            }
+
+            values = resolved;
             if (values.Count == 0)
             {
                 // "none captured" reads as "we looked and there was nothing", which is wrong when

--- a/Editor/Windows/DxMessagingMessageMonitorWindow.cs
+++ b/Editor/Windows/DxMessagingMessageMonitorWindow.cs
@@ -2458,16 +2458,30 @@ namespace DxMessaging.Editor.Windows
                 entry.StackTrace
             );
             bool captured = frames.Count > 0;
-            // A trace that was captured but holds nothing except Unity's capture frames is a
-            // different fact from one that was never captured, and saying "not captured" about
-            // it would be false.
+            // Three distinct facts, and calling any of them by another's name would be a lie:
+            // a trace holding only Unity's capture frames WAS captured; an empty trace while
+            // capture is off is the opt-in setting, not a missing call site; an empty trace while
+            // capture is ON is a record written before it was turned on (or built by hand).
             bool captureFramesOnly = !captured && !string.IsNullOrWhiteSpace(entry.StackTrace);
-            string emptyText = captureFramesOnly
-                ? "Stack trace (no caller frames)"
-                : "Stack trace (not captured)";
-            string emptyBody = captureFramesOnly
-                ? "Stack trace: captured, but every frame was Unity's own stack capture."
-                : "Stack trace: not captured";
+            bool captureDisabled =
+                !captured && !captureFramesOnly && !DxMessagingEmissionCaptureNotice.CaptureEnabled;
+            string emptyText;
+            string emptyBody;
+            if (captureFramesOnly)
+            {
+                emptyText = "Stack trace (no caller frames)";
+                emptyBody = "Stack trace: captured, but every frame was Unity's own stack capture.";
+            }
+            else if (captureDisabled)
+            {
+                emptyText = $"Stack trace ({DxMessagingEmissionCaptureNotice.DisabledSummary})";
+                emptyBody = DxMessagingEmissionCaptureNotice.DisabledExplanation;
+            }
+            else
+            {
+                emptyText = "Stack trace (not captured)";
+                emptyBody = "Stack trace: not captured";
+            }
             Foldout stackFoldout = new()
             {
                 name = foldoutName,
@@ -2482,10 +2496,26 @@ namespace DxMessaging.Editor.Windows
 
             if (!captured)
             {
-                Label empty = new(emptyBody) { name = labelName };
-                empty.style.whiteSpace = WhiteSpace.Normal;
-                stackFrames.Add(empty);
+                if (captureDisabled)
+                {
+                    // The switch travels with the explanation: an empty pane that only says
+                    // "off" still leaves the user hunting through project settings.
+                    stackFrames.Add(
+                        DxMessagingEmissionCaptureNotice.CreateDisabledNotice(labelName)
+                    );
+                }
+                else
+                {
+                    Label empty = new(emptyBody) { name = labelName };
+                    empty.style.whiteSpace = WhiteSpace.Normal;
+                    stackFrames.Add(empty);
+                }
+
                 stackFoldout.Add(stackFrames);
+                // Opened by default ONLY in the capture-off state: the header alone cannot carry
+                // the reason plus the fix, and a collapsed foldout is exactly how the setting
+                // stayed invisible. A real trace stays collapsed so it cannot bury the log.
+                stackFoldout.value = captureDisabled;
                 return stackFoldout;
             }
 

--- a/Runtime/Core/Diagnostics/MessageEmissionData.cs
+++ b/Runtime/Core/Diagnostics/MessageEmissionData.cs
@@ -1,7 +1,8 @@
 namespace DxMessaging.Core.Diagnostics
 {
     using System;
-    using System.Linq;
+    using System.Text;
+    using DxMessaging.Core.MessageBus;
 #if UNITY_2021_3_OR_NEWER
     using UnityEngine;
 #else
@@ -13,8 +14,11 @@ namespace DxMessaging.Core.Diagnostics
     /// </summary>
     /// <remarks>
     /// When diagnostics are enabled (see <see cref="MessageBus.IMessageBus.GlobalDiagnosticsTargets"/>),
-    /// the bus and tokens record recent emissions in ring buffers along with a trimmed stack trace
-    /// that excludes DxMessaging internals for easier debugging.
+    /// the bus and tokens record recent emissions in ring buffers. Each record also carries a trimmed
+    /// stack trace that excludes DxMessaging internals, but ONLY when
+    /// <see cref="MessageBus.IMessageBus.GlobalDiagnosticsStackTraces"/> is enabled; capturing a trace
+    /// costs hundreds of microseconds and tens of allocations per record, so <see cref="stackTrace"/> is
+    /// <see cref="string.Empty"/> by default.
     ///
     /// The <see cref="context"/> contains the relevant <see cref="InstanceId"/> for targeted/broadcast messages
     /// (target or source respectively) and is null for untargeted messages. Runtime records emitted by a
@@ -23,7 +27,6 @@ namespace DxMessaging.Core.Diagnostics
     /// </remarks>
     public readonly struct MessageEmissionData
     {
-        private static readonly string[] NewlineSeparators = { "\r\n", "\n", "\r" };
         private static readonly string JoinSeparator = Environment.NewLine;
 
         /// <summary>Emitted message payload.</summary>
@@ -32,7 +35,10 @@ namespace DxMessaging.Core.Diagnostics
         /// <summary>Relevant context (target/source) for the emission; null for untargeted.</summary>
         public readonly InstanceId? context;
 
-        /// <summary>Trimmed stack trace captured at the emission site.</summary>
+        /// <summary>
+        /// Trimmed stack trace captured at the emission site, or <see cref="string.Empty"/> when
+        /// <see cref="MessageBus.IMessageBus.GlobalDiagnosticsStackTraces"/> is disabled (the default).
+        /// </summary>
         public readonly string stackTrace;
 
         /// <summary>
@@ -70,7 +76,9 @@ namespace DxMessaging.Core.Diagnostics
             this.context = context;
             this.traceId = traceId;
             this.registrationHandle = registrationHandle;
-            stackTrace = GetAccurateStackTrace();
+            stackTrace = IMessageBus.GlobalDiagnosticsStackTraces
+                ? GetAccurateStackTrace()
+                : string.Empty;
         }
 
         private static string GetAccurateStackTrace()
@@ -86,32 +94,93 @@ namespace DxMessaging.Core.Diagnostics
                 return fullStackTrace;
             }
 
-            string[] lines = fullStackTrace.Split(NewlineSeparators, StringSplitOptions.None);
-
-            string[] trimmedLines = lines
-                .Where(line => !string.IsNullOrWhiteSpace(line) && !IsInternalFrame(line))
-                .ToArray();
-
-            return trimmedLines.Length == 0
-                ? string.Empty
-                : string.Join(JoinSeparator, trimmedLines);
+            return TrimInternalFrames(fullStackTrace);
         }
 
-        private static bool IsInternalFrame(string line)
+        /// <summary>
+        /// Drops blank lines and DxMessaging-internal frames in a single pass over
+        /// <paramref name="fullStackTrace"/>. The previous split + LINQ filter + join allocated a
+        /// line array, an iterator, a filtered array, and a join buffer on top of the trace itself;
+        /// this keeps the identical output with one builder.
+        /// </summary>
+        private static string TrimInternalFrames(string fullStackTrace)
         {
-            if (string.IsNullOrWhiteSpace(line))
+            StringBuilder builder = null;
+            int length = fullStackTrace.Length;
+            int lineStart = 0;
+            while (lineStart <= length)
+            {
+                int lineEnd = lineStart;
+                while (
+                    lineEnd < length
+                    && fullStackTrace[lineEnd] != '\n'
+                    && fullStackTrace[lineEnd] != '\r'
+                )
+                {
+                    lineEnd++;
+                }
+
+                int lineLength = lineEnd - lineStart;
+                if (
+                    0 < lineLength
+                    && !IsBlank(fullStackTrace, lineStart, lineLength)
+                    && !IsInternalFrame(fullStackTrace, lineStart, lineLength)
+                )
+                {
+                    builder ??= new StringBuilder(length);
+                    if (0 < builder.Length)
+                    {
+                        builder.Append(JoinSeparator);
+                    }
+
+                    builder.Append(fullStackTrace, lineStart, lineLength);
+                }
+
+                if (lineEnd >= length)
+                {
+                    break;
+                }
+
+                // A CRLF pair terminates one line, matching the old separator list.
+                if (
+                    fullStackTrace[lineEnd] == '\r'
+                    && lineEnd + 1 < length
+                    && fullStackTrace[lineEnd + 1] == '\n'
+                )
+                {
+                    lineEnd++;
+                }
+
+                lineStart = lineEnd + 1;
+            }
+
+            return builder == null ? string.Empty : builder.ToString();
+        }
+
+        private static bool IsBlank(string text, int start, int length)
+        {
+            for (int index = start; index < start + length; index++)
+            {
+                if (!char.IsWhiteSpace(text[index]))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private static bool IsInternalFrame(string text, int start, int length)
+        {
+            if (0 > text.IndexOf("DxMessaging.", start, length, StringComparison.Ordinal))
             {
                 return false;
             }
 
-            if (!line.Contains("DxMessaging.", StringComparison.Ordinal))
-            {
-                return false;
-            }
-
-            return line.Contains("DxMessaging.Core.", StringComparison.Ordinal)
-                || line.Contains("DxMessaging.Unity.", StringComparison.Ordinal)
-                || line.Contains("DxMessaging.Editor.", StringComparison.Ordinal);
+            return 0 <= text.IndexOf("DxMessaging.Core.", start, length, StringComparison.Ordinal)
+                || 0 <= text.IndexOf("DxMessaging.Unity.", start, length, StringComparison.Ordinal)
+                || 0
+                    <= text.IndexOf("DxMessaging.Editor.", start, length, StringComparison.Ordinal);
         }
     }
 }

--- a/Runtime/Core/DxMessagingStaticState.cs
+++ b/Runtime/Core/DxMessagingStaticState.cs
@@ -45,6 +45,7 @@ namespace DxMessaging.Core
                 MessagingDebug.LogFunction = Baseline.MessagingDebugLogFunction;
 
                 IMessageBus.GlobalDiagnosticsTargets = Baseline.GlobalDiagnosticsTargets;
+                IMessageBus.GlobalDiagnosticsStackTraces = Baseline.GlobalDiagnosticsStackTraces;
                 IMessageBus.GlobalMessageBufferSize = Baseline.GlobalMessageBufferSize;
                 IMessageBus.GlobalSequentialIndex = Baseline.GlobalSequentialIndex;
                 DxMessagingRuntimeSettingsProvider.ResetForTests();
@@ -79,6 +80,7 @@ namespace DxMessaging.Core
             bool messagingDebugEnabled = MessagingDebug.enabled;
             Action<LogLevel, string> messagingDebugLogFunction = MessagingDebug.LogFunction;
             DiagnosticsTarget globalDiagnosticsTargets = IMessageBus.GlobalDiagnosticsTargets;
+            bool globalDiagnosticsStackTraces = IMessageBus.GlobalDiagnosticsStackTraces;
             int globalMessageBufferSize = IMessageBus.GlobalMessageBufferSize;
             int globalSequentialIndex = IMessageBus.GlobalSequentialIndex;
             int syntheticOwnerCounter = MessageRegistrationBuilder.GetSyntheticOwnerCounter();
@@ -87,6 +89,7 @@ namespace DxMessaging.Core
                 messagingDebugEnabled,
                 messagingDebugLogFunction,
                 globalDiagnosticsTargets,
+                globalDiagnosticsStackTraces,
                 globalMessageBufferSize,
                 globalSequentialIndex,
                 syntheticOwnerCounter
@@ -99,6 +102,7 @@ namespace DxMessaging.Core
                 bool messagingDebugEnabled,
                 Action<LogLevel, string> messagingDebugLogFunction,
                 DiagnosticsTarget globalDiagnosticsTargets,
+                bool globalDiagnosticsStackTraces,
                 int globalMessageBufferSize,
                 int globalSequentialIndex,
                 int syntheticOwnerCounter
@@ -107,6 +111,7 @@ namespace DxMessaging.Core
                 MessagingDebugEnabled = messagingDebugEnabled;
                 MessagingDebugLogFunction = messagingDebugLogFunction;
                 GlobalDiagnosticsTargets = globalDiagnosticsTargets;
+                GlobalDiagnosticsStackTraces = globalDiagnosticsStackTraces;
                 GlobalMessageBufferSize = globalMessageBufferSize;
                 GlobalSequentialIndex = globalSequentialIndex;
                 SyntheticOwnerCounter = syntheticOwnerCounter;
@@ -117,6 +122,8 @@ namespace DxMessaging.Core
             internal Action<LogLevel, string> MessagingDebugLogFunction { get; }
 
             internal DiagnosticsTarget GlobalDiagnosticsTargets { get; }
+
+            internal bool GlobalDiagnosticsStackTraces { get; }
 
             internal int GlobalMessageBufferSize { get; }
 

--- a/Runtime/Core/MessageBus/IMessageBus.cs
+++ b/Runtime/Core/MessageBus/IMessageBus.cs
@@ -54,6 +54,20 @@ namespace DxMessaging.Core.MessageBus
         /// </summary>
         static DiagnosticsTarget GlobalDiagnosticsTargets { get; set; } = DiagnosticsTarget.Off;
 
+        /// <summary>
+        /// Whether diagnostic emission records capture the managed stack trace of the emission
+        /// site. Disabled by default: capturing a trace costs hundreds of microseconds and tens of
+        /// allocations PER RECORD, and a single-subscriber emission writes two records (one on the
+        /// bus, one per token delivery), so leaving it on turns every emission into the dominant
+        /// cost of a frame. Enable it only while investigating where a message came from; the
+        /// Message Monitor and Flow Graph emission-site links are the features that consume it.
+        /// </summary>
+        /// <remarks>
+        /// This is orthogonal to <see cref="GlobalDiagnosticsTargets"/>: capture happens only when
+        /// diagnostics are already recording for the current environment AND this is <c>true</c>.
+        /// </remarks>
+        static bool GlobalDiagnosticsStackTraces { get; set; }
+
         [Obsolete("Use GlobalDiagnosticsTargets instead.")]
         static bool GlobalDiagnosticsMode
         {

--- a/Tests/Editor/Allocations/DiagnosticsEmissionAllocationTests.cs
+++ b/Tests/Editor/Allocations/DiagnosticsEmissionAllocationTests.cs
@@ -1,0 +1,128 @@
+#if UNITY_2021_3_OR_NEWER
+namespace DxMessaging.Tests.Editor.Allocations
+{
+    using DxMessaging.Core;
+    using DxMessaging.Core.Extensions;
+    using DxMessaging.Core.MessageBus;
+    using DxMessaging.Core.Pooling;
+    using DxMessaging.Tests.Editor.Benchmarks;
+    using DxMessaging.Tests.Runtime;
+    using DxMessaging.Tests.Runtime.Benchmarks;
+    using DxMessaging.Tests.Runtime.Scripts.Messages;
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Pins the cost boundary of diagnostic emission-site capture (issue #433).
+    ///
+    /// <para>
+    /// Every diagnostic record used to capture and post-process a full managed stack trace in its
+    /// constructor, and a single-subscriber emission writes two records (bus plus token delivery).
+    /// Measured in Unity 6000.4.6f1 Editor PlayMode Mono, that cost about 236 microseconds and ~67
+    /// allocation calls PER RECORD, which dropped the
+    /// <c>Comparison_DxMessaging_GlobalToOne</c> row from tens of millions of emits per second to
+    /// about 1,100 -- roughly 305,000x slower than a plain C# event measured in the same session.
+    /// </para>
+    ///
+    /// <para>
+    /// The guard is DIFFERENTIAL rather than an absolute budget: absolute allocation counts in a
+    /// warm editor domain carry ambient noise, but the ratio between capture-on and capture-off is
+    /// dominated by the stack capture and is stable. If capture stops being opt-in, the two windows
+    /// converge and this fails.
+    /// </para>
+    /// </summary>
+    [Category("Allocation")]
+    public sealed class DiagnosticsEmissionAllocationTests : BenchmarkTestBase
+    {
+        private const int WarmupEmits = 256;
+        private const int MeasuredEmits = 64;
+        private const int MinAttempts = 8;
+
+        // Capture-off must remove at least this share of the capture-on allocation calls. Measured
+        // ~97% removed (about 134 calls per emit down to a handful of boxes and buffer writes); the
+        // threshold leaves a wide margin over backend noise while still failing outright if capture
+        // becomes unconditional again (ratio 1.0).
+        private const double MinimumRemovedShare = 0.75d;
+
+        protected override bool MessagingDebugEnabled => false;
+
+        [Test]
+        public void DisablingEmissionSiteCaptureRemovesMostDiagnosticAllocations()
+        {
+            long captureOn = MeasureEmitAllocations(captureStackTraces: true);
+            long captureOff = MeasureEmitAllocations(captureStackTraces: false);
+
+            if (captureOn == AllocationProbe.Unmeasured || captureOff == AllocationProbe.Unmeasured)
+            {
+                Assert.Ignore("GC.Alloc allocation probe is non-functional on this backend.");
+            }
+
+            Assert.That(
+                captureOn,
+                Is.GreaterThan(0L),
+                "Capture-on emissions must allocate; otherwise the comparison proves nothing."
+            );
+
+            double removedShare = 1d - ((double)captureOff / captureOn);
+            Assert.That(
+                removedShare,
+                Is.GreaterThanOrEqualTo(MinimumRemovedShare),
+                $"{MeasuredEmits} emissions allocated {captureOn} managed allocation calls with "
+                    + $"emission-site capture on and {captureOff} with it off ({removedShare:P1} "
+                    + "removed). Emission-site capture must stay opt-in: it captures and trims a "
+                    + "full managed stack trace per diagnostic record, and every emission writes at "
+                    + "least two records."
+            );
+        }
+
+        private static long MeasureEmitAllocations(bool captureStackTraces)
+        {
+            using DiagnosticsScope scope = new(
+                DiagnosticsTarget.All,
+                diagnosticsStackTraces: captureStackTraces
+            );
+
+            MessageBus bus = MessageBus.CreateForInternalUse(
+                StopwatchClock.Instance,
+                idleEvictionTicks: 0,
+                evictionTickIntervalSeconds: double.PositiveInfinity,
+                idleEvictionEnabled: false,
+                trimApiEnabled: true
+            );
+            bus.DiagnosticsMode = true;
+            MessageHandler handler = new(Owner, bus) { active = true };
+            MessageRegistrationToken token = MessageRegistrationToken.Create(handler, bus);
+            token.DiagnosticMode = true;
+            token.Enable();
+            _ = token.RegisterUntargeted<SimpleUntargetedMessage>(NoOp);
+
+            SimpleUntargetedMessage message = new();
+            for (int i = 0; i < WarmupEmits; ++i)
+            {
+                message.EmitUntargeted(bus);
+            }
+
+            long measured = AllocationProbe.MeasureMin(
+                MinAttempts,
+                prepare: null,
+                operation: () =>
+                {
+                    SimpleUntargetedMessage emitted = new();
+                    for (int i = 0; i < MeasuredEmits; ++i)
+                    {
+                        emitted.EmitUntargeted(bus);
+                    }
+                }
+            );
+
+            token.UnregisterAll();
+            token.Dispose();
+            handler.active = false;
+            return measured;
+        }
+
+        private static readonly InstanceId Owner = new InstanceId(0x4433_4433);
+
+        private static void NoOp(ref SimpleUntargetedMessage message) { }
+    }
+}
+#endif

--- a/Tests/Editor/Allocations/DiagnosticsEmissionAllocationTests.cs.meta
+++ b/Tests/Editor/Allocations/DiagnosticsEmissionAllocationTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 53b5dae76f9d4bd894adaa7ef9e87164
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests/Editor/DxMessagingBaseCallIgnoreSyncTests.cs
+++ b/Tests/Editor/DxMessagingBaseCallIgnoreSyncTests.cs
@@ -110,12 +110,14 @@ namespace DxMessaging.Tests.Editor
         private readonly List<DxMessagingSettings> _createdSettings = new();
         private readonly List<string> _warnings = new();
         private DiagnosticsTarget _previousDiagnosticsTargets;
+        private bool _previousDiagnosticsStackTraces;
         private int _previousMessageBufferSize;
 
         [SetUp]
         public void SetUp()
         {
             _previousDiagnosticsTargets = IMessageBus.GlobalDiagnosticsTargets;
+            _previousDiagnosticsStackTraces = IMessageBus.GlobalDiagnosticsStackTraces;
             _previousMessageBufferSize = IMessageBus.GlobalMessageBufferSize;
             _scheduled.Clear();
             _warnings.Clear();
@@ -124,6 +126,7 @@ namespace DxMessaging.Tests.Editor
             DxMessagingEditorInitializer.StaticStateResetter = () =>
             {
                 IMessageBus.GlobalDiagnosticsTargets = DiagnosticsTarget.Off;
+                IMessageBus.GlobalDiagnosticsStackTraces = false;
                 IMessageBus.GlobalMessageBufferSize = IMessageBus.DefaultMessageBufferSize;
             };
             DxMessagingEditorInitializer.AssetDatabaseMutationScheduler = work =>
@@ -151,6 +154,7 @@ namespace DxMessaging.Tests.Editor
             {
                 DxMessagingEditorInitializer.ResetTestSeams();
                 IMessageBus.GlobalDiagnosticsTargets = _previousDiagnosticsTargets;
+                IMessageBus.GlobalDiagnosticsStackTraces = _previousDiagnosticsStackTraces;
                 IMessageBus.GlobalMessageBufferSize = _previousMessageBufferSize;
             }
         }
@@ -161,12 +165,14 @@ namespace DxMessaging.Tests.Editor
             DxMessagingSettings settings = NewSettings();
             settings._diagnosticsTargets = DiagnosticsTarget.Off;
             settings._legacyEnableDiagnosticsInEditor = true;
+            settings._diagnosticsStackTraces = true;
             settings._messageBufferSize = 37;
             DxMessagingEditorInitializer.PassiveSettingsLoader = () => settings;
 
             DxMessagingEditorInitializer.ApplyEditorSettings();
 
             Assert.That(IMessageBus.GlobalDiagnosticsTargets, Is.EqualTo(DiagnosticsTarget.Editor));
+            Assert.That(IMessageBus.GlobalDiagnosticsStackTraces, Is.True);
             Assert.That(IMessageBus.GlobalMessageBufferSize, Is.EqualTo(37));
             Assert.That(
                 settings._legacyEnableDiagnosticsInEditor,
@@ -192,6 +198,7 @@ namespace DxMessaging.Tests.Editor
                 return NewSettings();
             };
             IMessageBus.GlobalDiagnosticsTargets = DiagnosticsTarget.All;
+            IMessageBus.GlobalDiagnosticsStackTraces = true;
             IMessageBus.GlobalMessageBufferSize = 3;
 
             DxMessagingEditorInitializer.ApplyEditorSettings();
@@ -203,6 +210,7 @@ namespace DxMessaging.Tests.Editor
             );
             Assert.That(_scheduled.Count, Is.EqualTo(1));
             Assert.That(IMessageBus.GlobalDiagnosticsTargets, Is.EqualTo(DiagnosticsTarget.Off));
+            Assert.That(IMessageBus.GlobalDiagnosticsStackTraces, Is.False);
             Assert.That(
                 IMessageBus.GlobalMessageBufferSize,
                 Is.EqualTo(IMessageBus.DefaultMessageBufferSize)

--- a/Tests/Editor/DxMessagingEmissionCaptureNoticeTests.cs
+++ b/Tests/Editor/DxMessagingEmissionCaptureNoticeTests.cs
@@ -144,10 +144,17 @@ namespace DxMessaging.Tests.Editor
             IMessageBus.GlobalDiagnosticsStackTraces = captureEnabled;
             VisualElement section = new();
 
+            // The list a node that HAS emitted actually carries while capture is off: one
+            // placeholder per emission, never an empty list. Passing Array.Empty here would have
+            // let the notice pass a test it could not pass in the window (Bugbot, PR #434).
             DxMessagingFlowGraphWindow.AddSourceDetailValues(
                 section,
                 "Emitted by",
-                Array.Empty<string>()
+                new[]
+                {
+                    DxMessagingEditorSourceLinks.UnknownCallSite,
+                    DxMessagingEditorSourceLinks.UnknownCallSite,
+                }
             );
 
             List<Label> labels = section.Query<Label>().ToList();
@@ -179,6 +186,45 @@ namespace DxMessaging.Tests.Editor
                 );
                 Assert.That(enable, Is.Not.Null, "The explanation must travel with the switch.");
             }
+        }
+
+        [Test]
+        public void FlowGraphKeepsRealCallSitesAndDropsPlaceholdersWithoutBlamingTheSetting()
+        {
+            IMessageBus.GlobalDiagnosticsStackTraces = false;
+            VisualElement section = new();
+
+            DxMessagingFlowGraphWindow.AddSourceDetailValues(
+                section,
+                "Emitted by",
+                new[]
+                {
+                    DxMessagingEditorSourceLinks.UnknownCallSite,
+                    "Sample:Emit () (at Assets/Sample.cs:12)",
+                }
+            );
+
+            List<Label> labels = section.Query<Label>().ToList();
+            Assert.That(
+                labels.Exists(label => label.text.Contains("Sample", StringComparison.Ordinal)),
+                Is.True,
+                "A real call site must survive alongside placeholders."
+            );
+            Assert.That(
+                labels.Exists(label =>
+                    label.text.Contains(
+                        DxMessagingEditorSourceLinks.UnknownCallSite,
+                        StringComparison.Ordinal
+                    )
+                ),
+                Is.False,
+                "A placeholder row says nothing; rendering it only buries the real site."
+            );
+            Assert.That(
+                section.Q<Button>(DxMessagingEmissionCaptureNotice.EnableButtonName),
+                Is.Null,
+                "Some sites WERE recorded, so the capture-off notice would be misleading here."
+            );
         }
 
         [Test]

--- a/Tests/Editor/DxMessagingEmissionCaptureNoticeTests.cs
+++ b/Tests/Editor/DxMessagingEmissionCaptureNoticeTests.cs
@@ -1,0 +1,247 @@
+#if UNITY_EDITOR && UNITY_2021_3_OR_NEWER
+namespace DxMessaging.Tests.Editor
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Core.MessageBus;
+    using DxMessaging.Editor;
+    using DxMessaging.Editor.Windows;
+    using NUnit.Framework;
+    using UnityEngine.UIElements;
+
+    /// <summary>
+    /// Emission-site capture is opt-in (issue #433), which means the Message Monitor stack pane and
+    /// the Flow Graph emission-site rows are empty for most users. An empty pane that does not say
+    /// WHY reads as a broken tool, so these tests pin the three things that keep it honest: the
+    /// empty state names the setting, it carries a one-click switch, and neither claim is made when
+    /// capture is already on.
+    /// </summary>
+    [TestFixture]
+    public sealed class DxMessagingEmissionCaptureNoticeTests
+    {
+        private bool _captureBeforeTest;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _captureBeforeTest = IMessageBus.GlobalDiagnosticsStackTraces;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            DxMessagingEmissionCaptureNotice.AssetDatabaseMutationScheduler = null;
+            IMessageBus.GlobalDiagnosticsStackTraces = _captureBeforeTest;
+        }
+
+        [Test]
+        public void MonitorStackPaneNamesTheSettingAndCarriesItsSwitchWhenCaptureIsOff()
+        {
+            IMessageBus.GlobalDiagnosticsStackTraces = false;
+
+            VisualElement section = DxMessagingMessageMonitorWindow.CreateStackTraceSection(
+                new MessageMonitorEntry("Sample.Message", "Context: Player", string.Empty),
+                DxMessagingMessageMonitorWindow.DetailsStackFoldoutName,
+                DxMessagingMessageMonitorWindow.DetailsStackFirstFrameLabelName
+            );
+
+            Foldout foldout = section as Foldout;
+            Assert.That(foldout, Is.Not.Null);
+            Assert.That(
+                foldout.text,
+                Does.Contain(DxMessagingEmissionCaptureNotice.DisabledSummary),
+                "The collapsed header must say the capture setting is off, not just that a trace "
+                    + "is absent."
+            );
+            Assert.That(
+                foldout.value,
+                Is.True,
+                "The capture-off state must start expanded; a collapsed disclosure is exactly how "
+                    + "the setting stays invisible."
+            );
+
+            Label explanation = foldout.Q<Label>(
+                DxMessagingMessageMonitorWindow.DetailsStackFirstFrameLabelName
+            );
+            Assert.That(explanation, Is.Not.Null);
+            Assert.That(
+                explanation.text,
+                Is.EqualTo(DxMessagingEmissionCaptureNotice.DisabledExplanation)
+            );
+
+            Button enable = foldout.Q<Button>(DxMessagingEmissionCaptureNotice.EnableButtonName);
+            Assert.That(enable, Is.Not.Null, "The explanation must travel with the switch.");
+            Assert.That(enable.text, Is.EqualTo(DxMessagingEmissionCaptureNotice.EnableButtonText));
+            Assert.That(
+                enable.tooltip,
+                Does.Contain(DxMessagingEmissionCaptureNotice.SettingsPathHint),
+                "The tooltip must say where the setting lives so it can be turned back off."
+            );
+        }
+
+        [Test]
+        public void MonitorStackPaneDoesNotBlameTheSettingWhenCaptureIsOn()
+        {
+            IMessageBus.GlobalDiagnosticsStackTraces = true;
+
+            VisualElement section = DxMessagingMessageMonitorWindow.CreateStackTraceSection(
+                new MessageMonitorEntry("Sample.Message", "Context: Player", string.Empty),
+                DxMessagingMessageMonitorWindow.DetailsStackFoldoutName,
+                DxMessagingMessageMonitorWindow.DetailsStackFirstFrameLabelName
+            );
+
+            Foldout foldout = section as Foldout;
+            Assert.That(foldout, Is.Not.Null);
+            Assert.That(
+                foldout.text,
+                Does.Not.Contain(DxMessagingEmissionCaptureNotice.DisabledSummary),
+                "With capture on, an empty trace is a record written before it was enabled, not "
+                    + "the setting."
+            );
+            Assert.That(foldout.value, Is.False, "Only the capture-off state opens by default.");
+            Assert.That(
+                foldout.Q<Button>(DxMessagingEmissionCaptureNotice.EnableButtonName),
+                Is.Null,
+                "Offering to enable a setting that is already on would be a false affordance."
+            );
+        }
+
+        [Test]
+        public void CapturedTraceWithOnlyEngineFramesIsNotBlamedOnTheSetting()
+        {
+            IMessageBus.GlobalDiagnosticsStackTraces = false;
+
+            VisualElement section = DxMessagingMessageMonitorWindow.CreateStackTraceSection(
+                new MessageMonitorEntry(
+                    "Sample.Message",
+                    "Context: Player",
+                    "UnityEngine.StackTraceUtility:ExtractStackTrace ()"
+                ),
+                DxMessagingMessageMonitorWindow.DetailsStackFoldoutName,
+                DxMessagingMessageMonitorWindow.DetailsStackFirstFrameLabelName
+            );
+
+            Foldout foldout = section as Foldout;
+            Assert.That(foldout, Is.Not.Null);
+            Assert.That(
+                foldout.text,
+                Does.Not.Contain(DxMessagingEmissionCaptureNotice.DisabledSummary),
+                "A trace that WAS captured but holds only engine frames is a different fact from "
+                    + "one the setting suppressed, even while the setting is off."
+            );
+            Assert.That(
+                foldout.Q<Button>(DxMessagingEmissionCaptureNotice.EnableButtonName),
+                Is.Null
+            );
+        }
+
+        [Test]
+        public void FlowGraphEmissionSiteRowsNameTheSettingWhenCaptureIsOff(
+            [Values(true, false)] bool captureEnabled
+        )
+        {
+            IMessageBus.GlobalDiagnosticsStackTraces = captureEnabled;
+            VisualElement section = new();
+
+            DxMessagingFlowGraphWindow.AddSourceDetailValues(
+                section,
+                "Emitted by",
+                Array.Empty<string>()
+            );
+
+            List<Label> labels = section.Query<Label>().ToList();
+            bool namesTheSetting = labels.Exists(label =>
+                label.text.Contains(
+                    DxMessagingEmissionCaptureNotice.DisabledSummary,
+                    StringComparison.Ordinal
+                )
+            );
+            Button enable = section.Q<Button>(DxMessagingEmissionCaptureNotice.EnableButtonName);
+
+            if (captureEnabled)
+            {
+                Assert.That(
+                    namesTheSetting,
+                    Is.False,
+                    "With capture on, no emission sites means none were observed, which is what "
+                        + "the plain wording already says."
+                );
+                Assert.That(enable, Is.Null);
+            }
+            else
+            {
+                Assert.That(
+                    namesTheSetting,
+                    Is.True,
+                    "\"none captured\" alone reads as \"we looked and found nothing\", which is "
+                        + "wrong when the setting suppressed the capture."
+                );
+                Assert.That(enable, Is.Not.Null, "The explanation must travel with the switch.");
+            }
+        }
+
+        [Test]
+        public void EnableCaptureTakesEffectImmediatelyAndPersistsToSettings()
+        {
+            IMessageBus.GlobalDiagnosticsStackTraces = false;
+            // The scheduled body is captured but deliberately NOT run: it calls
+            // DxMessagingSettings.GetOrCreateSettings(), which would create or rewrite the real
+            // project settings asset in whichever editor runs this suite. What is testable here
+            // without that side effect is the contract that matters -- immediate in-memory effect,
+            // deferred durable write.
+            List<Action> scheduled = new();
+            DxMessagingEmissionCaptureNotice.AssetDatabaseMutationScheduler = scheduled.Add;
+
+            DxMessagingEmissionCaptureNotice.EnableCapture();
+
+            Assert.That(
+                IMessageBus.GlobalDiagnosticsStackTraces,
+                Is.True,
+                "The in-memory flip must not wait on an editor-idle tick; the user clicked a "
+                    + "button and the next emission has to carry a site."
+            );
+            Assert.That(
+                scheduled.Count,
+                Is.EqualTo(1),
+                "The durable settings write must be deferred like every other settings mutation."
+            );
+        }
+
+        [Test]
+        public void CallSiteTooltipExplainsTheSettingOnlyWhenItIsTheReason(
+            [Values(true, false)] bool captureEnabled
+        )
+        {
+            IMessageBus.GlobalDiagnosticsStackTraces = captureEnabled;
+
+            string captured = DxMessagingEmissionCaptureNotice.DescribeCallSiteTooltip(
+                "Sample:Emit () (at Assets/Sample.cs:12)"
+            );
+            string missing = DxMessagingEmissionCaptureNotice.DescribeCallSiteTooltip(string.Empty);
+
+            Assert.That(
+                captured,
+                Is.EqualTo("Sample:Emit () (at Assets/Sample.cs:12)"),
+                "A real call site is always shown verbatim."
+            );
+            if (captureEnabled)
+            {
+                Assert.That(
+                    missing,
+                    Is.Empty,
+                    "With capture on, a missing site is not the setting's doing, so the tooltip "
+                        + "must not assert that it is."
+                );
+            }
+            else
+            {
+                Assert.That(
+                    missing,
+                    Does.Contain(DxMessagingEmissionCaptureNotice.SettingsPathHint)
+                );
+            }
+        }
+    }
+}
+#endif

--- a/Tests/Editor/DxMessagingEmissionCaptureNoticeTests.cs.meta
+++ b/Tests/Editor/DxMessagingEmissionCaptureNoticeTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b34b0d4eea62457a8b4640d4423e1e55
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests/Editor/DxMessagingFlowGraphWindowTests.cs
+++ b/Tests/Editor/DxMessagingFlowGraphWindowTests.cs
@@ -105,15 +105,23 @@ namespace DxMessaging.Tests.Editor
         private const string TraceIdLaneDetailsLabelName =
             "dxmessaging-flow-graph-trace-id-lane-details";
 
+        private bool _stackTracesBeforeTest;
+
         [SetUp]
         public void SetUp()
         {
             _selectionBeforeTest = Selection.activeObject;
+            // Emission-site capture is opt-in (issue #433) because it costs a full managed stack
+            // walk per diagnostic record. This fixture asserts on the emission sites the Flow Graph
+            // renders, so it turns capture on for its own duration.
+            _stackTracesBeforeTest = IMessageBus.GlobalDiagnosticsStackTraces;
+            IMessageBus.GlobalDiagnosticsStackTraces = true;
         }
 
         [TearDown]
         public void TearDown()
         {
+            IMessageBus.GlobalDiagnosticsStackTraces = _stackTracesBeforeTest;
             // The viewport-selection test keeps a shown host window open until teardown.
             // Unity resets LogAssert tolerance between the test body and teardown, so
             // re-enable the shared headless-only suppression before closing that window.

--- a/Tests/Editor/DxMessagingSettingsProviderTests.cs
+++ b/Tests/Editor/DxMessagingSettingsProviderTests.cs
@@ -111,12 +111,12 @@ namespace DxMessaging.Tests.Editor
 
             DxMessagingSettingsProvider.ApplySettingsToggleValue(
                 serializedSettings,
-                nameof(DxMessagingSettings._baseCallCheckEnabled),
+                (target, value) => target.BaseCallCheckEnabled = value,
                 false
             );
             DxMessagingSettingsProvider.ApplySettingsToggleValue(
                 serializedSettings,
-                nameof(DxMessagingSettings._useConsoleBridge),
+                (target, value) => target.UseConsoleBridge = value,
                 true
             );
 

--- a/Tests/Editor/DxMessagingSettingsProviderTests.cs
+++ b/Tests/Editor/DxMessagingSettingsProviderTests.cs
@@ -54,6 +54,7 @@ namespace DxMessaging.Tests.Editor
             );
             Assert.That(sections.TrueForAll(HasCompleteBorder), Is.True);
             AssertBoundField(root, nameof(DxMessagingSettings._diagnosticsTargets));
+            AssertBoundField(root, nameof(DxMessagingSettings._diagnosticsStackTraces));
             AssertBoundField(root, nameof(DxMessagingSettings._messageBufferSize));
             AssertBoundField(root, nameof(DxMessagingSettings._suppressDomainReloadWarning));
             AssertToggle(root, nameof(DxMessagingSettings._baseCallCheckEnabled), true);
@@ -70,11 +71,22 @@ namespace DxMessaging.Tests.Editor
             root.Add(new Label("Stale child"));
 
             DxMessagingSettingsProvider.BuildSettingsUi(root, serializedSettings);
+            int fieldsAfterFirstBuild = root.Query<PropertyField>().ToList().Count;
             DxMessagingSettingsProvider.BuildSettingsUi(root, serializedSettings);
 
             List<PropertyField> fields = root.Query<PropertyField>().ToList();
             List<Label> labels = root.Query<Label>().ToList();
-            Assert.That(fields.Count, Is.EqualTo(4));
+            Assert.That(
+                fieldsAfterFirstBuild,
+                Is.GreaterThan(0),
+                "The settings UI must bind at least one field, otherwise the rebuild comparison "
+                    + "below passes vacuously."
+            );
+            Assert.That(
+                fields.Count,
+                Is.EqualTo(fieldsAfterFirstBuild),
+                "Rebuilding must replace the previous fields rather than append a second copy."
+            );
             Assert.That(labels.Exists(label => label.text == "Stale child"), Is.False);
         }
 

--- a/Tests/Runtime/Core/DiagnosticsTests.cs
+++ b/Tests/Runtime/Core/DiagnosticsTests.cs
@@ -191,6 +191,83 @@ namespace DxMessaging.Tests.Runtime.Core
             }
         }
 
+        [Test]
+        public void EmissionSiteCaptureIsOptInOnBothBusAndTokenRecords(
+            [Values(true, false)] bool captureStackTraces
+        )
+        {
+            using (
+                new DiagnosticsScope(
+                    DiagnosticsTarget.All,
+                    diagnosticsStackTraces: captureStackTraces
+                )
+            )
+            {
+                GameObject host = new(nameof(EmissionSiteCaptureIsOptInOnBothBusAndTokenRecords));
+                _spawned.Add(host);
+                MessageHandler handler = new(host) { active = true };
+                MessageBus customBus = new() { DiagnosticsMode = true };
+
+                MessageRegistrationToken token = MessageRegistrationToken.Create(
+                    handler,
+                    customBus
+                );
+                token.DiagnosticMode = true;
+                token.Enable();
+
+                int count = 0;
+                MessageRegistrationHandle handle =
+                    token.RegisterUntargeted<SimpleUntargetedMessage>(_ => ++count);
+
+                SimpleUntargetedMessage message = new();
+                message.EmitUntargeted(customBus);
+                Assert.AreEqual(1, count);
+
+                CyclicBuffer<MessageEmissionData> busBuffer = GetEmissionBuffer(customBus);
+                CyclicBuffer<MessageEmissionData> tokenBuffer = GetEmissionBuffer(token);
+                Assert.AreEqual(
+                    1,
+                    busBuffer.Count,
+                    "The bus must record the emission whether or not the site is captured."
+                );
+                Assert.AreEqual(
+                    1,
+                    tokenBuffer.Count,
+                    "The token must record the delivery whether or not the site is captured."
+                );
+
+                foreach (
+                    (string source, CyclicBuffer<MessageEmissionData> buffer) in new[]
+                    {
+                        ("bus", busBuffer),
+                        ("token", tokenBuffer),
+                    }
+                )
+                {
+                    string capturedTrace = buffer[0].stackTrace;
+                    if (captureStackTraces)
+                    {
+                        Assert.IsFalse(
+                            string.IsNullOrWhiteSpace(capturedTrace),
+                            $"The {source} record must carry an emission site when capture is enabled."
+                        );
+                    }
+                    else
+                    {
+                        Assert.AreEqual(
+                            string.Empty,
+                            capturedTrace,
+                            $"The {source} record must not pay for an emission site when capture is disabled."
+                        );
+                    }
+                }
+
+                token.RemoveRegistration(handle);
+                token.Disable();
+                handler.active = false;
+            }
+        }
+
         private static Dictionary<MessageRegistrationHandle, int> GetCallCounts(
             MessageRegistrationToken token
         )

--- a/Tests/Runtime/Core/DxMessagingStaticStateTests.cs
+++ b/Tests/Runtime/Core/DxMessagingStaticStateTests.cs
@@ -25,6 +25,7 @@ namespace DxMessaging.Tests.Runtime.Core
             MessagingDebug.LogFunction = (logLevel, message) => { };
 
             IMessageBus.GlobalDiagnosticsTargets = DiagnosticsTarget.All;
+            IMessageBus.GlobalDiagnosticsStackTraces = true;
             IMessageBus.GlobalMessageBufferSize = 128;
             IMessageBus.GlobalSequentialIndex = 7;
 
@@ -43,6 +44,7 @@ namespace DxMessaging.Tests.Runtime.Core
             Assert.IsFalse(MessagingDebug.enabled);
             Assert.IsNull(MessagingDebug.LogFunction);
             Assert.AreEqual(DiagnosticsTarget.Off, IMessageBus.GlobalDiagnosticsTargets);
+            Assert.IsFalse(IMessageBus.GlobalDiagnosticsStackTraces);
             Assert.AreEqual(100, IMessageBus.GlobalMessageBufferSize);
             Assert.AreEqual(-1, IMessageBus.GlobalSequentialIndex);
 

--- a/Tests/Runtime/Core/MessageEmissionDataTests.cs
+++ b/Tests/Runtime/Core/MessageEmissionDataTests.cs
@@ -10,13 +10,15 @@ namespace DxMessaging.Tests.Runtime.Core
     public sealed class MessageEmissionDataTests
     {
         [Test]
-        public void StackTraceOmitsDxMessagingFrames()
+        public void StackTraceOmitsDxMessagingFramesWhenCaptureEnabled()
         {
+            using DiagnosticsScope scope = new(diagnosticsStackTraces: true);
+
             MessageEmissionData data = CaptureMessageEmission();
 
             Assert.IsFalse(
                 string.IsNullOrWhiteSpace(data.stackTrace),
-                "Stack trace should capture emission site."
+                "Stack trace should capture emission site when capture is enabled."
             );
 
             string[] lines = data.stackTrace.Split(
@@ -36,7 +38,10 @@ namespace DxMessaging.Tests.Runtime.Core
             }
 
             bool containsTestMethod = lines.Any(line =>
-                line.Contains(nameof(StackTraceOmitsDxMessagingFrames), StringComparison.Ordinal)
+                line.Contains(
+                    nameof(StackTraceOmitsDxMessagingFramesWhenCaptureEnabled),
+                    StringComparison.Ordinal
+                )
             );
             if (!containsTestMethod)
             {
@@ -44,12 +49,34 @@ namespace DxMessaging.Tests.Runtime.Core
                     $"Stack trace should include calling test method for debugging context.{Environment.NewLine}{data.stackTrace}"
                 );
             }
+
+            bool containsBlankLine = lines.Any(string.IsNullOrWhiteSpace);
+            Assert.IsFalse(containsBlankLine, "Trimmed stack trace should not retain blank lines.");
         }
 
         [Test]
-        public void ContextIsCapturedWhenProvided()
+        public void StackTraceIsEmptyWhenCaptureDisabled()
         {
+            using DiagnosticsScope scope = new(diagnosticsStackTraces: false);
+
+            MessageEmissionData data = CaptureMessageEmission();
+
+            Assert.AreEqual(
+                string.Empty,
+                data.stackTrace,
+                "Emission-site capture must stay off unless explicitly enabled; it costs hundreds "
+                    + "of microseconds and tens of allocations per record."
+            );
+        }
+
+        [Test]
+        public void RecordedPayloadIsPreservedRegardlessOfCapture(
+            [Values(true, false)] bool captureStackTraces
+        )
+        {
+            using DiagnosticsScope scope = new(diagnosticsStackTraces: captureStackTraces);
             InstanceId expectedContext = new(12345);
+
             MessageEmissionData data = new(new TestUntargetedMessage(), expectedContext);
 
             Assert.That(
@@ -58,6 +85,7 @@ namespace DxMessaging.Tests.Runtime.Core
                 "Context should be captured when supplied."
             );
             Assert.That(data.context.Value, Is.EqualTo(expectedContext));
+            Assert.That(data.message, Is.TypeOf<TestUntargetedMessage>());
         }
 
         private static MessageEmissionData CaptureMessageEmission()

--- a/Tests/Runtime/TestUtilities/DiagnosticsScope.cs
+++ b/Tests/Runtime/TestUtilities/DiagnosticsScope.cs
@@ -6,8 +6,9 @@ namespace DxMessaging.Tests.Runtime
 
     /// <summary>
     /// Save-restore guard for the global diagnostics statics
-    /// (<see cref="IMessageBus.GlobalDiagnosticsTargets"/> and
-    /// <see cref="IMessageBus.GlobalMessageBufferSize"/>). Captures both values on
+    /// (<see cref="IMessageBus.GlobalDiagnosticsTargets"/>,
+    /// <see cref="IMessageBus.GlobalDiagnosticsStackTraces"/>, and
+    /// <see cref="IMessageBus.GlobalMessageBufferSize"/>). Captures every value on
     /// construction, optionally applies overrides, and restores the captured values on
     /// <see cref="Dispose"/>. Replaces the hand-rolled try/finally and SetUp/TearDown
     /// save-restore blocks that were duplicated across diagnostics-sensitive fixtures.
@@ -15,6 +16,7 @@ namespace DxMessaging.Tests.Runtime
     public sealed class DiagnosticsScope : IDisposable
     {
         private readonly DiagnosticsTarget _savedDiagnosticsTargets;
+        private readonly bool _savedDiagnosticsStackTraces;
         private readonly int _savedMessageBufferSize;
         private bool _disposed;
 
@@ -24,14 +26,21 @@ namespace DxMessaging.Tests.Runtime
         /// </summary>
         public DiagnosticsScope(
             DiagnosticsTarget? diagnosticsTargets = null,
-            int? messageBufferSize = null
+            int? messageBufferSize = null,
+            bool? diagnosticsStackTraces = null
         )
         {
             _savedDiagnosticsTargets = IMessageBus.GlobalDiagnosticsTargets;
+            _savedDiagnosticsStackTraces = IMessageBus.GlobalDiagnosticsStackTraces;
             _savedMessageBufferSize = IMessageBus.GlobalMessageBufferSize;
             if (diagnosticsTargets.HasValue)
             {
                 IMessageBus.GlobalDiagnosticsTargets = diagnosticsTargets.Value;
+            }
+
+            if (diagnosticsStackTraces.HasValue)
+            {
+                IMessageBus.GlobalDiagnosticsStackTraces = diagnosticsStackTraces.Value;
             }
 
             if (messageBufferSize.HasValue)
@@ -52,6 +61,7 @@ namespace DxMessaging.Tests.Runtime
 
             _disposed = true;
             IMessageBus.GlobalDiagnosticsTargets = _savedDiagnosticsTargets;
+            IMessageBus.GlobalDiagnosticsStackTraces = _savedDiagnosticsStackTraces;
             IMessageBus.GlobalMessageBufferSize = _savedMessageBufferSize;
         }
     }

--- a/docs/guides/diagnostics.md
+++ b/docs/guides/diagnostics.md
@@ -42,6 +42,7 @@ DxMessaging provides multiple levels of diagnostics control:
 
 - `IMessageBus.GlobalDiagnosticsTargets` -- Sets the default diagnostics mode for newly created buses and tokens. Uses the `DiagnosticsTarget` flags enum.
 - `IMessageBus.GlobalMessageBufferSize` -- Sets the default ring buffer size for emission history (default: 100).
+- `IMessageBus.GlobalDiagnosticsStackTraces` -- Records the call site of every emission. Off by default; see [Emission-Site Capture](#emission-site-capture) before turning it on.
 
 ### Per-Bus and Per-Token
 
@@ -473,6 +474,7 @@ The `RegistrationMethod` enum captures how the handler was wired up:
 When diagnostics are enabled, buses and tokens record message emissions in a ring buffer:
 
 - Buffer size is controlled by `IMessageBus.GlobalMessageBufferSize` (default: 100).
+- Emission-site stack traces are captured only when `IMessageBus.GlobalDiagnosticsStackTraces` is on; see [Emission-Site Capture](#emission-site-capture).
 - Setting buffer size to 0 disables history retention (emissions are silently discarded).
 - Inspect recent emissions per token via built-in diagnostics or build custom tools using post-processors.
 - Bus-side `MessageBus` records carry a non-zero `traceId` while dispatching.
@@ -513,7 +515,7 @@ using DxMessaging.Core.MessageBus;
 IMessageBus.GlobalDiagnosticsTargets = DiagnosticsTarget.Editor;
 ```
 
-This is the recommended default for most projects. You get full visibility during development without any performance cost in production builds.
+This is the recommended default for most projects. You get full visibility during development without any performance cost in production builds. Leave emission-site capture off unless you are actively tracing a call site; see [Emission-Site Capture](#emission-site-capture).
 
 ### Runtime Diagnostics for QA Builds
 
@@ -569,6 +571,36 @@ Diagnostics add overhead. Consider these factors when enabling them:
 - Registration logging adds overhead to every `Register` and `Deregister` call.
 - Emission recording adds overhead to every message broadcast.
 - Post-processor chains for diagnostics run after each message dispatch.
+
+### Emission-Site Capture
+
+`MessageEmissionData.stackTrace` holds the call site an emission came from, and it is what the
+Message Monitor and Flow Graph **Open** buttons resolve into source links. Capturing it means
+walking and formatting the managed stack on every diagnostic record, which is expensive enough to
+dominate a frame:
+
+| Measurement (Unity 6000.4.6f1, Editor PlayMode Mono x64 Release) | Value                |
+| ---------------------------------------------------------------- | -------------------- |
+| Cost of one captured record                                      | ~236 microseconds    |
+| Allocation calls per captured record                             | ~67                  |
+| Records written per single-subscriber emission                   | 2 (bus plus token)   |
+| `Comparison_DxMessaging_GlobalToOne` with capture on             | ~1,100 emissions/sec |
+| Same row with a plain C# event, same session                     | ~340,000,000/sec     |
+
+Capture cost scales with stack depth, so deeper gameplay call stacks pay more. Because of that,
+capture is off by default:
+
+```csharp
+using DxMessaging.Core.MessageBus;
+
+// Only while tracing where a message came from.
+IMessageBus.GlobalDiagnosticsStackTraces = true;
+```
+
+In the editor, the same switch is **Project Settings > Wallstop Studios > DxMessaging > Capture
+Emission Stack Traces**. With it off, every other part of diagnostics still works: emission history,
+call counts, trace ids, registration logs, the Message Monitor log, and the Flow Graph. Only the
+per-row stack trace and its source links are empty.
 
 ### Recommendations
 

--- a/docs/guides/diagnostics.md
+++ b/docs/guides/diagnostics.md
@@ -107,7 +107,8 @@ type and the context. Snapshot ends the row with the dispatch id; live ends it
 with the time the row was observed and the `N` count of emissions merged into it.
 Selecting a row fills the detail pane below the log; the stack trace lives there
 behind a disclosure that starts closed, so a long call stack never buries the log
-itself.
+itself. When emission-site capture is off the disclosure starts open instead, says
+so, and offers the switch -- see [Emission-Site Capture](#emission-site-capture).
 
 The detail pane links out to what a row stands for:
 
@@ -588,7 +589,16 @@ dominate a frame:
 | Same row with a plain C# event, same session                     | ~340,000,000/sec     |
 
 Capture cost scales with stack depth, so deeper gameplay call stacks pay more. Because of that,
-capture is off by default:
+capture is off by default.
+
+The editor tells you when that is why a call site is missing, and offers the switch on the spot:
+the Message Monitor's **Stack trace** disclosure reads `Stack trace (capture off)`, opens itself,
+explains the trade-off, and carries an **Enable stack traces** button; the Flow Graph's emission-site
+rows read `none captured (capture off)` and carry the same button. Clicking it takes effect for the
+next emission and is saved to the project settings asset. Rows already recorded stay empty, because
+their call site was never captured.
+
+You can also set it from code or from the settings page:
 
 ```csharp
 using DxMessaging.Core.MessageBus;
@@ -598,9 +608,9 @@ IMessageBus.GlobalDiagnosticsStackTraces = true;
 ```
 
 In the editor, the same switch is **Project Settings > Wallstop Studios > DxMessaging > Capture
-Emission Stack Traces**. With it off, every other part of diagnostics still works: emission history,
-call counts, trace ids, registration logs, the Message Monitor log, and the Flow Graph. Only the
-per-row stack trace and its source links are empty.
+Emission Stack Traces**, which is also where you turn it back off. With it off, every other part of
+diagnostics still works: emission history, call counts, trace ids, registration logs, the Message
+Monitor log, and the Flow Graph. Only the per-row stack trace and its source links are empty.
 
 ### Recommendations
 


### PR DESCRIPTION
Closes #433.

## What this is

I went after #414 (MessagePipe parity) and could not get a trustworthy local dispatch bracket,
because the control read **1,113 emits/sec**. That turned out to be a real defect, not measurement
noise, and it is worth more than the parity work it was blocking.

Every diagnostic emission record captured and post-processed a full managed stack trace in its
constructor, and a single-subscriber emission writes **two** records (one on the bus, one per token
delivery). So enabling diagnostics -- the setting `docs/guides/diagnostics.md` called "the
recommended default for most projects" -- cost about 236 microseconds and ~67 allocation calls per
record.

## Evidence

Same editor session, same harness, Unity 6000.4.6f1, Editor PlayMode Mono x64 Release:

| Row                                  | emits/sec   | alloc calls per emit |
| ------------------------------------ | ----------- | -------------------- |
| `Comparison_CsEvent_GlobalToOne`     | 339,939,504 | 0                    |
| `Comparison_UnityEvent_GlobalToOne`  | 103,680,567 | 0                    |
| `Comparison_DxMessaging_GlobalToOne` | 1,113       | ~134                 |

Reproduced across three runs (1,113.1 / 1,173.5 / 1,179.6 emits/sec), so it is deterministic. A raw
delegate loop in the same editor ran at 508M invocations/sec and the profiler was off with editor
code optimization on Release, so neither the machine nor the harness explained it. Constructing
records in isolation pinned it: one `MessageEmissionData` costs 236 microseconds and ~67 allocation
calls, and two per emission reproduces the observed ~134 exactly.

The published Standalone IL2CPP numbers never showed this because CI measures with diagnostics off.

## The change

- `IMessageBus.GlobalDiagnosticsStackTraces` (default off) plus a **Capture Emission Stack Traces**
  project setting gate the capture. Applied by `DxMessagingEditorInitializer`, restored by
  `DxMessagingStaticState.Reset`.
- The opted-in path got cheaper too: the `Split` + LINQ `Where`/`ToArray` + `string.Join` trim
  became one `StringBuilder` pass. Identical output (blank lines and DxMessaging internal frames
  dropped, joined with `Environment.NewLine`), without allocating a line array, an iterator, a
  filtered array, and a join buffer on top of the trace.
- Everything else diagnostics records is unchanged: emission history, call counts, trace ids,
  registration logs, Message Monitor rows, Flow Graph nodes and edges. Only the per-row stack trace
  and its source links wait for the opt-in.

The diagnostics-off path -- the shipped default and the published CI scope -- is untouched. No
record is constructed there, so the new gate is never read.

## Result

Same editor, same project settings (`DiagnosticsTarget.Editor`), only the code changed:

| Measurement                          | Before (3 runs) | After (2 runs) | Factor  |
| ------------------------------------ | --------------- | -------------- | ------- |
| `Comparison_DxMessaging_GlobalToOne` | 1,155/s mean    | 4,412,794/s    | 3,819x  |
| `Comparison_DxMessaging_StructNoBox` | 1,170/s mean    | 4,570,779/s    | 3,908x  |
| Alloc calls per 10,000 emits         | ~1,342,500      | 20,000 (exact) | 67x     |
| Bytes per emission                   | ~143 KB         | 34 B           | ~4,200x |

The two remaining allocation calls per emission are the message boxed into `IMessage` once for the
bus record and once for the token record, inherent to the record shape while diagnostics is on.

## Behavior change worth calling out

`MessageEmissionData.stackTrace` is now `string.Empty` unless capture is enabled, so Message Monitor
and Flow Graph emission-site **Open** links stay empty until a user opts in. That is in the changelog
as a breaking diagnostics-output change, with the switch documented in both the guide and the project
settings page. The alternative was leaving a documented, recommended setting that makes the editor
unusable at normal message volume.

## Coverage

- `MessageEmissionDataTests`: capture-on trace omits internal frames, includes the calling test
  method, and retains no blank lines; capture-off trace is empty; payload and context survive both
  (parameterized).
- `DiagnosticsTests.EmissionSiteCaptureIsOptInOnBothBusAndTokenRecords`: parameterized over capture
  on/off, proves BOTH the bus record and the token delivery record follow the gate while the
  emission is still recorded either way.
- `DiagnosticsEmissionAllocationTests`: differential guard -- disabling capture must remove at least
  75% of the capture-on allocation calls (measured ~97%). An unconditional capture drives the ratio
  to 1.0 and fails it. Differential rather than an absolute budget because warm editor domains carry
  ambient allocation noise.
- `DxMessagingStaticStateTests`, `DxMessagingBaseCallIgnoreSyncTests`, `DxMessagingSettingsProviderTests`:
  baseline/reset, initializer application, and settings binding for the new field.
- `DxMessagingFlowGraphWindowTests` opts into capture for its own duration, since it asserts on the
  emission sites the Flow Graph renders.

One drive-by: that settings-provider fixture asserted a hardcoded `Is.EqualTo(4)` PropertyField
count, which breaks whenever the settings page gains a field. Replaced with the rebuild-idempotence
assertion the test was actually about (field count after a second build equals the count after the
first, and no stale child survives).

## Verification

Local Unity (host editor, Unity 6000.4.6f1, macOS):

- Full EditMode (`Tests.Editor` + `Tests.Editor.Allocations`): 1,052 pass, 0 fail, 1 skip,
  8 inconclusive.
- Full PlayMode (`Tests.Runtime`): 1,131 pass, 0 fail, 1 skip.
- Editor windows (Flow Graph, Monitor, live view, recorder): 349 pass, 0 fail.

Local repository: `npm test` 441 pass; `npm run validate:all` pass; `format:check`, `lint:markdown`,
`check:spelling` pass; `.docs-tests` 593 pass; `pre-commit` all hooks pass.

## Not in this PR

#414 stays open. The Standalone IL2CPP dispatch gap is unchanged here. The next bounded mechanism is
scoped in `PLAN.md`: the steady-state emit walks roughly eight dependent loads where MessagePipe
walks about three, so caching the resolved entry array and count on the version-stamped
`DispatchPlan` is the candidate, gated on `plan.version == _dispatchPlanVersion` (every mutation path
already calls `InvalidateDispatchPlans` before staging a rebuild). It was not attempted here because
local dispatch brackets were not trustworthy until this defect was fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes a hot diagnostics path and a global static that now leaves `MessageEmissionData.stackTrace` empty by default (breaking for tools that assumed traces). Emission history and dispatch without diagnostics stay the same.
> 
> **Overview**
> **BREAKING (diagnostics output):** emission records no longer capture a call-site stack unless you opt in via `IMessageBus.GlobalDiagnosticsStackTraces` or **Project Settings > Capture Emission Stack Traces**. Capture used to cost ~236 µs and ~67 allocations *per record* (two records per emission), collapsing editor dispatch to ~1,100 emits/sec.
> 
> `MessageEmissionData` now stores `string.Empty` when capture is off. The opted-in trim path is a single `StringBuilder` pass instead of split/LINQ/join. The setting is applied by the editor initializer and restored by `DxMessagingStaticState.Reset`.
> 
> Message Monitor, Flow Graph, and the component inspector explain missing sites as **capture off** and offer **Enable stack traces** (immediate in-memory, deferred settings persist). Other diagnostics (history, counts, trace ids, graphs) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb24023f6198c07e2387c7d02ffab8cbc7bc1d89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->