### PR TITLE
Stabilize the Unity heartbeat orphan probe

### DIFF
--- a/Runtime/Core/MessageBus/MessageBus.cs
+++ b/Runtime/Core/MessageBus/MessageBus.cs
@@ -4069,13 +4069,25 @@ namespace DxMessaging.Core.MessageBus
             if (untargetedPostHandlers != null && untargetedPostHandlers.handlers.Count > 0)
             {
                 Touch(untargetedPostHandlers, touchTick);
-                untargetedPostSnapshot = AcquireDispatchSnapshotFast<TMessage>(
-                    this,
-                    untargetedPostHandlers,
-                    UntargetedPostSlot,
-                    emissionId,
-                    default
-                );
+                // SYNC: Inlined copy of the AcquireDispatchSnapshotFast steady-state branch.
+                DebugAssertAcquireFastPrecondition(untargetedPostHandlers);
+                DispatchState postState = untargetedPostHandlers.dispatchState;
+                if (postState != null && !postState.hasPending && postState.active.IsInitialized)
+                {
+                    untargetedPostHandlers.lastTouchTicks = _tickCounter;
+                    postState.snapshotEmissionId = emissionId;
+                    untargetedPostSnapshot = postState.active;
+                }
+                else
+                {
+                    untargetedPostSnapshot = AcquireDispatchSnapshot<TMessage>(
+                        this,
+                        untargetedPostHandlers,
+                        UntargetedPostSlot,
+                        emissionId,
+                        default
+                    );
+                }
             }
 
             InterceptorCache<object> untargetedInterceptors = plan.interceptorCache;
@@ -5647,13 +5659,26 @@ namespace DxMessaging.Core.MessageBus
                 return false;
             }
 
-            DispatchSnapshot snapshot = AcquireDispatchSnapshotFast<TMessage>(
-                this,
-                sortedHandlers,
-                UntargetedHandleSlot,
-                emissionId,
-                default
-            );
+            // SYNC: Inlined copy of the AcquireDispatchSnapshotFast steady-state branch.
+            DebugAssertAcquireFastPrecondition(sortedHandlers);
+            DispatchState handleState = sortedHandlers.dispatchState;
+            DispatchSnapshot snapshot;
+            if (handleState != null && !handleState.hasPending && handleState.active.IsInitialized)
+            {
+                sortedHandlers.lastTouchTicks = _tickCounter;
+                handleState.snapshotEmissionId = emissionId;
+                snapshot = handleState.active;
+            }
+            else
+            {
+                snapshot = AcquireDispatchSnapshot<TMessage>(
+                    this,
+                    sortedHandlers,
+                    UntargetedHandleSlot,
+                    emissionId,
+                    default
+                );
+            }
 
             // Flat dispatch; see DispatchFlatSnapshot for the frozen-array
             // semantics, the reset-generation guard, and the
@@ -6725,6 +6750,8 @@ namespace DxMessaging.Core.MessageBus
         )
             where TMessage : IMessage
         {
+            // SYNC: Keep this branch aligned with the inlined copies in
+            // UntargetedBroadcast and DispatchUntargetedHandlePhase.
             DebugAssertAcquireFastPrecondition(handlers);
             DispatchState state = handlers.dispatchState;
             if (state != null && !state.hasPending && state.active.IsInitialized)

--- a/Runtime/Core/MessageBus/MessageBus.cs
+++ b/Runtime/Core/MessageBus/MessageBus.cs
@@ -5533,6 +5533,7 @@ namespace DxMessaging.Core.MessageBus
         /// </remarks>
         // IL2CPP check elision on the frozen array walk: entries are non-null
         // by plan construction and the loop bound is the plan's own count.
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [Il2CppSetOption(Option.NullChecks, false)]
         [Il2CppSetOption(Option.ArrayBoundsChecks, false)]
         private bool RunUntargetedInterceptors<T>(ref T message, InterceptorCache<object> cache)

--- a/Runtime/Core/MessageBus/MessageBus.cs
+++ b/Runtime/Core/MessageBus/MessageBus.cs
@@ -4069,25 +4069,13 @@ namespace DxMessaging.Core.MessageBus
             if (untargetedPostHandlers != null && untargetedPostHandlers.handlers.Count > 0)
             {
                 Touch(untargetedPostHandlers, touchTick);
-                // SYNC: Inlined copy of the AcquireDispatchSnapshotFast steady-state branch.
-                DebugAssertAcquireFastPrecondition(untargetedPostHandlers);
-                DispatchState postState = untargetedPostHandlers.dispatchState;
-                if (postState != null && !postState.hasPending && postState.active.IsInitialized)
-                {
-                    untargetedPostHandlers.lastTouchTicks = _tickCounter;
-                    postState.snapshotEmissionId = emissionId;
-                    untargetedPostSnapshot = postState.active;
-                }
-                else
-                {
-                    untargetedPostSnapshot = AcquireDispatchSnapshot<TMessage>(
-                        this,
-                        untargetedPostHandlers,
-                        UntargetedPostSlot,
-                        emissionId,
-                        default
-                    );
-                }
+                untargetedPostSnapshot = AcquireDispatchSnapshotFast<TMessage>(
+                    this,
+                    untargetedPostHandlers,
+                    UntargetedPostSlot,
+                    emissionId,
+                    default
+                );
             }
 
             InterceptorCache<object> untargetedInterceptors = plan.interceptorCache;
@@ -5659,26 +5647,13 @@ namespace DxMessaging.Core.MessageBus
                 return false;
             }
 
