### PR TITLE
perf: cache settled untargeted dispatch routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Improve untargeted dispatch throughput when no interceptors, global handlers, or post-processors
+  are registered ([#414](https://github.com/Ambiguous-Interactive/DxMessaging/issues/414)).
 - Show a pause announcement coordinating independent UI and audio systems and a source-bound
   collision driving independent sound and breakable-object reactions on the homepage
   ([#426](https://github.com/Ambiguous-Interactive/DxMessaging/issues/426)).

--- a/Runtime/Core/MessageBus/MessageBus.cs
+++ b/Runtime/Core/MessageBus/MessageBus.cs
@@ -150,8 +150,8 @@ namespace DxMessaging.Core.MessageBus
             ),
             new SweepableTypeCache(
                 nameof(_untargetedDispatchPlans),
-                typeof(MessageCache<DispatchPlan>),
-                static (bus, force) => bus.SweepStaleDispatchPlans(bus._untargetedDispatchPlans)
+                typeof(MessageCache<UntargetedDispatchPlan>),
+                static (bus, force) => bus.SweepStaleUntargetedDispatchPlans()
             ),
             new SweepableTypeCache(
                 nameof(_targetedDispatchPlans),
@@ -527,7 +527,7 @@ namespace DxMessaging.Core.MessageBus
         /// <see cref="MessagingDebug.enabled"/> are deliberately NOT cached
         /// here - both are live-settable and read per emission.
         /// </summary>
-        private sealed class DispatchPlan
+        private class DispatchPlan
         {
             public long version = long.MinValue;
             public bool fastPath;
@@ -564,6 +564,26 @@ namespace DxMessaging.Core.MessageBus
                 contextHandle = null;
                 contextPost = null;
                 interceptorCache = null;
+            }
+        }
+
+        /// <summary>
+        /// Untargeted plan extension that borrows the resolved entry array from
+        /// the active handle snapshot after its first post-refresh acquisition.
+        /// The snapshot remains the array owner; this plan only removes the
+        /// steady-state state/snapshot/holder pointer chase. Targeted and
+        /// broadcast plans stay at the smaller common shape because their
+        /// context-keyed routes cannot share one entry array per message type.
+        /// </summary>
+        private sealed class UntargetedDispatchPlan : DispatchPlan
+        {
+            public object handleEntries;
+            public int handleEntryCount;
+
+            public void ClearCachedRoute()
+            {
+                handleEntries = null;
+                handleEntryCount = 0;
             }
         }
 
@@ -1140,7 +1160,7 @@ namespace DxMessaging.Core.MessageBus
         // single bus-wide version stamp (see DispatchPlan /
         // InvalidateDispatchPlans). Registered in SweepableTypeCacheRegistry
         // so sweeps drop their cached sink references.
-        private readonly MessageCache<DispatchPlan> _untargetedDispatchPlans = new();
+        private readonly MessageCache<UntargetedDispatchPlan> _untargetedDispatchPlans = new();
         private readonly MessageCache<DispatchPlan> _targetedDispatchPlans = new();
         private readonly MessageCache<DispatchPlan> _broadcastDispatchPlans = new();
 
@@ -2096,6 +2116,25 @@ namespace DxMessaging.Core.MessageBus
                 if (plan.version != _dispatchPlanVersion)
                 {
                     plan.ClearCachedSinks();
+                }
+            }
+
+            return 0;
+        }
+
+        /// <summary>
+        /// Untargeted plan sweep companion that also drops the borrowed flat
+        /// entry arrays. A sweep invalidates plans before this row runs, so no
+        /// stale route remains reachable after its owning snapshot is evicted.
+        /// </summary>
+        private int SweepStaleUntargetedDispatchPlans()
+        {
+            foreach (UntargetedDispatchPlan plan in _untargetedDispatchPlans)
+            {
+                if (plan.version != _dispatchPlanVersion)
+                {
+                    plan.ClearCachedSinks();
+                    plan.ClearCachedRoute();
                 }
             }
 
@@ -3906,7 +3945,7 @@ namespace DxMessaging.Core.MessageBus
             // afterwards guarantees the plan's cached references are live
             // until the first user code of this emission runs.
             TrySweepIdle();
-            if (!_untargetedDispatchPlans.TryGetValue<TMessage>(out DispatchPlan plan))
+            if (!_untargetedDispatchPlans.TryGetValue<TMessage>(out UntargetedDispatchPlan plan))
             {
                 plan = _untargetedDispatchPlans.GetOrAdd<TMessage>();
                 // Root the IL2CPP AOT untyped-dispatch bridge for TMessage on the
@@ -3953,14 +3992,53 @@ namespace DxMessaging.Core.MessageBus
                 HandlerCache<int, HandlerCache> fastHandlers = plan.scalarHandle;
                 if (fastHandlers != null && 0 < fastHandlers.handlers.Count)
                 {
-                    DispatchSnapshot fastSnapshot = AcquireDispatchSnapshotFast<TMessage>(
-                        this,
-                        fastHandlers,
-                        UntargetedHandleSlot,
-                        emissionId,
-                        default
-                    );
-                    fastFound = DispatchFlatSnapshot(fastSnapshot, ref typedMessage);
+                    object handleEntries = plan.handleEntries;
+                    int handleEntryCount = plan.handleEntryCount;
+                    if (handleEntries == null)
+                    {
+                        DispatchSnapshot fastSnapshot = AcquireDispatchSnapshotFast<TMessage>(
+                            this,
+                            fastHandlers,
+                            UntargetedHandleSlot,
+                            emissionId,
+                            default
+                        );
+                        FlatDispatchArray flatBase = fastSnapshot.flat;
+                        if (flatBase != null)
+                        {
+                            DebugAssertFlatShape<FlatDispatch<TMessage>>(flatBase);
+                            FlatDispatch<TMessage> flat = DxUnsafe.As<FlatDispatch<TMessage>>(
+                                flatBase
+                            );
+                            handleEntries = flat.entries;
+                            handleEntryCount = flat.count;
+
+                            // Publish the settled route BEFORE user code runs. A handler can
+                            // mutate registrations and re-emit this type; publishing after the
+                            // callback would let the outer emission overwrite the nested
+                            // emission's fresh route with a displaced array under a current
+                            // plan version.
+                            plan.handleEntryCount = handleEntryCount;
+                            plan.handleEntries = handleEntries;
+                        }
+                    }
+                    else
+                    {
+                        // Equivalent steady-state stores from
+                        // AcquireDispatchSnapshotFast. The cached route is valid only while
+                        // the plan stamp matches, and every relevant mutation invalidates it.
+                        fastHandlers.lastTouchTicks = _tickCounter;
+                        fastHandlers.dispatchState.snapshotEmissionId = emissionId;
+                    }
+
+                    if (handleEntries != null)
+                    {
+                        fastFound = DispatchCachedUntargetedEntries(
+                            handleEntries,
+                            handleEntryCount,
+                            ref typedMessage
+                        );
+                    }
                 }
 
                 if (!fastFound && MessagingDebug.enabled)
@@ -4070,9 +4148,13 @@ namespace DxMessaging.Core.MessageBus
         /// churn, interceptor/global/post mutation, sweep, reset, settings
         /// reload); steady-state emissions skip straight past it.
         /// </summary>
-        private void RefreshUntargetedDispatchPlan<TMessage>(DispatchPlan plan)
+        private void RefreshUntargetedDispatchPlan<TMessage>(UntargetedDispatchPlan plan)
             where TMessage : IUntargetedMessage
         {
+            // A relevant mutation can have staged a pending snapshot that the
+            // first post-refresh acquire still has to promote. Clear the route
+            // here, then repopulate it only AFTER that acquisition settles.
+            plan.ClearCachedRoute();
             _ = _scalarSinks[BusSinkIndex.UntargetedHandleDefault]
                 .TryGetValue<TMessage>(out HandlerCache<int, HandlerCache> handle);
             _ = _scalarSinks[BusSinkIndex.UntargetedPostProcessDefault]
@@ -7208,6 +7290,69 @@ namespace DxMessaging.Core.MessageBus
             }
 
             return HasAnyDispatchEntries(snapshot);
+        }
+
+        /// <summary>
+        /// Untargeted no-feature steady-state loop over the entry array borrowed
+        /// by <see cref="UntargetedDispatchPlan"/> from its active snapshot.
+        /// The caller's live non-empty sink gate preserves the legacy
+        /// found-handler result even when the flattened array contains zero
+        /// invocable entries. Per-entry activity and reset-generation reads
+        /// remain live for the same mutation and reentrancy semantics as
+        /// <see cref="DispatchFlatSnapshot{TMessage}"/>.
+        /// </summary>
+        [Il2CppSetOption(Option.NullChecks, false)]
+        [Il2CppSetOption(Option.ArrayBoundsChecks, false)]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private bool DispatchCachedUntargetedEntries<TMessage>(
+            object entriesObject,
+            int count,
+            ref TMessage message
+        )
+            where TMessage : IUntargetedMessage
+        {
+            DebugAssertCachedUntargetedRoute<TMessage>(entriesObject, count);
+            FlatDispatchEntry<TMessage>[] entries = DxUnsafe.As<FlatDispatchEntry<TMessage>[]>(
+                entriesObject
+            );
+            long resetGeneration = _resetGeneration;
+            for (int i = 0; i < count; ++i)
+            {
+                ref FlatDispatchEntry<TMessage> entry = ref entries[i];
+                if (entry.handler.active)
+                {
+                    entry.invoker(ref message);
+                    if (_resetGeneration != resetGeneration)
+                    {
+                        break;
+                    }
+                }
+            }
+
+            return true;
+        }
+
+        [Conditional("DXMESSAGING_INTERNAL_CHECKS")]
+        private static void DebugAssertCachedUntargetedRoute<TMessage>(
+            object entriesObject,
+            int count
+        )
+            where TMessage : IUntargetedMessage
+        {
+            if (
+                entriesObject is FlatDispatchEntry<TMessage>[] entries
+                && 0 <= count
+                && count <= entries.Length
+            )
+            {
+                return;
+            }
+
+            System.Diagnostics.Debug.Assert(
+                false,
+                "Cached untargeted route must contain the expected closed entry-array type "
+                    + "with a count inside its physical bounds."
+            );
         }
 
         /// <summary>

--- a/Tests/Editor/Allocations/AllocationMatrixTests.cs
+++ b/Tests/Editor/Allocations/AllocationMatrixTests.cs
@@ -221,6 +221,74 @@ namespace DxMessaging.Tests.Editor.Allocations
             );
         }
 
