### PR TITLE
Fix landing page empty space and draw the banner hexagon flat-on-top

### DIFF
--- a/.llm/context.md
+++ b/.llm/context.md
@@ -212,7 +212,10 @@ fallback. A failed `gh auth status` is not a blocker while either earlier path w
 
 - Update relevant docs after user-visible behavior changes.
 - Keep examples accurate and aligned with real usage.
-- Update `CHANGELOG.md` only for user-facing DxMessaging changes, not developer-only tooling/process updates.
+- Update `CHANGELOG.md` only for library behavior a package consumer experiences in Unity
+  (runtime, editor, public API, samples, shipped settings). Documentation-site content or layout,
+  README text, brand artwork, CI, and repository tooling never earn entries, even when the files
+  ship in the package. See the changelog-management skill.
 - For `## [Unreleased]` entries, mutate existing bullets as behavior evolves; do not stack separate `Added` then `Fixed` bullets for the same unreleased change.
 - For edited Markdown files, run `npx prettier --write` and `npx markdownlint-cli2` before finishing.
 - Ordered lists must follow MD029 `one` style (`1.` for each item).

--- a/.llm/index.json
+++ b/.llm/index.json
@@ -80,7 +80,7 @@
         "category": "documentation",
         "tags": "changelog, documentation, versioning, semantic-versioning, release-notes, keep-a-changelog, user-communication"
       },
