### PR TITLE
Stop Dependabot from splitting lock-pin bumps and add the combined-hooks comparison

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,13 @@ updates:
           - "*"
     labels:
       - "dependencies"
+    ignore:
+      # The build-lock actions are first-party infrastructure whose immutable
+      # commit pins are copied into the docs/ops examples. Dependabot cannot
+      # edit those pages, so an automated bump would fail the copyable-example
+      # contract in scripts/__tests__/ci-aggregate-workflow.test.js. Bump these
+      # actions manually in one commit across .github/workflows and docs/ops.
+      - dependency-name: "Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/*"
 
   # NuGet: SourceGenerator project - Roslyn packages pinned for Unity compiler compatibility
   - package-ecosystem: "nuget"

--- a/Tests/Runtime/Comparisons/ComparisonDispatchTopologyTests.cs
+++ b/Tests/Runtime/Comparisons/ComparisonDispatchTopologyTests.cs
@@ -105,6 +105,14 @@ namespace DxMessaging.Tests.Runtime.Comparisons
                     "Comparison runs one post-processor plus one handler; the dispatch twin "
                         + "runs four post-processors plus one handler."
                 ),
+                [ComparisonScenario.InterceptedPostProcessingDispatch] = new TopologyMapping(
+                    1,
+                    null,
+                    isTrueTopologyTwin: false,
+                    "One interceptor plus one post-processor plus one handler; no dispatch "
+                        + "scenario combines hook kinds, so this row only supports within-matrix "
+                        + "comparison against GlobalToOne, Filtered, and PostProcess."
+                ),
                 [ComparisonScenario.SubscribeUnsubscribeChurn] = new TopologyMapping(
                     1,
                     null,

--- a/Tests/Runtime/Comparisons/ComparisonScenario.cs
+++ b/Tests/Runtime/Comparisons/ComparisonScenario.cs
@@ -18,6 +18,7 @@ namespace DxMessaging.Tests.Runtime.Comparisons
         PriorityOrderedDispatch,
         FilteredDispatch,
         PostProcessingDispatch,
+        InterceptedPostProcessingDispatch,
         SubscribeUnsubscribeChurn,
         StructMessageNoBoxing,
     }
@@ -79,6 +80,7 @@ namespace DxMessaging.Tests.Runtime.Comparisons
                 ComparisonScenario.PriorityOrderedDispatch => "PriorityOrdered",
                 ComparisonScenario.FilteredDispatch => "Filtered",
                 ComparisonScenario.PostProcessingDispatch => "PostProcess",
+                ComparisonScenario.InterceptedPostProcessingDispatch => "FilteredPostProcess",
                 ComparisonScenario.SubscribeUnsubscribeChurn => "SubUnsub",
                 ComparisonScenario.StructMessageNoBoxing => "StructNoBox",
                 _ => throw new ArgumentOutOfRangeException(nameof(s), s, null),
@@ -96,6 +98,8 @@ namespace DxMessaging.Tests.Runtime.Comparisons
                 ComparisonScenario.PriorityOrderedDispatch => "Priority-ordered dispatch",
                 ComparisonScenario.FilteredDispatch => "Filtered/intercepted dispatch",
                 ComparisonScenario.PostProcessingDispatch => "Post-processing dispatch",
+                ComparisonScenario.InterceptedPostProcessingDispatch =>
+                    "Intercepted + post-processed dispatch",
                 ComparisonScenario.SubscribeUnsubscribeChurn => "Subscribe/unsubscribe churn",
                 ComparisonScenario.StructMessageNoBoxing => "Struct message (no boxing)",
                 _ => throw new ArgumentOutOfRangeException(nameof(s), s, null),

--- a/Tests/Runtime/Comparisons/DxMessagingBridge.cs
+++ b/Tests/Runtime/Comparisons/DxMessagingBridge.cs
@@ -144,6 +144,15 @@ namespace DxMessaging.Tests.Runtime.Comparisons
                     );
                     _ = _token.RegisterUntargeted<SimpleUntargetedMessage>(Handle);
                     return;