+        /// <summary>
+        /// The untargeted no-feature route is cached on the bus-wide dispatch
+        /// plan only after its active snapshot settles. Unrelated registration
+        /// churn invalidates that plan without dirtying the measured sink, so
+        /// every measured operation below is the first emit that must reacquire
+        /// and republish the borrowed entry array.
+        /// </summary>
+        [Test]
+        [Category("Allocation")]
+        public void UntargetedEmitIsZeroAllocAfterUnrelatedPlanInvalidation()
+        {
+            MessageScenario scenario = MessageScenario.Untargeted();
+            RunWithFreshHarness(
+                scenario,
+                (token, bus) =>
+                {
+                    Action emit = BuildEmitClosure(scenario, bus);
+                    int invocationCount = 0;
+                    MessageHandler.FastHandler<SimpleUntargetedMessage> measuredHandler = (
+                        ref SimpleUntargetedMessage _
+                    ) => invocationCount++;
+                    _ = ScenarioHarness.RegisterUntargeted(scenario, token, measuredHandler);
+                    MessageHandler.FastHandler<ComplexUntargetedMessage> churnHandler = (
+                        ref ComplexUntargetedMessage _
+                    ) => { };
+
+                    void InvalidatePlan()
+                    {
+                        MessageRegistrationHandle churnHandle =
+                            token.RegisterUntargeted<ComplexUntargetedMessage>(churnHandler);
+                        token.RemoveRegistration(churnHandle);
+                    }
+
+                    for (int i = 0; i < 8; ++i)
+                    {
+                        InvalidatePlan();
+                        emit();
+                    }
+
+                    int invocationCountBeforeMeasurement = invocationCount;
+                    long delta = AllocationProbe.MeasureMin(
+                        AllocationMeasurementAttempts,
+                        prepare: InvalidatePlan,
+                        operation: emit
+                    );
+                    Assert.AreEqual(
+                        AllocationMeasurementAttempts,
+                        invocationCount - invocationCountBeforeMeasurement,
+                        "Every measured first emit after unrelated invalidation must still "
+                            + "deliver exactly once to the registered untargeted handler."
+                    );
+                    if (delta == AllocationProbe.Unmeasured)
+                    {
+                        Assert.Ignore(
+                            "The GC.Alloc allocation probe is non-functional on this backend."
+                        );
+                    }
+
+                    Assert.AreEqual(
+                        0,
+                        delta,
+                        "The first untargeted no-feature emit after an unrelated plan "
+                            + "invalidation must reacquire and cache its route without allocating."
+                    );
+                }
+            );
+        }
+
         [Test]
         [Category("Allocation")]
         public void GlobalMessageBusOverrideScopeIsZeroAllocAfterWarmup()

