### PR TITLE
Update CI and NUnit test dependencies

### DIFF
--- a/.docs-tests/WallstopStudios.DxMessaging.Docs.Tests.csproj
+++ b/.docs-tests/WallstopStudios.DxMessaging.Docs.Tests.csproj
@@ -17,7 +17,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.3.0" />
     <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1035,7 +1035,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Verify all static CI jobs succeeded
-        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # release/v1
+        uses: re-actors/alls-green@b5b5b37504aa4183270bd3d855c52a67f212be35 # release/v1
         with:
           jobs: ${{ toJSON(needs) }}
           allowed-skips: ""

--- a/SourceGenerators/WallstopStudios.DxMessaging.SourceGenerators.Tests/WallstopStudios.DxMessaging.SourceGenerators.Tests.csproj
+++ b/SourceGenerators/WallstopStudios.DxMessaging.SourceGenerators.Tests/WallstopStudios.DxMessaging.SourceGenerators.Tests.csproj
@@ -13,7 +13,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.3.0" />
     <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Why

Dependabot closed the source-generator adapter update when it opened the documentation test update. This left one test project on NUnit3TestAdapter 6.2.0. The CI aggregate action also had a security fix available.

## What changed

- Updated NUnit3TestAdapter to 6.3.0 in both test projects.
- Updated `re-actors/alls-green` to its pinned 1.3.0 release commit.
- Kept the existing aggregate inputs and fail-closed behavior.

## How we know

- Documentation tests: 601 passed.
- Source-generator tests: 257 passed.
- Script tests: 453 passed.
- `npm run validate:all` passed.
- `npm run format:check` passed.
- An independent final review found no issues.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only changes to test adapters and a pinned CI helper action; no runtime, auth, or product code paths are modified.
> 
> **Overview**
> Aligns **NUnit3TestAdapter** from **6.2.0** to **6.3.0** in both `.docs-tests` and source-generator test projects so they match after a partial Dependabot update left one project behind.
> 
> The **CI Success** aggregate step bumps the pinned **`re-actors/alls-green`** commit (still **`release/v1` / 1.3.0**); **`jobs`**, **`allowed-skips`**, and **`allowed-failures`** inputs are unchanged, so fail-closed gating behavior stays the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69dcd42d77a7ebbb5a5f211f7b170ff9af8f5a2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->