+                case ComparisonScenario.InterceptedPostProcessingDispatch:
+                    _ = _token.RegisterUntargetedInterceptor<SimpleUntargetedMessage>(
+                        AllowUntargeted
+                    );
+                    _ = _token.RegisterUntargetedPostProcessor<SimpleUntargetedMessage>(
+                        PostProcess
+                    );
+                    _ = _token.RegisterUntargeted<SimpleUntargetedMessage>(Handle);
+                    return;
                 case ComparisonScenario.SubscribeUnsubscribeChurn:
                     // No persistent registration; EmitOnce performs one register/unregister
                     // cycle using the cached handler below.

--- a/Tests/Runtime/Comparisons/External/ExternalComparisonContractTests.cs
+++ b/Tests/Runtime/Comparisons/External/ExternalComparisonContractTests.cs
@@ -62,6 +62,7 @@ namespace DxMessaging.Tests.Runtime.Comparisons.External
         [Test]
         [TestCase("MessagePipe", ComparisonScenario.FilteredDispatch)]
         [TestCase("MessagePipe", ComparisonScenario.PostProcessingDispatch)]
+        [TestCase("MessagePipe", ComparisonScenario.InterceptedPostProcessingDispatch)]
         [TestCase("UniRx", ComparisonScenario.FilteredDispatch)]
         [TestCase("ZenjectSignalBus", ComparisonScenario.KeyedToOneOfMany)]
         public void BridgeSupportsItsIdiomaticComparisonScenario(

--- a/Tests/Runtime/Comparisons/External/MessagePipeBridge.cs
+++ b/Tests/Runtime/Comparisons/External/MessagePipeBridge.cs
@@ -67,6 +67,7 @@ namespace DxMessaging.Tests.Runtime.Comparisons.External
                 case ComparisonScenario.KeyedToOneOfMany:
                 case ComparisonScenario.FilteredDispatch:
                 case ComparisonScenario.PostProcessingDispatch:
+                case ComparisonScenario.InterceptedPostProcessingDispatch:
                 case ComparisonScenario.SubscribeUnsubscribeChurn:
                 case ComparisonScenario.StructMessageNoBoxing:
                     return true;
@@ -146,6 +147,14 @@ namespace DxMessaging.Tests.Runtime.Comparisons.External
                     BuildProvider(builder);
                     ResolveKeylessBroker();
                     _subscriptions.Add(_subscriber.Subscribe(Handle, new PostProcessingFilter()));
+                    return;
+                case ComparisonScenario.InterceptedPostProcessingDispatch:
+                    builder.AddMessageBroker<int>();
+                    BuildProvider(builder);
+                    ResolveKeylessBroker();
+                    _subscriptions.Add(
+                        _subscriber.Subscribe(Handle, Allow, new PostProcessingFilter())
+                    );
                     return;
                 case ComparisonScenario.SubscribeUnsubscribeChurn:
                     builder.AddMessageBroker<int>();

--- a/docs/ops/ambiguous-release-migration.md
+++ b/docs/ops/ambiguous-release-migration.md
@@ -116,6 +116,10 @@ organization lock.
   Grant `actions: read` to each acquiring job so the action can confirm that a
   holder's workflow is still live before expiring its reservation.
 
+  The pinned commit above is part of the example. Dependabot is configured to
+  ignore the build-lock actions, so bump their pins manually in one commit
+  across `.github/workflows` and this page.
+
   The matching release step uses the same immutable lock commit with `if:
 always()`. Never use `wallstop-organization-builds` as a native GitHub
   `concurrency.group`; the native primitive is repository-scoped and would

--- a/docs/ops/ci-and-github-settings.md
+++ b/docs/ops/ci-and-github-settings.md
@@ -52,6 +52,10 @@ Grant `actions: read` to every job that acquires the lock. The action uses the
 workflow token to distinguish a live holder from an expired reservation before
 the reaper can reclaim it.
 
+The pinned commit above is part of the example. Dependabot is configured to
+ignore the build-lock actions, so bump their pins manually in one commit across
+`.github/workflows` and this page.
+
 The matching release step uses the same immutable lock commit with `if:
 always()`. This lets checkout, cache, Node setup, and assembly discovery split
 across eligible runners while the organization lock enforces the two-seat

--- a/docs/runbooks/perf-benchmark-methodology.md
+++ b/docs/runbooks/perf-benchmark-methodology.md
@@ -353,21 +353,22 @@ sub-millisecond single shot without changing the reported per-bus cardinality.
 
 ### Comparison scenarios (cross-library)
 
-The eight apples-to-apples comparison scenarios are defined in
+The nine apples-to-apples comparison scenarios are defined in
 [`ComparisonScenario.cs`](https://github.com/Ambiguous-Interactive/DxMessaging/blob/master/Tests/Runtime/Comparisons/ComparisonScenario.cs).
 Each library implements only the scenarios it idiomatically supports; an
 unsupported scenario renders `N/A` in the matrix and is **never faked**:
 
-| #   | Scenario key      | What it measures                      |
-| --- | ----------------- | ------------------------------------- |
-| S1  | `GlobalToOne`     | Global dispatch to one subscriber.    |
-| S2  | `GlobalToMany`    | Global dispatch to 16 subscribers.    |
-| S3  | `KeyedToOne`      | Keyed/targeted dispatch to 1 of many. |
-| S4  | `PriorityOrdered` | Priority-ordered dispatch.            |
-| S5  | `Filtered`        | Filtered/intercepted dispatch.        |
-| S6  | `PostProcess`     | Post-processing dispatch.             |
-| S7  | `SubUnsub`        | Subscribe/unsubscribe churn.          |
-| S8  | `StructNoBox`     | Struct message dispatch (no boxing).  |
+| #   | Scenario key          | What it measures                         |
+| --- | --------------------- | ---------------------------------------- |
+| S1  | `GlobalToOne`         | Global dispatch to one subscriber.       |
+| S2  | `GlobalToMany`        | Global dispatch to 16 subscribers.       |
+| S3  | `KeyedToOne`          | Keyed/targeted dispatch to 1 of many.    |
+| S4  | `PriorityOrdered`     | Priority-ordered dispatch.               |
+| S5  | `Filtered`            | Filtered/intercepted dispatch.           |
+| S6  | `PostProcess`         | Post-processing dispatch.                |
+| S7  | `FilteredPostProcess` | Intercepted and post-processed dispatch. |
+| S8  | `SubUnsub`            | Subscribe/unsubscribe churn.             |
+| S9  | `StructNoBox`         | Struct message dispatch (no boxing).     |
 
 ### Comparison vs dispatch: deliberately different topologies
 
@@ -386,16 +387,17 @@ that suite fails the build if the DxMessaging fan-out, the dispatch scenario key
 the scenario roster drift from this table, so this documentation and the code cannot
 silently desync.
 
-| Comparison cell   | DxMessaging shape                    | Nearest dispatch cell                         | True twin? | Why they differ                                                                                                                                       |
-| ----------------- | ------------------------------------ | --------------------------------------------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `GlobalToOne`     | 1 token, 1 untargeted handler        | `UntargetedFlood_OneHandler`                  | **Yes**    | Identical shape; the DxMessaging numbers must agree within noise.                                                                                     |
-| `StructNoBox`     | 1 token, 1 untargeted handler        | `UntargetedFlood_OneHandler`                  | No         | Same storage shape, but the comparison uses the canonical `ComparisonStructPayload` while the dispatch row uses `SimpleUntargetedMessage`.            |
-| `GlobalToMany`    | 16 tokens, 16 untargeted handlers    | (none)                                        | No         | No dispatch scenario fans untargeted dispatch out to 16 handlers (the dispatch family caps untargeted fan-out at four).                               |
-| `KeyedToOne`      | 16 targets registered, dispatch to 1 | `TargetedFlood_OneListener`                   | No         | Measures lookup selectivity (16 registered, 1 fires); the dispatch cell registers a single target.                                                    |
-| `PriorityOrdered` | 1 token, 4 priorities                | `UntargetedFlood_FourHandlers_FourPriorities` | No         | Comparison uses one MessageHandler with four handler-store entries; the dispatch cell uses four separate tokens. Same fan-out (4), different storage. |
-| `Filtered`        | 1 interceptor + 1 handler            | `InterceptorHeavy_FourInterceptors`           | No         | Comparison runs one interceptor; the dispatch cell runs four.                                                                                         |
-| `PostProcess`     | 1 post-processor + 1 handler         | `PostProcessingHeavy_FourPostProcessors`      | No         | Comparison runs one post-processor; the dispatch cell runs four.                                                                                      |
-| `SubUnsub`        | register/unregister churn cycle      | (none)                                        | No         | The dispatch family has no subscribe/unsubscribe throughput scenario.                                                                                 |
+| Comparison cell       | DxMessaging shape                            | Nearest dispatch cell                         | True twin? | Why they differ                                                                                                                                       |
+| --------------------- | -------------------------------------------- | --------------------------------------------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GlobalToOne`         | 1 token, 1 untargeted handler                | `UntargetedFlood_OneHandler`                  | **Yes**    | Identical shape; the DxMessaging numbers must agree within noise.                                                                                     |
+| `StructNoBox`         | 1 token, 1 untargeted handler                | `UntargetedFlood_OneHandler`                  | No         | Same storage shape, but the comparison uses the canonical `ComparisonStructPayload` while the dispatch row uses `SimpleUntargetedMessage`.            |
+| `GlobalToMany`        | 16 tokens, 16 untargeted handlers            | (none)                                        | No         | No dispatch scenario fans untargeted dispatch out to 16 handlers (the dispatch family caps untargeted fan-out at four).                               |
+| `KeyedToOne`          | 16 targets registered, dispatch to 1         | `TargetedFlood_OneListener`                   | No         | Measures lookup selectivity (16 registered, 1 fires); the dispatch cell registers a single target.                                                    |
+| `PriorityOrdered`     | 1 token, 4 priorities                        | `UntargetedFlood_FourHandlers_FourPriorities` | No         | Comparison uses one MessageHandler with four handler-store entries; the dispatch cell uses four separate tokens. Same fan-out (4), different storage. |
+| `Filtered`            | 1 interceptor + 1 handler                    | `InterceptorHeavy_FourInterceptors`           | No         | Comparison runs one interceptor; the dispatch cell runs four.                                                                                         |
+| `PostProcess`         | 1 post-processor + 1 handler                 | `PostProcessingHeavy_FourPostProcessors`      | No         | Comparison runs one post-processor; the dispatch cell runs four.                                                                                      |
+| `FilteredPostProcess` | 1 interceptor + 1 post-processor + 1 handler | (none)                                        | No         | No dispatch scenario combines hook kinds. Compare this cell inside the matrix against `GlobalToOne`, `Filtered`, and `PostProcess` from the same run. |
+| `SubUnsub`            | register/unregister churn cycle              | (none)                                        | No         | The dispatch family has no subscribe/unsubscribe throughput scenario.                                                                                 |
 
 **Fresh-state guarantee.** CI builds the comparison matrix into a dedicated player;
 the internal benchmark player, including the 131072-cycle and teardown rows,

--- a/scripts/__tests__/ci-aggregate-workflow.test.js
+++ b/scripts/__tests__/ci-aggregate-workflow.test.js
@@ -12,9 +12,10 @@ const WORKFLOW_DIR = path.join(REPO_ROOT, ".github", "workflows");
 const LOCK_ACTION_PREFIX =
   "Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/";
 
-// Build-lock pins are bumped by Dependabot, so they are derived here rather than
-// written as literals. What must hold is that each action group stays immutably
-// pinned and identical at every call site.
+// Build-lock pins are excluded from Dependabot (the github-actions ignore block
+// in .github/dependabot.yml), so humans bump them together with the docs examples
+// that copy the same immutable commits. Each group stays immutably pinned and
+// identical at every call site.
 // prettier-ignore
 function resolveLockActionPin(actionNames) {
   const shas = new Map(); const comments = new Set(); const label = actionNames.join(", ");
@@ -447,6 +448,27 @@ test("copyable build-lock documentation follows the runner and App credential co
       source,
       /`BUILD_LOCK_APP_PRIVATE_KEY`/,
       `${relativePath} must list the App key secret`
+    );
+  }
+});
+
+test("dependabot never splits a build-lock bump from the copyable docs examples", () => {
+  const updates = YAML.parse(
+    fs.readFileSync(path.join(REPO_ROOT, ".github", "dependabot.yml"), "utf8")
+  ).updates;
+  const ignore = (updates.find((u) => u["package-ecosystem"] === "github-actions") || {}).ignore;
+  assert.ok(Array.isArray(ignore), "dependabot.yml github-actions block must carry an ignore list");
+  const patterns = ignore.map((entry) => entry["dependency-name"] || "");
+  // prettier-ignore
+  const actions = ["acquire-build-lock", "check-unity-runner-availability", "release-build-lock", "require-current-pr-head", "return-unity-license", "classify-unity-cleanup-evidence", "require-confirmed-unity-cleanup"];
+  for (const name of actions) {
+    const dependency = `${LOCK_ACTION_PREFIX}${name}`;
+    const matched = patterns.some((pattern) =>
+      new RegExp(`^${escapeRegExp(pattern).replaceAll("\\*", ".*")}$`).test(dependency)
+    );
+    assert.ok(
+      matched,
+      `dependabot.yml must ignore ${dependency}; its pin is copied into docs/ops and automation cannot edit both files in one commit`
     );
   }
 });

--- a/scripts/unity/comparison-supported-scenarios.json
+++ b/scripts/unity/comparison-supported-scenarios.json
@@ -6,6 +6,7 @@
     "PriorityOrdered",
     "Filtered",
     "PostProcess",
+    "FilteredPostProcess",
     "SubUnsub",
     "StructNoBox"
   ],
@@ -15,6 +16,7 @@
     "KeyedToOne",
     "Filtered",
     "PostProcess",
+    "FilteredPostProcess",
     "SubUnsub",
     "StructNoBox"
   ],

--- a/scripts/unity/perf-scenarios.js
+++ b/scripts/unity/perf-scenarios.js
@@ -73,6 +73,7 @@ const COMPARISON_SCENARIO_ORDER = [
   "PriorityOrdered",
   "Filtered",
   "PostProcess",
+  "FilteredPostProcess",
   "SubUnsub",
   "StructNoBox"
 ];
@@ -87,6 +88,7 @@ const COMPARISON_SCENARIO_LABELS = {
   PriorityOrdered: "Priority-ordered dispatch",
   Filtered: "Filtered/intercepted dispatch",
   PostProcess: "Post-processing dispatch",
+  FilteredPostProcess: "Intercepted + post-processed dispatch",
   SubUnsub: "Subscribe/unsubscribe churn",
   StructNoBox: "Struct message (no boxing)"
 };

--- a/scripts/unity/require-comparison-rows.ps1
+++ b/scripts/unity/require-comparison-rows.ps1
@@ -25,8 +25,8 @@ try {
     $expectedSorted = @($expected | Sort-Object)
     $actualSorted = @($actual | Sort-Object)
 
-    if ($expectedSorted.Count -ne 46) {
-        throw "The pinned comparison capability manifest must contain exactly 46 rows; found $($expectedSorted.Count)."
+    if ($expectedSorted.Count -ne 48) {
+        throw "The pinned comparison capability manifest must contain exactly 48 rows; found $($expectedSorted.Count)."
     }
     if ($actualSorted.Count -eq 0) {
         throw 'The comparison baseline contains no published comparison rows.'

--- a/scripts/validate-js-loc-budget.js
+++ b/scripts/validate-js-loc-budget.js
@@ -134,7 +134,7 @@ const path = require("path");
 //     check into the summary FILE, because the workflow runs the harness once
 //     per test mode, so an in-process flag printed the header three times per
 //     job; the test now spawns one process per leg: 18367.
-// 080 dependabot build-lock ignore contract. Dependabot bumps of the
+// 082 dependabot build-lock ignore contract. Dependabot bumps of the
 //     first-party lock actions broke the copyable-example doc contract on
 //     arrival (PR #447 failed eight checks; the 2026-08-18 bump needed a
 //     silent manual docs realignment), so dependabot.yml now ignores those

--- a/scripts/validate-js-loc-budget.js
+++ b/scripts/validate-js-loc-budget.js
@@ -134,7 +134,14 @@ const path = require("path");
 //     check into the summary FILE, because the workflow runs the harness once
 //     per test mode, so an in-process flag printed the header three times per
 //     job; the test now spawns one process per leg: 18367.
-const TOTAL_BUDGET = 18367;
+// 080 dependabot build-lock ignore contract. Dependabot bumps of the
+//     first-party lock actions broke the copyable-example doc contract on
+//     arrival (PR #447 failed eight checks; the 2026-08-18 bump needed a
+//     silent manual docs realignment), so dependabot.yml now ignores those
+//     actions and a new ci-aggregate-workflow test enforces the ignore list,
+//     converting every future bump into one manual commit across workflows
+//     and docs, plus the 7 lines this entry itself adds: 18398.
+const TOTAL_BUDGET = 18398;
 const LARGEST_FILE_COUNT = 10;
 const REPO_ROOT = path.resolve(__dirname, "..");
 


### PR DESCRIPTION
### Why: Dependabot bumps of the build-lock actions broke the docs contract

PR #447 bumped the seven build-lock action pins. Eight checks went red. One cause: the copyable `acquire-build-lock@<sha>` examples in two `docs/ops` pages must pin the same commit as the workflows, and Dependabot cannot edit those pages. The 2026-08-18 bump had the same failure; `d1d88e20` realigned the pages by hand two days later.

dependabot.yml now ignores the build-lock actions. A new test enforces the ignore list, so the coupling cannot return. Bumps of these actions arrive as one manual commit across workflows and docs. Both doc pages say so next to the example.

How we know: the new test fails when the ignore line is removed and passes with it. Full script suite passes (453/453). The JS line budget moves 18367 to 18398 with history entry 082.

### Why: the IL2CPP hook-cost bracket was missing an arm

The comparison matrix measured control (`GlobalToOne`), intercepted (`Filtered`), and post-processed (`PostProcess`) dispatch. No row stacked both hooks, so a Standalone IL2CPP leg could not show whether stacking multiplies or saturates the cost. Issue #414 needs that bracket before any dispatch change.

A `FilteredPostProcess` scenario now ships for DxMessaging and MessagePipe. DxMessaging registers interceptor, post-processor, and handler on one token. MessagePipe uses its combined subscribe overload, so the predicate runs before the handler and the post-filter after it. UniRx stays N/A because its filter composes before the handler. The capability manifest grows from 46 to 48 rows, with the row-count gate updated.

How we know: ComparisonContract suite passes on the host editor (177 pass, 0 fail). The full PerfComparison suite passes (43 supported pairs) and both new rows emit structured logs. The existing allocation matrix already pins the combined-hook shape at zero allocations per emit (9 rows pass).

Closes #447 by merge; advances #414 without touching dispatch code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CI Dependabot policy and the published comparison-matrix contract (new scenario keys and a 46→48 row gate). Runtime dispatch paths are unchanged.
> 
> **Overview**
> **Dependabot no longer auto-bumps first-party build-lock actions.** Those SHA pins are copied into `docs/ops` examples that Dependabot cannot edit, so automated bumps broke the copyable-example contract. `dependabot.yml` ignores `ambiguous-organization-build-lock` actions; a new workflow test enforces the ignore list so future bumps must be one manual commit across workflows and docs.
> 
> **Adds `FilteredPostProcess` to the cross-library comparison matrix** (nine scenarios, capability manifest 46→48). DxMessaging registers interceptor + post-processor + handler on one token; MessagePipe uses its combined subscribe overload. Other libraries stay N/A. There is no dispatch-throughput twin; the row is for within-matrix comparison against `GlobalToOne`, `Filtered`, and `PostProcess`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa74cac4926f55e92fffd4c2aea357ab4f9bee34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->