--- a/Tests/Editor/Contract/EvictionSweepContractTests.cs
+++ b/Tests/Editor/Contract/EvictionSweepContractTests.cs
@@ -349,7 +349,7 @@ namespace DxMessaging.Tests.Editor.Contract
         }
 
         [Test]
-        public void EmitTimeSweepReclaimsIdleDirtySlotsWhenCadenceHasElapsed()
+        public void EmitTimeSweepReclaimsIdleDirtySlotsAndDropsBorrowedRoute()
         {
             ManualClock clock = new ManualClock();
             MessageBus bus = MessageBus.CreateForInternalUse(
@@ -369,6 +369,37 @@ namespace DxMessaging.Tests.Editor.Contract
                     priority: 17,
                     messageBus: bus
                 );
+                ProbeMessage probe = new ProbeMessage();
+                bus.UntargetedBroadcast(ref probe);
+
+                FieldInfo plansField = typeof(MessageBus).GetField(
+                    "_untargetedDispatchPlans",
+                    BindingFlags.Instance | BindingFlags.NonPublic
+                );
+                Assert.IsNotNull(plansField, "MessageBus must retain its untargeted plan cache.");
+                object plan = null;
+                foreach (
+                    object candidate in (System.Collections.IEnumerable)plansField.GetValue(bus)
+                )
+                {
+                    plan = candidate;
+                    break;
+                }
+                Assert.IsNotNull(plan, "The first untargeted emit must create a dispatch plan.");
+                FieldInfo entriesField = plan.GetType()
+                    .GetField(
+                        "handleEntries",
+                        BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic
+                    );
+                Assert.IsNotNull(
+                    entriesField,
+                    "The untargeted plan must expose its borrowed entry-array field."
+                );
+                Assert.IsNotNull(
+                    entriesField.GetValue(plan),
+                    "The first untargeted emit must publish the borrowed route."
+                );
+
                 deregistration();
                 Assert.GreaterOrEqual(bus.OccupiedTypeSlots, 1);
 
@@ -378,6 +409,10 @@ namespace DxMessaging.Tests.Editor.Contract
                 Assert.AreEqual(0, bus.OccupiedTypeSlots);
                 Assert.AreEqual(0, ReadCollectionCount(bus, "_dirtyTypes"));
                 Assert.AreEqual(0, ReadCollectionCount(bus, "_dirtyHandlers"));
+                Assert.IsNull(
+                    entriesField.GetValue(plan),
+                    "The automatic emit-time sweep must drop the stale borrowed route."
+                );
             }
             finally
             {

--- a/Tests/Editor/Contract/Il2CppDispatchOptionContractTests.cs
+++ b/Tests/Editor/Contract/Il2CppDispatchOptionContractTests.cs
@@ -22,6 +22,7 @@ namespace DxMessaging.Tests.Editor.Contract
         private static readonly string[] FullyElidedMethods =
         {
             "DispatchFlatSnapshot",
+            "DispatchCachedUntargetedEntries",
             "DispatchContextFlatSnapshot",
             "HasAnyDispatchEntries",
             "BroadcastGlobalUntargeted",

--- a/Tests/Runtime/MemoryReclaim/MemoryReclamationTests.cs
+++ b/Tests/Runtime/MemoryReclaim/MemoryReclamationTests.cs
@@ -80,6 +80,111 @@ namespace DxMessaging.Tests.Runtime.MemoryReclaim
             );
         }
 
