### PR TITLE
Ignore the machine-local opencode config pair repo-wide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -414,12 +414,12 @@ progress.meta
 .codex/config.toml
 .env.local
 
-# Hand-written opencode CLI config carries the relay bearer token, and Unity
-# generates opencode.jsonc.meta for it on import. Ignore both everywhere:
-# a tracked .meta whose sibling asset stays untracked fails the meta pairing
-# validator, so the pair must never be tracked on any machine.
-opencode.jsonc
-opencode.jsonc.meta
+# Hand-written opencode CLI config carries the relay bearer token, so it is
+# never tracked. Unity still generates its .meta on import; ignore both at
+# the repository root, because a tracked .meta whose sibling stays untracked
+# fails the meta pairing validator.
+/opencode.jsonc
+/opencode.jsonc.meta
 
 pre-commit.md*
 pre-commit.txt*

--- a/.gitignore
+++ b/.gitignore
@@ -414,6 +414,13 @@ progress.meta
 .codex/config.toml
 .env.local
 
+# Hand-written opencode CLI config carries the relay bearer token, and Unity
+# generates opencode.jsonc.meta for it on import. Ignore both everywhere:
+# a tracked .meta whose sibling asset stays untracked fails the meta pairing
+# validator, so the pair must never be tracked on any machine.
+opencode.jsonc
+opencode.jsonc.meta
+
 pre-commit.md*
 pre-commit.txt*
 pre-push.md*


### PR DESCRIPTION
## Why

`opencode.jsonc` holds the Unity MCP relay bearer token, so it must never be committed. Unity imports the file anyway and generates `opencode.jsonc.meta` in every clone that has it. A tracked `.meta` whose sibling asset stays untracked always fails the meta pairing validator (#455). The old workaround excluded both paths per clone through `.git/info/exclude`, which fresh clones had to recreate by hand.

Closes #455.

## What changed

Add anchored `/opencode.jsonc` and `/opencode.jsonc.meta` entries to the existing machine-local MCP config block in `.gitignore`, next to `.mcp.json`, `.cursor/mcp.json`, `.vscode/mcp.json`, `.codex/config.toml`, and `.env.local`. The block comment records the ruling beside the files it governs: metas for machine-local untracked root entries are never tracked, and the validator's orphan check is the contract.

The validator itself is unchanged. With both paths ignored on every clone, the regenerated meta can never be tracked again.

## How we know

- `node scripts/validate-npm-meta.js --repo-metas-only` passes on the current tree: 600 tracked assets, 359 C# metas.
- Full script suite green: 453/453 via `npm test`; `npm run validate:all` passes end to end.
- The JS LOC budget stays at its exact ceiling because no JavaScript changed.
- Anchored patterns match only the repository root, so a deliberate example config elsewhere stays addable.
- Packaging is unaffected: the npm `files` allowlist in `package.json` excludes both paths, and unitypackage export stages from the extracted tarball, not the working tree.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> .gitignore-only change for local config and its Unity sidecar; no runtime, auth, or packaging logic is modified.
> 
> **Overview**
> Ignores the machine-local OpenCode CLI config at the repo root so the relay bearer token is never committed, and also ignores Unity’s generated `opencode.jsonc.meta`.
> 
> Root-anchored `/opencode.jsonc` and `/opencode.jsonc.meta` sit with the other MCP client ignores. That stops a tracked `.meta` with an untracked sibling from failing the meta pairing validator, without blocking a non-root example config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 349805eb1e9d6848804325db33a7ccbdf8ed241d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->