-            // SYNC: Inlined copy of the AcquireDispatchSnapshotFast steady-state branch.
-            DebugAssertAcquireFastPrecondition(sortedHandlers);
-            DispatchState handleState = sortedHandlers.dispatchState;
-            DispatchSnapshot snapshot;
-            if (handleState != null && !handleState.hasPending && handleState.active.IsInitialized)
-            {
-                sortedHandlers.lastTouchTicks = _tickCounter;
-                handleState.snapshotEmissionId = emissionId;
-                snapshot = handleState.active;
-            }
-            else
-            {
-                snapshot = AcquireDispatchSnapshot<TMessage>(
-                    this,
-                    sortedHandlers,
-                    UntargetedHandleSlot,
-                    emissionId,
-                    default
-                );
-            }
+            DispatchSnapshot snapshot = AcquireDispatchSnapshotFast<TMessage>(
+                this,
+                sortedHandlers,
+                UntargetedHandleSlot,
+                emissionId,
+                default
+            );
 
             // Flat dispatch; see DispatchFlatSnapshot for the frozen-array
             // semantics, the reset-generation guard, and the
@@ -6750,8 +6725,6 @@ namespace DxMessaging.Core.MessageBus
         )
             where TMessage : IMessage
         {
-            // SYNC: Keep this branch aligned with the inlined copies in
-            // UntargetedBroadcast and DispatchUntargetedHandlePhase.
             DebugAssertAcquireFastPrecondition(handlers);
             DispatchState state = handlers.dispatchState;
             if (state != null && !state.hasPending && state.active.IsInitialized)

--- a/Runtime/Core/MessageBus/MessageBus.cs
+++ b/Runtime/Core/MessageBus/MessageBus.cs
@@ -5533,7 +5533,6 @@ namespace DxMessaging.Core.MessageBus
         /// </remarks>
         // IL2CPP check elision on the frozen array walk: entries are non-null
         // by plan construction and the loop bound is the plan's own count.
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [Il2CppSetOption(Option.NullChecks, false)]
         [Il2CppSetOption(Option.ArrayBoundsChecks, false)]
         private bool RunUntargetedInterceptors<T>(ref T message, InterceptorCache<object> cache)

--- a/scripts/__tests__/test-editor-provisioning-heartbeat.ps1
+++ b/scripts/__tests__/test-editor-provisioning-heartbeat.ps1
@@ -488,10 +488,16 @@ while ($true) {
     $orphanPidPath = Join-Path ([IO.Path]::GetTempPath()) "dxm-heartbeat-orphan-$([Guid]::NewGuid().ToString('N')).pid"
     $orphanPidLiteral = $orphanPidPath.Replace("'", "''")
     $orphanPidStagingLiteral = "$orphanPidPath.tmp".Replace("'", "''")
+    # Split the stall window around nested pwsh startup and PID publication. Without these
+    # markers, cold startup can consume the window and let the wrapper kill the parent tree before
+    # the probe reaches the quick-exit state that this case is meant to exercise. Eight seconds is
+    # the same cold-start margin used by the wrapper stall-path probe above.
     $orphanParent = @"
+Write-Output 'starting'
 `$child = Start-Process -FilePath '$pwshPath' -ArgumentList @('-NoLogo', '-NoProfile', '-EncodedCommand', '$descendantCode') -PassThru
 [IO.File]::WriteAllText('$orphanPidStagingLiteral', [string]`$child.Id)
 [IO.File]::Move('$orphanPidStagingLiteral', '$orphanPidLiteral')
+Write-Output 'published'
 "@
     $orphanAttempts = 0
     $orphanResult = $null
@@ -505,7 +511,7 @@ while ($true) {
             Invoke-UnityCliCaptureWithTimeout `
                 -Arguments @('-NoLogo', '-NoProfile', '-EncodedCommand', (ConvertTo-EncodedCommand $orphanParent)) `
                 -TimeoutSeconds 10 `
-                -StallSeconds 1
+                -StallSeconds 8
         }
     } catch {
         $orphanSafetyErrorEscaped = ($_.Exception.Message -match 'safe process-tree termination could not be confirmed')


### PR DESCRIPTION
## Why

The macOS static-CI heartbeat fixture could fire its one-second stall guard during a cold nested PowerShell startup. That killed the fixture before it published the detached descendant PID and produced false process-safety failures.

## What changed

The orphan fixture now emits one marker before nested process startup and another after atomic PID publication. Its fixture-only stall window is eight seconds, matching the adjacent cold-start probe.

Production timeout and process-tree code is unchanged. A separate silent-child test still exercises the real one-second heartbeat contract and asserts the stall sentinel.

## How we know

- 50 focused final-shape runs passed all 44 assertions each.
- The full script suite passed 453 tests.
- `npm run validate:all` and `npm run format:check` passed.
- Final-head static CI passed on macOS, Ubuntu, and Windows.
- Final-head Unity CI passed EditMode, PlayMode, and Standalone on all four supported Unity versions.
- Adversarial review completed with zero findings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only timing and fixture output changes in a PowerShell heartbeat script; no production provisioning or timeout logic is modified.
> 
> **Overview**
> **Stabilizes the quick-exit orphan fixture** in `test-editor-provisioning-heartbeat.ps1` so cold nested PowerShell startup no longer trips the stall guard before the descendant PID is published.
> 
> The orphan parent script now emits **`starting`** before `Start-Process` and **`published`** after the atomic PID write, and the fixture-only **`StallSeconds`** for that invoke rises from **1 to 8**, matching the existing wrapper stall-path probe margin. Comments document why the stall window must straddle startup and publication.
> 
> **Production heartbeat / timeout behavior is unchanged**; the silent-child case still drives the real one-second stall contract via `DXM_ENSURE_EDITOR_PROGRESS_STALL_SECONDS`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f55ee808a23310cfa0f5fabf4b632b358dfea53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->