+        [TestCase(false)]
+        [TestCase(true)]
+        public void UntargetedPlanSweepDropsBorrowedEntryArray(bool force)
+        {
+            MessageBus bus = MessageBus.CreateForInternalUse(
+                new FakeClock(),
+                idleEvictionTicks: 0,
+                trimApiEnabled: true
+            );
+            using LeakWatcher watcher = LeakWatcher.WatchWithSlots(
+                bus,
+                label: nameof(UntargetedPlanSweepDropsBorrowedEntryArray)
+            );
+            using IDisposable cleanup = ForceTrimCleanup(bus);
+            MessageHandler handler = CreateActiveHandler(bus);
+            Action deregister = null;
+            try
+            {
+                Action<UntargetedOne> callback = _ => { };
+                deregister = handler.RegisterUntargetedMessageHandler(
+                    callback,
+                    callback,
+                    priority: 0,
+                    messageBus: bus
+                );
+                UntargetedOne message = new UntargetedOne();
+                bus.UntargetedBroadcast(ref message);
+
+                const BindingFlags declaredInstanceFields =
+                    BindingFlags.Instance
+                    | BindingFlags.Public
+                    | BindingFlags.NonPublic
+                    | BindingFlags.DeclaredOnly;
+                FieldInfo plansField = typeof(MessageBus).GetField(
+                    "_untargetedDispatchPlans",
+                    declaredInstanceFields
+                );
+                Assert.That(
+                    plansField,
+                    Is.Not.Null,
+                    "MessageBus must retain the untargeted plan cache field registered for sweep."
+                );
+                object plan = null;
+                foreach (
+                    object candidate in (System.Collections.IEnumerable)plansField.GetValue(bus)
+                )
+                {
+                    Assert.That(
+                        plan,
+                        Is.Null,
+                        "The scenario must create exactly one untargeted dispatch plan."
+                    );
+                    plan = candidate;
+                }
+
+                Assert.That(plan, Is.Not.Null, "The first emit must create a dispatch plan.");
+                Type planType = plan.GetType();
+                FieldInfo entriesField = planType.GetField("handleEntries", declaredInstanceFields);
+                FieldInfo countField = planType.GetField(
+                    "handleEntryCount",
+                    declaredInstanceFields
+                );
+                Assert.That(
+                    entriesField,
+                    Is.Not.Null,
+                    "The untargeted plan must expose its borrowed entry-array field to this contract."
+                );
+                Assert.That(
+                    countField,
+                    Is.Not.Null,
+                    "The untargeted plan must expose its borrowed entry-count field to this contract."
+                );
+                Assert.That(
+                    entriesField.GetValue(plan),
+                    Is.Not.Null,
+                    "The first untargeted fast emit must publish the settled borrowed route."
+                );
+                Assert.That(
+                    (int)countField.GetValue(plan),
+                    Is.GreaterThan(0),
+                    "The borrowed route must describe the invocable handler entry."
+                );
+
+                deregister();
+                deregister = null;
+                _ = bus.Trim(force);
+
+                Assert.That(
+                    entriesField.GetValue(plan),
+                    Is.Null,
+                    "Sweeping stale untargeted plans must drop the borrowed entry array."
+                );
+                Assert.That(
+                    countField.GetValue(plan),
+                    Is.EqualTo(0),
+                    "Sweeping stale untargeted plans must reset the cached entry count."
+                );
+            }
+            finally
+            {
+                deregister?.Invoke();
+                handler.active = false;
+            }
+        }
+
         [Test]
         public void TrimEvictsEmptyTargetSlots(
             [ValueSource(

--- a/docs/architecture/design-and-architecture.md
+++ b/docs/architecture/design-and-architecture.md
@@ -97,6 +97,9 @@ flowchart TB
 - Struct messages passed by `ref` to avoid copying and GC.
 - Minimal allocations in hot paths; logging and diagnostics use ring buffers.
 - Pre-allocated internal collections for common operations.
+- Untargeted dispatch without interceptors, global accept-all handlers, or post-processors reuses
+  resolved handler entries across steady-state emissions; registration changes and sweeps refresh
+  the route.
 - Handlers are sorted by priority once during registration. Emitting a message iterates through all active handlers in that order.
 
 ## Message Type System

--- a/docs/architecture/performance.md
+++ b/docs/architecture/performance.md
@@ -14,6 +14,11 @@ see the
 See also: [Performance optimizations](./design-and-architecture.md#performance-optimizations)
 for design details.
 
+Untargeted emissions with no interceptors, global accept-all handlers, or post-processors reuse
+their resolved handler route across steady-state emissions. Registration changes and sweeps refresh
+the route. Dispatch keeps live handler-state and reset checks while preserving the zero-allocation
+steady-state contract.
+
 ## How to read these tables
 
 - **Scopes.** Each dispatch table is labeled by execution scope and backend.


### PR DESCRIPTION
## Summary

- cache the settled untargeted handler entry array and count on the versioned untargeted dispatch plan
- preserve live activity/reset checks, publication-before-callback reentrancy behavior, and zero-allocation dispatch
- clear borrowed routes on registration invalidation, reset, explicit trim, and automatic idle sweeps
- add allocation, IL2CPP option, public trim, automatic sweep, and leak/slot reclamation contracts
- document the optimization and its exact sink-free scope

Closes none; advances #414.

## Correctness model

The dispatch-plan version does not by itself prove the active snapshot is settled. Refresh first clears the borrowed route. The first post-refresh acquire promotes any pending snapshot, then publishes the count followed by the array before user callbacks. Nested registration mutation/emission therefore sees either no cached route or the complete route for its current plan version. The snapshot remains the array owner.

Steady-state cached dispatch still:

- updates the handler cache touch time and snapshot emission id
- checks each handler's active state
- stops after reset-generation changes
- preserves the legacy found-handler result
- uses managed checks outside IL2CPP and the existing IL2CPP null/bounds-check contract inside IL2CPP

## Local performance screen

Unity 6000.4.6f1, macOS host editor, Mono Release, diagnostics and diagnostic stack capture off, repository five-second warmed measurement window:

| Bracket | GlobalToOne | StructNoBox | Allocation calls / bytes |
| --- | ---: | ---: | ---: |
| Control A1 | 23,784,954/s | 24,508,837/s | 0 / 0 |
| Candidate B1 | 25,062,579/s | 24,034,481/s | 0 / 0 |
| Control A2 | 24,250,080/s | 24,280,568/s | 0 / 0 |
| Candidate B2 | 25,465,140/s | 25,981,856/s | 0 / 0 |

Means: GlobalToOne +5.19%; StructNoBox +2.51%. This clears the predeclared 3% local screen on the representative GlobalToOne row. These Mono numbers are only a pre-filter; the Standalone IL2CPP Release comparison leg is the keep/reject verdict.

## Verification

Fresh loaded Unity assemblies were proven newer than the changed sources.

- Editor EditMode: 789 passed, 0 failed, 1 skipped, 8 inconclusive
- Editor Allocations: 274 passed, 0 failed
- Runtime PlayMode: 1,133 passed, 0 failed, 1 skipped
- npm script tests: 441 passed, 0 failed
- documentation compilation: 593 passed, 0 failed
- `npm run validate:all`: passed
- Markdown lint, spelling, format checks, branch-range pre-commit hooks: passed
- final adversarial review: zero findings

The shared Unity editor was left stopped and idle on one clean SampleScene, on the main stage, with an empty error console.

## Standalone IL2CPP verdict

Unity 6000.5.2f1 WindowsPlayer IL2CPP x64 Release:

| Scenario | PR #434 baseline | Candidate | Change |
| --- | ---: | ---: | ---: |
| GlobalToOne | 37,461,562/s | 43,358,514/s | +15.74% |
| StructNoBox | 28,681,243/s | 32,289,667/s | +12.58% |

Both directly affected rows confirm the optimization direction and clear the representative keep gate. The performance workflow and `Performance Unity Success` aggregate passed.

The workflow omitted its historical-delta table by policy because this PR changes the benchmark-adjacent allocation matrix. Its current raw rows are still retained. An unrelated KeyedToOne window was 11.22% below PR #434; keyed dispatch cannot read this untargeted plan, and the fresh local A/B/A/B bracket isolated no regression, so that single row is recorded as non-causal run variance rather than attributed to this candidate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the untargeted emit hot path, reentrancy publication order, and sweep/trim of borrowed arrays. Semantics are intended to stay the same, but a bug here would mis-deliver or leak handler arrays.
> 
> **Overview**
> Speeds up the common untargeted fast path (no interceptors, globals, or post-processors) by borrowing the settled flat handler-entry array onto a new `UntargetedDispatchPlan` after the first post-refresh snapshot acquire, then looping that array on later emits.
> 
> The snapshot still owns the array. Refresh and sweeps (`SweepStaleUntargetedDispatchPlans`) drop the borrowed route so stale arrays cannot outlive eviction. Nested mutation/re-emit is handled by publishing count then array *before* user callbacks.
> 
> Targeted and broadcast plans stay on the smaller shared `DispatchPlan` shape. Tests pin zero-alloc reacquire after unrelated invalidation, IL2CPP check elision on `DispatchCachedUntargetedEntries`, and trim/idle-sweep dropping the borrowed route.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 273c15c761b95041a11b07b79ebdd38f77554de4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->