-      "lineCount": 119,
+      "lineCount": 122,
       "references": [
         ".llm/skills/changelog-management/references/changelog-entry-writing-part-1.md",
         ".llm/skills/changelog-management/references/changelog-entry-writing.md",

--- a/.llm/skills/changelog-management/SKILL.md
+++ b/.llm/skills/changelog-management/SKILL.md
@@ -32,8 +32,11 @@ published GitHub Release body from, so its section headings must stay well-forme
 - Never add an entry for: internal refactoring with no API change, test additions, AI agent
   guidance, skill files, or other developer-facing process documentation. Package consumers
   never see them.
-- Documentation and dependency updates earn an entry only when they change what a consumer
-  sees or has to do.
+- The changelog records library behavior: what a package consumer experiences in Unity. Runtime
+  and editor code, public API, samples, and shipped settings qualify. Documentation-site content
+  or layout, README text, brand artwork (marks, banners, cards, favicons), CI, and repository
+  tooling never earn entries, even when the changed files ship inside the package.
+- Dependency updates earn an entry only when they change what a consumer has to do.
 
 ### Entry length
 

--- a/.llm/skills/changelog-management/references/changelog-entry-writing.md
+++ b/.llm/skills/changelog-management/references/changelog-entry-writing.md
@@ -156,14 +156,10 @@ To upgrade from v2.x:
 
 **Why it's wrong**: This describes internal process/tooling, not user-facing product impact.
 
-**Correct**:
-
-```markdown
-### Changed
-
-- Improved AI-assistant onboarding for users by adding `llms.txt` and README guidance
-  so package docs and APIs are discovered with accurate context
-```
+**Correct**: No entry. `llms.txt`, README guidance, and agent routing help people and agents
+reading the repository. They are not library behavior, and a reworded entry does not make them
+eligible. The same holds for documentation-site layout and brand artwork: the changelog records
+what a package consumer experiences in Unity.
 
 ### Bad: Missing Breaking Change Warnings
 

--- a/.llm/skills/changelog-management/references/changelog-management.md
+++ b/.llm/skills/changelog-management/references/changelog-management.md
@@ -66,16 +66,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Update the changelog for **every user-facing change**:
 
-| Change Type                          | Update Changelog? | Category                   |
-| ------------------------------------ | ----------------- | -------------------------- |
-| New public API                       | Yes               | Added                      |
-| Bug fix                              | Yes               | Fixed                      |
-| Performance improvement              | Yes               | Changed                    |
-| Internal refactoring (no API change) | No                | N/A                        |
-| Test additions                       | No                | N/A                        |
-| Documentation fixes                  | Maybe             | Changed (if significant)   |
-| Dependency updates                   | Maybe             | Changed (if affects users) |
-| Breaking changes                     | Yes               | Changed/Removed            |
+| Change Type                           | Update Changelog? | Category                   |
+| ------------------------------------- | ----------------- | -------------------------- |
+| New public API                        | Yes               | Added                      |
+| Bug fix                               | Yes               | Fixed                      |
+| Performance improvement               | Yes               | Changed                    |
+| Internal refactoring (no API change)  | No                | N/A                        |
+| Test additions                        | No                | N/A                        |
+| Documentation site, README, brand art | No                | N/A                        |
+| Dependency updates                    | Maybe             | Changed (if affects users) |
+| Breaking changes                      | Yes               | Changed/Removed            |
 
 ### Semantic Versioning Guidelines
 
@@ -113,7 +113,7 @@ MAJOR.MINOR.PATCH
 
 Changelog entries describe changes that **users experience**, not internal tooling, AI agent guidance, or developer-facing documentation. Skills, context files, and internal process documentation are invisible to package consumers and do not belong in the changelog.
 
-**What to document instead**: Changes to user-facing documentation (API docs, tutorials, README) may warrant changelog entries if they significantly improve the user experience.
+**What to document instead**: Nothing for this class of change. The changelog records library behavior: what a package consumer experiences in Unity. Documentation-site content or layout, README text, brand artwork (marks, banners, cards, favicons), CI, and repository tooling never earn entries, even when the changed files ship inside the package. Announce them through the docs site or repository channels instead.
 
 ### Anti-Pattern 2: Overly Broad Scope
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Improve untargeted dispatch throughput when no interceptors, global handlers, or post-processors
   are registered ([#414](https://github.com/Ambiguous-Interactive/DxMessaging/issues/414)).
-- Show untargeted and broadcast examples on the landing page instead of the targeted one alone.
-  The hero and a new **First Message** selector each offer all three shapes: a pause announcement
-  coordinating independent systems, a hazard damaging one object it holds no reference to, and a
-  source-bound collision driving independent sound and breakable-object reactions. Each example
-  window sizes to its tallest sample instead of a fixed floor
-  ([#426](https://github.com/Ambiguous-Interactive/DxMessaging/issues/426),
-  [#451](https://github.com/Ambiguous-Interactive/DxMessaging/issues/451)).
 - Reduce repeated message-handler subscribe/unsubscribe churn by six managed allocation calls per
   cycle ([#414](https://github.com/Ambiguous-Interactive/DxMessaging/issues/414)).
 - **BREAKING (diagnostics output):** Diagnostic emission records no longer capture the emission-site
@@ -29,12 +22,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Monitor and Flow Graph now say when a call site is missing because capture is off and offer an
   **Enable stack traces** button that applies immediately and is saved to project settings
   ([#433](https://github.com/Ambiguous-Interactive/DxMessaging/issues/433)).
-- Replace the brand mark's three-spoke hub with the emitter artwork supplied on the issue, across
-  the mark, its light and single-color variants, the icon tile, the README banner, and the raster
-  assets derived from them
-  ([#436](https://github.com/Ambiguous-Interactive/DxMessaging/issues/436)).
-- Draw the README banner's badge hexagon flat-on-top, matching the orientation of the brand mark
-  ([#452](https://github.com/Ambiguous-Interactive/DxMessaging/issues/452)).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Show untargeted and broadcast examples on the landing page instead of the targeted one alone.
   The hero and a new **First Message** selector each offer all three shapes: a pause announcement
   coordinating independent systems, a hazard damaging one object it holds no reference to, and a
-  source-bound collision driving independent sound and breakable-object reactions
-  ([#426](https://github.com/Ambiguous-Interactive/DxMessaging/issues/426)).
+  source-bound collision driving independent sound and breakable-object reactions. Each example
+  window sizes to its tallest sample instead of a fixed floor
+  ([#426](https://github.com/Ambiguous-Interactive/DxMessaging/issues/426),
+  [#451](https://github.com/Ambiguous-Interactive/DxMessaging/issues/451)).
 - Reduce repeated message-handler subscribe/unsubscribe churn by six managed allocation calls per
   cycle ([#414](https://github.com/Ambiguous-Interactive/DxMessaging/issues/414)).
 - **BREAKING (diagnostics output):** Diagnostic emission records no longer capture the emission-site
@@ -31,6 +33,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the mark, its light and single-color variants, the icon tile, the README banner, and the raster
   assets derived from them
   ([#436](https://github.com/Ambiguous-Interactive/DxMessaging/issues/436)).
+- Draw the README banner's badge hexagon flat-on-top, matching the orientation of the brand mark
+  ([#452](https://github.com/Ambiguous-Interactive/DxMessaging/issues/452)).
 
 ### Fixed
 

--- a/docs/images/DxMessaging-banner.svg
+++ b/docs/images/DxMessaging-banner.svg
@@ -22,13 +22,14 @@
   <path d="M0 38 C154 66 274 28 414 52 C558 78 650 62 800 34" fill="none" stroke="#f4a836" stroke-width="1.2" opacity="0.2"/>
   <path d="M0 58 C168 88 296 48 432 72 C568 96 658 82 800 54" fill="none" stroke="#ffd48e" stroke-width="1.2" opacity="0.12"/>
 
-  <g transform="translate(34 42)" filter="url(#dxBannerSoftShadow)">
-    <polygon points="44,0 82,22 82,66 44,88 6,66 6,22" fill="#0d1117" stroke="#222b36" stroke-width="1.5" stroke-linejoin="round"/>
-    <polygon points="44,7 76,25 76,63 44,81 12,63 12,25" fill="none" stroke="url(#dxBannerAmber)" stroke-width="3" stroke-linejoin="round"/>
-    <!-- The mark's emitter, in the mark's own 96-unit coordinates. The banner hexagon is
-         pointy-top and narrower than the mark's, so the group is scaled about its center by the
-         width ratio (32/40) and re-centered; every proportion the mark was drawn with survives. -->
-    <g transform="translate(44 44) scale(0.8) translate(-48 -48)">
+  <g transform="translate(31 42)" filter="url(#dxBannerSoftShadow)">
+    <polygon points="90,44 67,83.84 21,83.84 -2,44 21,4.16 67,4.16" fill="#0d1117" stroke="#222b36" stroke-width="1.5" stroke-linejoin="round"/>
+    <polygon points="84,44 64,78.64 24,78.64 4,44 24,9.36 64,9.36" fill="none" stroke="url(#dxBannerAmber)" stroke-width="3" stroke-linejoin="round"/>
+    <!-- The mark's emitter, in the mark's own 96-unit coordinates, shifted so its center sits on
+         the badge center. The amber ring is the mark's own flat-top hexagon (80x69.28 at R=40)
+         translated the same way, and the dark plate is that hexagon scaled about the center to
+         R=46, so the badge keeps the mark's proportions and its flat-on-top orientation. -->
+    <g transform="translate(-4 -4)">
       <circle cx="30" cy="48" r="6" fill="#ffd48e"/>
       <path d="M46,34 a20,20 0 0 1 0,28" fill="none" stroke="#ffd48e" stroke-width="4" stroke-linecap="round"/>
       <path d="M58,26 a32,32 0 0 1 0,44" fill="none" stroke="#ffd48e" stroke-width="4" stroke-linecap="round" opacity="0.55"/>

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -323,18 +323,11 @@
     color: var(--dxm-route-broadcast);
   }
 
+  /* Every panel of a tab group shares one grid cell, and a hidden panel keeps its box, so the
+     row is always as tall as the tallest sample and switching tabs cannot resize the window.
+     A min-height floor here would only add empty space below the visible sample. */
   .dxm-sample-panels {
     display: grid;
-  }
-
-  /* The hero panels share one grid cell, so the tallest sample would otherwise resize the window
-     on every switch. The First Message samples are longer and carry their own floor. */
-  .dxm-hero-glow .dxm-sample-panels {
-    min-height: 21.5rem;
-  }
-
-  .dxm-first-message .dxm-sample-panels {
-    min-height: 34rem;
   }
 
   .dxm-first-message-heading {

--- a/scripts/render-brand-cards.py
+++ b/scripts/render-brand-cards.py
@@ -35,7 +35,10 @@ REQUIRED_FONTS = ["Space Grotesk", "IBM Plex Sans", "JetBrains Mono"]
 # Every SVG that draws the mark inline, so a mark change cannot reach one copy
 # and miss another. There is no portable way to reference an external SVG that
 # both a browser and cairo honour, so the geometry is duplicated on purpose and
-# the duplication is checked instead of hidden.
+# the duplication is checked instead of hidden. The README banner also copies
+# the mark's ring and emitter, but transformed (translated, and the ring is
+# rescaled for its plate), so the verbatim check below cannot cover it; update
+# docs/images/DxMessaging-banner.svg by hand when the mark's geometry changes.
 MARK_SOURCE = "docs/images/dxmessaging-mark.svg"
 MARK_COPIES = [
     "docs/images/dxmessaging-icon-tile.svg",


### PR DESCRIPTION
# Fix landing page empty space and draw the banner hexagon flat-on-top

## First Message window wasted vertical space

### Why

The landing page reserved a fixed height for each example window. The First Message window showed a band of empty space under the visible sample.

### What changed

- Removed the min-height floors on the hero and First Message tab groups.
- Each window now sizes to its tallest sample. Switching tabs cannot resize a window.

### How we know

- All panels of a tab group share one grid cell. A hidden panel keeps its layout box. The row is always as tall as the tallest sample, so the floors never had a job.
- Headless Chromium on the built site: the First Message panel row went from 680px to 601px. The hero floor was already inactive. All six tab switches hold one height. No horizontal scroll at 375px or 760px.

## Banner badge hexagon orientation

### Why

The brand mark's hexagon is flat-on-top. The README banner badge was the one hexagon in the set with a point on top.

### What changed

- The banner ring is now the mark's own flat-top hexagon.
- The dark plate scales that hexagon about its center.
- The emitter renders at the mark's native scale, so the old shrink factor is gone.
- The brand render script names the banner as a hand-updated mark copy.

### How we know

- A polygon sweep over every tracked SVG classifies all six-point polygons as flat-on-top. The three-point route arrowheads stay.
- Rendered the banner with cairosvg and compared the badge against the mark.
- No tracked PNG depicts the banner, so no raster needed a rebuild.

Closes #451
Closes #452

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs layout, SVG branding, and agent changelog guidance only. No runtime, editor, or public API changes.
> 
> **Overview**
> Removes wasted empty space on the docs landing page and aligns the README banner badge with the brand mark’s **flat-on-top** hexagon.
> 
> Landing sample tab groups no longer use `min-height` floors. Shared CSS grid already sizes the row to the tallest panel, so switching samples cannot resize the window.
> 
> The banner badge now uses the mark’s own flat-top hexagon (dark plate scaled about center; emitter at native scale). `render-brand-cards.py` documents that the banner is a transformed copy and must be updated by hand.
> 
> Changelog policy now treats docs-site layout, README, and brand artwork as ineligible. Unreleased landing-page and brand-mark bullets are removed to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3f54961aebf981aa2aab4e563b6728645c80eff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->