### PR TITLE
Add same-player comparison stability evidence

### DIFF
--- a/.github/workflows/perf-numbers.yml
+++ b/.github/workflows/perf-numbers.yml
@@ -513,12 +513,16 @@ jobs:
           # Unity Test Framework injects it by default; Release is the runner's
           # contract and -ReleasePlayerBuild is a kept-for-clarity no-op), so the
           # published numbers come from a true Release IL2CPP player
-          # (Release C++ config, isDebugBuild=false).
+          # (Release C++ config, isDebugBuild=false). The comparison leg builds
+          # once and launches that exact player three times. Only run 1 keeps the
+          # canonical results.xml/player.log names used by publication; runs 2-3
+          # are diagnostic evidence for #414's host-stability gate.
           $extra = @{
               IncludeComparisons = '${{ matrix.benchmark-suite }}' -eq 'comparisons'
               ReleaseCodeOptimization = $true
               ReleasePlayerBuild = $true
               StandaloneScriptingBackend = 'IL2CPP'
+              StandalonePlayerRunCount = if ('${{ matrix.benchmark-suite }}' -eq 'comparisons') { 3 } else { 1 }
           }
           $projectPath = Join-Path $env:RUNNER_WORKSPACE 'dxm-u\p\${{ matrix.unity-version }}-${{ matrix.test-mode }}-${{ matrix.benchmark-suite }}'
           $cachePath = Join-Path $env:RUNNER_WORKSPACE 'dxm-c\${{ matrix.unity-version }}'
@@ -532,6 +536,14 @@ jobs:
             -CachePath $cachePath `
             -LicenseReturnOwner Central `
             @extra
+
+      - name: Require same-player comparison evidence
+        if: ${{ matrix.benchmark-suite == 'comparisons' && steps.run_tests.outcome == 'success' }}
+        timeout-minutes: 5
+        shell: pwsh
+        run: |
+          ./scripts/unity/require-same-player-stability.ps1 `
+            -ArtifactsPath '.artifacts/unity/perf/${{ matrix.unity-version }}-${{ matrix.test-mode }}-comparisons'
 
       - name: Capture exact standalone player size
         if: ${{ matrix.test-mode == 'standalone' && matrix.benchmark-suite == 'internal' && steps.run_tests.outcome == 'success' }}

--- a/docs/runbooks/perf-benchmark-methodology.md
+++ b/docs/runbooks/perf-benchmark-methodology.md
@@ -412,6 +412,45 @@ before its `ProgressMarker` assertion reconciles the full measurement. This catc
 current-row deduplication and fan-out mismatches. Teardown contracts separately verify
 synchronous cleanup where the pinned API exposes observable Unity objects or assets.
 
+### Same-player host-stability evidence
+
+The published comparison job builds one Standalone IL2CPP Release player, then
+launches that exact player three times. Run 1 keeps the canonical `results.xml`
+and `player.log` names consumed by publication. Runs 2 and 3 use noncanonical
+filenames under `same-player-repeats/`, so recursive publication input discovery
+cannot include them. Every launch still runs each scenario's one warmed five-second
+window, and every NUnit result file must pass independently.
+
+The runner records an ordinal-sorted path, byte length, and SHA-256 manifest for
+every file under the built player directory before run 1 and after run 3. CI
+fails if a file changes, appears, or disappears. No files are excluded from this
+check. Each launch also records the player process id and its actual
+processor-affinity mask. Host probes run immediately before process start and
+after process exit, outside every benchmark window. They record active
+per-logical-processor frequency and load when Windows exposes those counters,
+package clock and load as a fallback, and total host CPU load. The thermal probe
+records raw ACPI thermal-zone identities and values when firmware exposes them.
+An ACPI zone is not assumed to be the CPU package sensor; an unavailable probe is
+recorded as unavailable rather than invented as a temperature.
+
+`scripts/unity/require-same-player-stability.ps1` validates the evidence and
+writes `same-player-stability.json` plus `same-player-stability.md`. For each of
+the nine DxMessaging comparison scenarios, it calculates:
+
+```text
+spread_percent = (maximum_emits_per_second / minimum_emits_per_second - 1) * 100
+```
+
+The predeclared materiality band is 3%. The report uses all three observations:
+it does not take a median or discard an outlier. Missing or changed manifest
+data, a timed-out player, affinity, host conditions, results, or expected rows
+fails the comparison job. The gate also requires its schema versions, managed
+artifact paths, snapshot order, and one measured commit and exact Standalone
+IL2CPP x64 Release platform across all 27 DxMessaging rows. A spread above 3% is
+retained as an instability verdict and emits a workflow warning instead of
+failing the test run. Such a verdict keeps the runtime-candidate gate closed; it
+does not turn an unstable host into a performance regression.
+
 Cases run scenario-major within each roster assembly. This keeps same-scenario cells
 closer together inside the zero-dependency, external-package, and Unity Atoms rosters,
 but assembly boundaries still separate the complete matrix. A single pass cannot

--- a/scripts/__tests__/unity-perf.test.js
+++ b/scripts/__tests__/unity-perf.test.js
@@ -212,19 +212,18 @@ test("scenario filters keep only dispatch and DxMessaging comparison rows", () =
   }
 });
 
-test("comparison row gate fails closed when the extracted baseline has no comparison rows", () => {
-  const testScript = path.join(
-    REPO_ROOT,
-    "scripts",
-    "unity",
-    "__tests__",
-    "require-comparison-rows.test.ps1"
-  );
-  const result = spawnSync("pwsh", ["-NoLogo", "-NoProfile", "-File", testScript], {
-    encoding: "utf8"
-  });
-  assert.ifError(result.error);
-  assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+test("PowerShell performance harness regression tests pass", () => {
+  for (const script of [
+    "require-comparison-rows.test.ps1",
+    "same-player-repeat-evidence.test.ps1"
+  ]) {
+    const testScript = path.join(REPO_ROOT, "scripts", "unity", "__tests__", script);
+    const result = spawnSync("pwsh", ["-NoLogo", "-NoProfile", "-File", testScript], {
+      encoding: "utf8"
+    });
+    assert.ifError(result.error);
+    assert.equal(result.status, 0, `${script}\n${result.stdout}\n${result.stderr}`);
+  }
 });
 
 test("extractRows parses CSV and structured log lines, dedupes, skips noise", () => {

--- a/scripts/unity/__tests__/same-player-repeat-evidence.test.ps1
+++ b/scripts/unity/__tests__/same-player-repeat-evidence.test.ps1
@@ -1,0 +1,441 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Exercises the real same-player manifest, process-affinity, and host-probe helpers.
+#>
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$runnerPath = Join-Path (Split-Path -Parent $PSScriptRoot) 'run-ci-tests.ps1'
+$repoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSScriptRoot))
+$workflowPath = Join-Path $repoRoot '.github/workflows/perf-numbers.yml'
+$stabilityScriptPath = Join-Path (Split-Path -Parent $PSScriptRoot) 'require-same-player-stability.ps1'
+$tokens = $null
+$parseErrors = $null
+$ast = [System.Management.Automation.Language.Parser]::ParseFile(
+    $runnerPath,
+    [ref]$tokens,
+    [ref]$parseErrors
+)
+if ($parseErrors -and $parseErrors.Count -gt 0) {
+    throw "run-ci-tests.ps1 has parse errors: $($parseErrors.Message -join '; ')"
+}
+
+foreach ($name in @(
+    'Get-StandaloneHostConditionSnapshot',
+    'Get-StandalonePlayerManifest',
+    'Write-JsonArtifact',
+    'ConvertTo-ProcessArgumentLine',
+    'Invoke-ProcessWithTreeKillTimeout'
+)) {
+    $definition = $ast.FindAll(
+        {
+            param($node)
+            $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+                $node.Name -eq $name
+        },
+        $true
+    ) | Select-Object -First 1
+    if (-not $definition) {
+        throw "Function '$name' was not found in run-ci-tests.ps1."
+    }
+    Invoke-Expression $definition.Extent.Text
+}
+
+function Assert-That {
+    param(
+        [Parameter(Mandatory = $true)][string]$Description,
+        [Parameter(Mandatory = $true)][bool]$Condition
+    )
+    if (-not $Condition) {
+        throw "Assertion failed: $Description"
+    }
+}
+
+function Write-TestJson {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)]$Value
+    )
+
+    $Value | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $Path -Encoding utf8NoBOM
+}
+
+function Assert-StabilityGateFails {
+    param(
+        [Parameter(Mandatory = $true)][string]$Description,
+        [Parameter(Mandatory = $true)][string]$ArtifactsPath,
+        [Parameter(Mandatory = $true)][string]$ExpectedMessage
+    )
+
+    $failedAsExpected = $false
+    try {
+        & $stabilityScriptPath -ArtifactsPath $ArtifactsPath
+    } catch {
+        $failedAsExpected = $_.Exception.Message.Contains($ExpectedMessage)
+    }
+    Assert-That $Description $failedAsExpected
+}
+
+function New-StabilityFixture {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][double[]]$RunValues,
+        [Parameter(Mandatory = $true)][string[]]$Scenarios
+    )
+
+    $repeatRoot = Join-Path $Path 'same-player-repeats'
+    New-Item -ItemType Directory -Force -Path $repeatRoot | Out-Null
+    $records = New-Object System.Collections.Generic.List[object]
+    for ($index = 0; $index -lt $RunValues.Count; $index++) {
+        $runIndex = $index + 1
+        $runNumber = '{0:D2}' -f $runIndex
+        if ($runIndex -eq 1) {
+            $relativeResultsPath = 'results.xml'
+            $relativeLogPath = 'player.log'
+        } else {
+            $relativeResultsPath = "same-player-repeats/run-$runNumber/repeat-$runNumber-results.xml"
+            $relativeLogPath = "same-player-repeats/run-$runNumber/repeat-$runNumber-player.log"
+            New-Item `
+                -ItemType Directory `
+                -Force `
+                -Path (Split-Path -Parent (Join-Path $Path $relativeResultsPath)) |
+                Out-Null
+        }
+        $rows = foreach ($scenario in $Scenarios) {
+            "Comparison_DxMessaging_$scenario,Standalone IL2CPP x64 Release (WindowsPlayer; Unity 6000.3.16f1),aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,0,$($RunValues[$index]),0,5000,0"
+        }
+        [System.IO.File]::WriteAllLines((Join-Path $Path $relativeResultsPath), $rows)
+        [System.IO.File]::WriteAllText((Join-Path $Path $relativeLogPath), 'fixture')
+
+        $hostConditionsFile = "run-$runNumber-host-conditions.json"
+        $beforeTimestamp = [DateTime]::UtcNow
+        $snapshot = [ordered]@{
+            phase = 'before'
+            timestampUtc = $beforeTimestamp.ToString('O')
+            logicalProcessors = @([ordered]@{ frequencyMhz = 4000; loadPercent = 20 })
+            processors = @()
+            totalCpuLoadPercent = 20
+            acpiThermalZones = [ordered]@{ available = $false; zones = @() }
+        }
+        $afterSnapshot = [ordered]@{} + $snapshot
+        $afterSnapshot.phase = 'after'
+        $afterSnapshot.timestampUtc = $beforeTimestamp.AddSeconds(1).ToString('O')
+        Write-TestJson `
+            -Path (Join-Path $repeatRoot $hostConditionsFile) `
+            -Value ([ordered]@{
+                schemaVersion = 1
+                runIndex = $runIndex
+                runCount = $RunValues.Count
+                playerProcessId = 1000 + $runIndex
+                playerProcessorAffinityMask = '0x3'
+                timedOut = $false
+                before = $snapshot
+                after = $afterSnapshot
+            })
+        $records.Add([ordered]@{
+                runIndex = $runIndex
+                resultsPath = $relativeResultsPath
+                playerLogPath = $relativeLogPath
+                hostConditionsFile = $hostConditionsFile
+                processId = 1000 + $runIndex
+                processorAffinityMask = '0x3'
+                timedOut = $false
+            })
+    }
+    $manifest = [ordered]@{
+        schemaVersion = 1
+        fileCount = 1
+        files = @([ordered]@{
+                path = 'DxmTestPlayer.exe'
+                length = 3
+                sha256 = 'A' * 64
+            })
+    }
+    Write-TestJson `
+        -Path (Join-Path $repeatRoot 'same-player-evidence.json') `
+        -Value ([ordered]@{
+            schemaVersion = 1
+            runCount = $RunValues.Count
+            canonicalPublishedRunIndex = 1
+            playerDirectoryManifestMatches = $true
+            playerDirectoryManifestBefore = $manifest
+            playerDirectoryManifestAfter = $manifest
+            runs = @($records.ToArray())
+        })
+}
+
+$fixtureRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("dxm-same-player-{0}" -f [guid]::NewGuid().ToString('N'))
+try {
+    New-Item -ItemType Directory -Force -Path $fixtureRoot | Out-Null
+    $executablePath = Join-Path $fixtureRoot 'DxmTestPlayer.exe'
+    $gameAssemblyPath = Join-Path $fixtureRoot 'GameAssembly.dll'
+    $metadataPath = Join-Path $fixtureRoot 'global-metadata.dat'
+    $unityPlayerPath = Join-Path $fixtureRoot 'UnityPlayer.dll'
+    $nestedDirectory = Join-Path $fixtureRoot 'DxmTestPlayer_Data/Managed'
+    New-Item -ItemType Directory -Force -Path $nestedDirectory | Out-Null
+    $arbitraryPlayerFilePath = Join-Path $nestedDirectory 'arbitrary-player-file.bin'
+    [System.IO.File]::WriteAllText($executablePath, 'exe-v1')
+    [System.IO.File]::WriteAllText($gameAssemblyPath, 'game-v1')
+    [System.IO.File]::WriteAllText($metadataPath, 'metadata-v1')
+    [System.IO.File]::WriteAllText($unityPlayerPath, 'unity-v1')
+    [System.IO.File]::WriteAllText($arbitraryPlayerFilePath, 'arbitrary-v1')
+
+    $manifestBefore = Get-StandalonePlayerManifest -ExecutablePath $executablePath
+    [System.IO.File]::WriteAllText($arbitraryPlayerFilePath, 'arbitrary-v2')
+    $manifestAfter = Get-StandalonePlayerManifest -ExecutablePath $executablePath
+    Assert-That 'the manifest includes every nested player file in ordinal path order' (
+        $manifestBefore.fileCount -eq 5 -and
+        (@($manifestBefore.files.path) -join ',') -ceq (
+            'DxmTestPlayer.exe,' +
+            'DxmTestPlayer_Data/Managed/arbitrary-player-file.bin,' +
+            'GameAssembly.dll,UnityPlayer.dll,global-metadata.dat'
+        ) -and
+        @($manifestBefore.files | Where-Object { $_.path -eq 'DxmTestPlayer_Data/Managed/arbitrary-player-file.bin' }).Count -eq 1
+    )
+    $arbitraryBefore = @(
+        $manifestBefore.files |
+            Where-Object { $_.path -eq 'DxmTestPlayer_Data/Managed/arbitrary-player-file.bin' }
+    )[0]
+    $arbitraryAfter = @(
+        $manifestAfter.files |
+            Where-Object { $_.path -eq 'DxmTestPlayer_Data/Managed/arbitrary-player-file.bin' }
+    )[0]
+    Assert-That 'a mutation to an arbitrary player file changes the complete manifest' (
+        $arbitraryBefore.sha256 -ne $arbitraryAfter.sha256
+    )
+    Assert-That 'unchanged player files keep their manifest entries' (
+        @($manifestBefore.files | Where-Object { $_.path -eq 'GameAssembly.dll' })[0].sha256 -eq
+        @($manifestAfter.files | Where-Object { $_.path -eq 'GameAssembly.dll' })[0].sha256
+    )
+
+    $snapshot = Get-StandaloneHostConditionSnapshot -Phase 'test'
+    Assert-That 'the snapshot records its phase and timestamp' (
+        $snapshot.phase -eq 'test' -and -not [string]::IsNullOrWhiteSpace($snapshot.timestampUtc)
+    )
+    Assert-That 'the snapshot distinguishes logical, package, and ACPI thermal probes' (
+        $null -ne $snapshot.logicalProcessors -and
+        $null -ne $snapshot.processors -and
+        $null -ne $snapshot.acpiThermalZones.available
+    )
+
+    $jsonPath = Join-Path $fixtureRoot 'evidence.json'
+    Write-JsonArtifact -Path $jsonPath -Value $snapshot
+    $bytes = [System.IO.File]::ReadAllBytes($jsonPath)
+    Assert-That 'JSON evidence is UTF-8 without a BOM' (
+        $bytes.Length -ge 3 -and
+        -not ($bytes[0] -eq 0xEF -and $bytes[1] -eq 0xBB -and $bytes[2] -eq 0xBF)
+    )
+    $parsed = Get-Content -LiteralPath $jsonPath -Raw | ConvertFrom-Json
+    Assert-That 'JSON evidence round-trips' ($parsed.phase -eq 'test')
+
+    $processLog = Join-Path $fixtureRoot 'process.log'
+    $pwshPath = (Get-Process -Id $PID).Path
+    $processArguments = @{
+        FilePath = $pwshPath
+        Arguments = @('-NoLogo', '-NoProfile', '-Command', 'Wait-Event -Timeout 1 | Out-Null; exit 0')
+        TimeoutSeconds = 30
+        LogPath = $processLog
+        Label = 'same-player process evidence test'
+    }
+    $processResult = Invoke-ProcessWithTreeKillTimeout @processArguments
+    Assert-That 'the process helper returns success and a process id' (
+        $processResult.ExitCode -eq 0 -and $processResult.ProcessId -gt 0
+    )
+    Assert-That 'the process helper captures actual child affinity' (
+        -not [string]::IsNullOrWhiteSpace([string]$processResult.ProcessorAffinityMask)
+    )
+
+    $runnerText = Get-Content -LiteralPath $runnerPath -Raw
+    $buildIndex = $runnerText.IndexOf('$buildResult = Invoke-ProcessWithTreeKillTimeout')
+    $repeatIndex = $runnerText.IndexOf('for ($playerRunIndex = 1;')
+    Assert-That 'one editor build remains outside and before the repeat loop' (
+        $buildIndex -ge 0 -and $repeatIndex -gt $buildIndex
+    )
+    Assert-That 'run 1 stays canonical while repeat filenames are noncanonical' (
+        $runnerText.Contains('$currentResultsPath = $resultsPath') -and
+        $runnerText.Contains('"repeat-$runNumber-results.xml"') -and
+        $runnerText.Contains('"repeat-$runNumber-player.log"')
+    )
+    Assert-That 'the managed repeat root is cleared before reuse' (
+        $runnerText.Contains('Remove-Item -LiteralPath $samePlayerEvidenceRoot -Recurse -Force')
+    )
+    Assert-That 'the runner captures and compares complete player manifests' (
+        $runnerText.Contains('Get-StandalonePlayerManifest') -and
+        $runnerText.Contains('playerDirectoryManifestMatches')
+    )
+
+    $workflowText = Get-Content -LiteralPath $workflowPath -Raw
+    Assert-That 'only the comparison player receives three launches' (
+        $workflowText -match "StandalonePlayerRunCount = if .*benchmark-suite.*comparisons.* 3 .* 1"
+    )
+    Assert-That 'the workflow invokes the tested same-player evidence gate' (
+        $workflowText.Contains('./scripts/unity/require-same-player-stability.ps1')
+    )
+
+    $scenarioModulePath = Join-Path (Split-Path -Parent $PSScriptRoot) 'perf-scenarios.js'
+    $scenarios = @(
+        & node -e 'require(process.argv[1]).COMPARISON_SCENARIO_ORDER.forEach((scenario) => console.log(scenario))' `
+            $scenarioModulePath
+    )
+    Assert-That 'the fixture uses all comparison scenarios' (
+        $LASTEXITCODE -eq 0 -and $scenarios.Count -eq 9
+    )
+
+    $stableFixturePath = Join-Path $fixtureRoot 'stable-artifacts'
+    New-Item -ItemType Directory -Force -Path $stableFixturePath | Out-Null
+    New-StabilityFixture `
+        -Path $stableFixturePath `
+        -RunValues @(1000000, 1010000, 1020000) `
+        -Scenarios $scenarios
+    & $stabilityScriptPath -ArtifactsPath $stableFixturePath
+    $stableReportPath = Join-Path $stableFixturePath 'same-player-repeats/same-player-stability.json'
+    $stableReport = Get-Content -LiteralPath $stableReportPath -Raw | ConvertFrom-Json
+    Assert-That 'three stable samples pass without median or outlier removal' (
+        $stableReport.allRowsStable -eq $true -and
+        $stableReport.calculation -eq '(maximum / minimum - 1) * 100' -and
+        $stableReport.platform -eq 'Standalone IL2CPP x64 Release (WindowsPlayer; Unity 6000.3.16f1)' -and
+        $stableReport.commit -eq 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' -and
+        @($stableReport.rows).Count -eq 9
+    )
+
+    $unstableFixturePath = Join-Path $fixtureRoot 'unstable-artifacts'
+    New-Item -ItemType Directory -Force -Path $unstableFixturePath | Out-Null
+    New-StabilityFixture `
+        -Path $unstableFixturePath `
+        -RunValues @(1000000, 1010000, 1050000) `
+        -Scenarios $scenarios
+    & $stabilityScriptPath -ArtifactsPath $unstableFixturePath
+    $unstableReportPath = Join-Path $unstableFixturePath 'same-player-repeats/same-player-stability.json'
+    $unstableReport = Get-Content -LiteralPath $unstableReportPath -Raw | ConvertFrom-Json
+    Assert-That 'an unstable spread remains a successful evidence verdict' (
+        $unstableReport.allRowsStable -eq $false -and
+        @($unstableReport.rows | Where-Object { $_.withinMaterialityBand -eq $false }).Count -eq 9
+    )
+
+    $invalidEvidencePath = Join-Path $unstableFixturePath 'same-player-repeats/same-player-evidence.json'
+    $invalidEvidence = Get-Content -LiteralPath $invalidEvidencePath -Raw | ConvertFrom-Json
+    $invalidEvidence.runs[1].processorAffinityMask = ''
+    Write-TestJson -Path $invalidEvidencePath -Value $invalidEvidence
+    $invalidFailed = $false
+    try {
+        & $stabilityScriptPath -ArtifactsPath $unstableFixturePath
+    } catch {
+        $invalidFailed = $_.Exception.Message.Contains('did not record its actual processor affinity')
+    }
+    Assert-That 'malformed process evidence fails closed' $invalidFailed
+
+    $invalidEvidence.runs[1].processorAffinityMask = '0x3'
+    $invalidEvidence.playerDirectoryManifestAfter.files[0].sha256 = 'E' * 64
+    Write-TestJson -Path $invalidEvidencePath -Value $invalidEvidence
+    $identityMismatchFailed = $false
+    try {
+        & $stabilityScriptPath -ArtifactsPath $unstableFixturePath
+    } catch {
+        $identityMismatchFailed = $_.Exception.Message.Contains('manifest entry 0 is missing, invalid, or changed')
+    }
+    Assert-That 'the gate independently rejects a changed player manifest entry' $identityMismatchFailed
+
+    New-StabilityFixture `
+        -Path $unstableFixturePath `
+        -RunValues @(1000000, 1010000, 1020000) `
+        -Scenarios $scenarios
+    $invalidEvidence = Get-Content -LiteralPath $invalidEvidencePath -Raw | ConvertFrom-Json
+    $invalidEvidence.schemaVersion = 2
+    Write-TestJson -Path $invalidEvidencePath -Value $invalidEvidence
+    Assert-StabilityGateFails `
+        -Description 'the aggregate evidence schema fails closed' `
+        -ArtifactsPath $unstableFixturePath `
+        -ExpectedMessage 'Expected same-player evidence schemaVersion 1'
+
+    New-StabilityFixture `
+        -Path $unstableFixturePath `
+        -RunValues @(1000000, 1010000, 1020000) `
+        -Scenarios $scenarios
+    $invalidEvidence = Get-Content -LiteralPath $invalidEvidencePath -Raw | ConvertFrom-Json
+    $invalidEvidence.runs[1].resultsPath = 'same-player-repeats/run-02/wrong.xml'
+    Write-TestJson -Path $invalidEvidencePath -Value $invalidEvidence
+    Assert-StabilityGateFails `
+        -Description 'noncanonical managed repeat paths fail closed' `
+        -ArtifactsPath $unstableFixturePath `
+        -ExpectedMessage 'did not use its exact managed evidence paths'
+
+    New-StabilityFixture `
+        -Path $unstableFixturePath `
+        -RunValues @(1000000, 1010000, 1020000) `
+        -Scenarios $scenarios
+    $invalidEvidence = Get-Content -LiteralPath $invalidEvidencePath -Raw | ConvertFrom-Json
+    $invalidEvidence.runs[1].timedOut = $true
+    Write-TestJson -Path $invalidEvidencePath -Value $invalidEvidence
+    Assert-StabilityGateFails `
+        -Description 'a timed-out player remains valid NUnit output but fails stability evidence' `
+        -ArtifactsPath $unstableFixturePath `
+        -ExpectedMessage 'timed out and cannot support stability evidence'
+
+    New-StabilityFixture `
+        -Path $unstableFixturePath `
+        -RunValues @(1000000, 1010000, 1020000) `
+        -Scenarios $scenarios
+    $hostPath = Join-Path $unstableFixturePath 'same-player-repeats/run-02-host-conditions.json'
+    $invalidHost = Get-Content -LiteralPath $hostPath -Raw | ConvertFrom-Json
+    $invalidHost.schemaVersion = 2
+    Write-TestJson -Path $hostPath -Value $invalidHost
+    Assert-StabilityGateFails `
+        -Description 'the per-run host schema fails closed' `
+        -ArtifactsPath $unstableFixturePath `
+        -ExpectedMessage 'host evidence does not match its run record'
+
+    New-StabilityFixture `
+        -Path $unstableFixturePath `
+        -RunValues @(1000000, 1010000, 1020000) `
+        -Scenarios $scenarios
+    $invalidHost = Get-Content -LiteralPath $hostPath -Raw | ConvertFrom-Json
+    $invalidHost.after.timestampUtc = (
+        [DateTimeOffset]::Parse([string]$invalidHost.before.timestampUtc).AddMinutes(-1).ToString('O')
+    )
+    Write-TestJson -Path $hostPath -Value $invalidHost
+    Assert-StabilityGateFails `
+        -Description 'reversed before and after timestamps fail closed' `
+        -ArtifactsPath $unstableFixturePath `
+        -ExpectedMessage 'recorded its before snapshot after its after snapshot'
+
+    New-StabilityFixture `
+        -Path $unstableFixturePath `
+        -RunValues @(1000000, 1010000, 1020000) `
+        -Scenarios $scenarios
+    $thirdRunPath = Join-Path $unstableFixturePath 'same-player-repeats/run-03/repeat-03-results.xml'
+    $thirdRunText = Get-Content -LiteralPath $thirdRunPath -Raw
+    $thirdRunText = $thirdRunText.Replace(
+        'Standalone IL2CPP x64 Release (WindowsPlayer; Unity 6000.3.16f1)',
+        'Standalone IL2CPP x64 Debug (WindowsPlayer; Unity 6000.3.16f1)'
+    )
+    [System.IO.File]::WriteAllText($thirdRunPath, $thirdRunText)
+    Assert-StabilityGateFails `
+        -Description 'a non-Release repeat platform fails closed' `
+        -ArtifactsPath $unstableFixturePath `
+        -ExpectedMessage 'recorded a non-published platform'
+
+    New-StabilityFixture `
+        -Path $unstableFixturePath `
+        -RunValues @(1000000, 1010000, 1020000) `
+        -Scenarios $scenarios
+    $thirdRunText = Get-Content -LiteralPath $thirdRunPath -Raw
+    $thirdRunText = $thirdRunText.Replace(
+        'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+    )
+    [System.IO.File]::WriteAllText($thirdRunPath, $thirdRunText)
+    Assert-StabilityGateFails `
+        -Description 'a different measured commit in one repeat fails closed' `
+        -ArtifactsPath $unstableFixturePath `
+        -ExpectedMessage 'did not preserve one platform and measured commit'
+} finally {
+    if (Test-Path -LiteralPath $fixtureRoot -PathType Container) {
+        Remove-Item -LiteralPath $fixtureRoot -Recurse -Force
+    }
+}
+
+Write-Host 'same-player repeat evidence tests passed'

--- a/scripts/unity/__tests__/same-player-repeat-evidence.test.ps1
+++ b/scripts/unity/__tests__/same-player-repeat-evidence.test.ps1
@@ -245,9 +245,24 @@ try {
     Assert-That 'the process helper returns success and a process id' (
         $processResult.ExitCode -eq 0 -and $processResult.ProcessId -gt 0
     )
-    Assert-That 'the process helper captures actual child affinity' (
-        -not [string]::IsNullOrWhiteSpace([string]$processResult.ProcessorAffinityMask)
+    $hasProcessorAffinity = -not [string]::IsNullOrWhiteSpace(
+        [string]$processResult.ProcessorAffinityMask
     )
+    $hasProcessorAffinityError = -not [string]::IsNullOrWhiteSpace(
+        [string]$processResult.ProcessorAffinityError
+    )
+    if ($IsMacOS) {
+        # Investigation 2026-08-25: macOS does not implement Process.ProcessorAffinity.
+        # Require its explicit probe error here; the Windows-only evidence gate below still
+        # rejects a missing affinity value, and Windows/Linux test hosts require the real value.
+        Assert-That 'the macOS process helper captures its platform affinity probe error' (
+            -not $hasProcessorAffinity -and $hasProcessorAffinityError
+        )
+    } else {
+        Assert-That 'the process helper captures actual child affinity' (
+            $hasProcessorAffinity -and -not $hasProcessorAffinityError
+        )
+    }
 
     $runnerText = Get-Content -LiteralPath $runnerPath -Raw
     $buildIndex = $runnerText.IndexOf('$buildResult = Invoke-ProcessWithTreeKillTimeout')

--- a/scripts/unity/__tests__/same-player-repeat-evidence.test.ps1.meta
+++ b/scripts/unity/__tests__/same-player-repeat-evidence.test.ps1.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 41bf2e528cef44139db38995b12327ea
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/scripts/unity/require-same-player-stability.ps1
+++ b/scripts/unity/require-same-player-stability.ps1
@@ -1,0 +1,326 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Validates repeated launches of one Standalone comparison player.
+
+.DESCRIPTION
+    Verifies the complete player directory manifest, per-run results,
+    processor-affinity evidence, and host-condition probes. Writes JSON and
+    Markdown reports for the nine DxMessaging comparison rows. A max/min spread
+    above the materiality band is reported as a warning and retained as evidence;
+    malformed evidence fails.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateScript({ Test-Path -LiteralPath $_ -PathType Container })]
+    [string]$ArtifactsPath,
+
+    [ValidateRange(2, 10)]
+    [int]$ExpectedRunCount = 3,
+
+    [ValidateRange(0.01, 100.0)]
+    [double]$MaterialityBandPercent = 3.0
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$resolvedArtifactsPath = (Resolve-Path -LiteralPath $ArtifactsPath).Path
+$repeatRoot = Join-Path $resolvedArtifactsPath 'same-player-repeats'
+$evidencePath = Join-Path $repeatRoot 'same-player-evidence.json'
+if (-not (Test-Path -LiteralPath $evidencePath -PathType Leaf)) {
+    throw "Same-player evidence was not written to $evidencePath."
+}
+
+$evidence = Get-Content -LiteralPath $evidencePath -Raw | ConvertFrom-Json
+if ($evidence.schemaVersion -ne 1) {
+    throw "Expected same-player evidence schemaVersion 1; found '$($evidence.schemaVersion)'."
+}
+$runs = @($evidence.runs)
+if ($evidence.runCount -ne $ExpectedRunCount -or $runs.Count -ne $ExpectedRunCount) {
+    throw "Expected $ExpectedRunCount same-player launches; evidence recorded runCount=$($evidence.runCount), records=$($runs.Count)."
+}
+$expectedRunIndexes = 1..$ExpectedRunCount
+if ((@($runs | ForEach-Object { $_.runIndex }) -join ',') -ne ($expectedRunIndexes -join ',')) {
+    throw "Same-player evidence did not record the exact run sequence $($expectedRunIndexes -join ',')."
+}
+if (
+    $evidence.canonicalPublishedRunIndex -ne 1 -or
+    $evidence.playerDirectoryManifestMatches -ne $true
+) {
+    throw 'Same-player evidence did not preserve canonical run 1 with an unchanged player directory manifest.'
+}
+$manifestBefore = $evidence.playerDirectoryManifestBefore
+$manifestAfter = $evidence.playerDirectoryManifestAfter
+if (
+    $manifestBefore.schemaVersion -ne 1 -or
+    $manifestAfter.schemaVersion -ne 1
+) {
+    throw 'Player directory manifests must use schemaVersion 1.'
+}
+$beforeFiles = @($manifestBefore.files)
+$afterFiles = @($manifestAfter.files)
+if (
+    $manifestBefore.fileCount -ne $beforeFiles.Count -or
+    $manifestAfter.fileCount -ne $afterFiles.Count -or
+    $beforeFiles.Count -eq 0 -or
+    $beforeFiles.Count -ne $afterFiles.Count
+) {
+    throw 'Player directory manifests have missing or inconsistent file counts.'
+}
+for ($manifestIndex = 0; $manifestIndex -lt $beforeFiles.Count; $manifestIndex++) {
+    $beforeFile = $beforeFiles[$manifestIndex]
+    $afterFile = $afterFiles[$manifestIndex]
+    $relativePath = [string]$beforeFile.path
+    if (
+        [string]::IsNullOrWhiteSpace($relativePath) -or
+        $relativePath.Contains('\') -or
+        [System.IO.Path]::IsPathRooted($relativePath) -or
+        $relativePath -match '(^|/)\.\.(/|$)' -or
+        [string]$afterFile.path -cne $relativePath -or
+        [long]$beforeFile.length -lt 0 -or
+        [long]$afterFile.length -ne [long]$beforeFile.length -or
+        [string]$beforeFile.sha256 -notmatch '^[0-9A-Fa-f]{64}$' -or
+        [string]$afterFile.sha256 -cne [string]$beforeFile.sha256
+    ) {
+        throw "Player directory manifest entry $manifestIndex is missing, invalid, or changed."
+    }
+    if (
+        $manifestIndex -gt 0 -and
+        [System.StringComparer]::Ordinal.Compare(
+            [string]$beforeFiles[$manifestIndex - 1].path,
+            $relativePath
+        ) -ge 0
+    ) {
+        throw 'Player directory manifest paths are not unique and ordinal-sorted.'
+    }
+}
+
+foreach ($runRecord in $runs) {
+    $runIndex = [int]$runRecord.runIndex
+    $runNumber = '{0:D2}' -f $runIndex
+    $expectedResultsPath = if ($runIndex -eq 1) {
+        'results.xml'
+    } else {
+        "same-player-repeats/run-$runNumber/repeat-$runNumber-results.xml"
+    }
+    $expectedPlayerLogPath = if ($runIndex -eq 1) {
+        'player.log'
+    } else {
+        "same-player-repeats/run-$runNumber/repeat-$runNumber-player.log"
+    }
+    $expectedHostConditionsFile = "run-$runNumber-host-conditions.json"
+    if (
+        [string]$runRecord.resultsPath -cne $expectedResultsPath -or
+        [string]$runRecord.playerLogPath -cne $expectedPlayerLogPath -or
+        [string]$runRecord.hostConditionsFile -cne $expectedHostConditionsFile
+    ) {
+        throw "Player run $runIndex did not use its exact managed evidence paths."
+    }
+    if ([int]$runRecord.processId -le 0) {
+        throw "Player run $runIndex did not record its process id."
+    }
+    if ([string]::IsNullOrWhiteSpace([string]$runRecord.processorAffinityMask)) {
+        throw "Player run $runIndex did not record its actual processor affinity."
+    }
+    if ($runRecord.timedOut -ne $false) {
+        throw "Player run $runIndex timed out and cannot support stability evidence."
+    }
+    $resultPath = Join-Path $resolvedArtifactsPath ([string]$runRecord.resultsPath)
+    if (-not (Test-Path -LiteralPath $resultPath -PathType Leaf)) {
+        throw "Player run $runIndex results were not written to $resultPath."
+    }
+    $playerLogPath = Join-Path $resolvedArtifactsPath ([string]$runRecord.playerLogPath)
+    if (-not (Test-Path -LiteralPath $playerLogPath -PathType Leaf)) {
+        throw "Player run $runIndex log was not written to $playerLogPath."
+    }
+    $hostPath = Join-Path $repeatRoot ([string]$runRecord.hostConditionsFile)
+    if (-not (Test-Path -LiteralPath $hostPath -PathType Leaf)) {
+        throw "Player run $runIndex host conditions were not written to $hostPath."
+    }
+    $hostConditions = Get-Content -LiteralPath $hostPath -Raw | ConvertFrom-Json
+    if (
+        $hostConditions.schemaVersion -ne 1 -or
+        $hostConditions.runIndex -ne $runIndex -or
+        $hostConditions.runCount -ne $ExpectedRunCount -or
+        $hostConditions.playerProcessId -ne $runRecord.processId -or
+        $hostConditions.playerProcessorAffinityMask -ne $runRecord.processorAffinityMask -or
+        $hostConditions.timedOut -ne $false
+    ) {
+        throw "Player run $runIndex host evidence does not match its run record or records a timeout."
+    }
+    $snapshotTimestamps = @{}
+    foreach ($expectedPhase in @('before', 'after')) {
+        $snapshot = $hostConditions.$expectedPhase
+        $timestamp = [DateTimeOffset]::MinValue
+        if (
+            $null -eq $snapshot -or
+            $snapshot.phase -ne $expectedPhase -or
+            -not [DateTimeOffset]::TryParse([string]$snapshot.timestampUtc, [ref]$timestamp)
+        ) {
+            throw "Player run $runIndex has invalid $expectedPhase snapshot timing evidence."
+        }
+        $snapshotTimestamps[$expectedPhase] = $timestamp
+        $logicalProcessors = @($snapshot.logicalProcessors)
+        $processors = @($snapshot.processors)
+        $logicalFrequencyCount = @(
+            $logicalProcessors | Where-Object { $_.frequencyMhz -gt 0 }
+        ).Count
+        $packageFrequencyCount = @(
+            $processors | Where-Object { $_.currentClockMhz -gt 0 }
+        ).Count
+        if ($logicalFrequencyCount -eq 0 -and $packageFrequencyCount -eq 0) {
+            throw "Player run $runIndex did not record active CPU frequency around the run."
+        }
+        $logicalLoadCount = @(
+            $logicalProcessors | Where-Object { $null -ne $_.loadPercent }
+        ).Count
+        $packageLoadCount = @(
+            $processors | Where-Object { $null -ne $_.loadPercent }
+        ).Count
+        if (
+            $null -eq $snapshot.totalCpuLoadPercent -and
+            $logicalLoadCount -eq 0 -and
+            $packageLoadCount -eq 0
+        ) {
+            throw "Player run $runIndex did not record host CPU load around the run."
+        }
+        if ($null -eq $snapshot.acpiThermalZones -or $null -eq $snapshot.acpiThermalZones.available) {
+            throw "Player run $runIndex did not record the thermal probe result."
+        }
+    }
+    if ($snapshotTimestamps.before -gt $snapshotTimestamps.after) {
+        throw "Player run $runIndex recorded its before snapshot after its after snapshot."
+    }
+}
+
+$canonicalCollisions = @(
+    Get-ChildItem -LiteralPath $repeatRoot -File -Recurse |
+        Where-Object { $_.Name -in @('results.xml', 'player.log') }
+)
+if ($canonicalCollisions.Count -gt 0) {
+    throw 'Diagnostic repeats used canonical publication filenames.'
+}
+
+$scenarioModulePath = Join-Path $PSScriptRoot 'perf-scenarios.js'
+$expectedDxScenarios = @(
+    & node -e "require(process.argv[1]).COMPARISON_SCENARIO_ORDER.forEach((scenario) => console.log('Comparison_DxMessaging_' + scenario))" $scenarioModulePath
+)
+if ($LASTEXITCODE -ne 0 -or $expectedDxScenarios.Count -eq 0) {
+    throw 'Could not resolve the expected DxMessaging comparison scenarios.'
+}
+
+$extractorPath = Join-Path $PSScriptRoot 'extract-perf-baseline.js'
+$measurements = @{}
+$measuredPlatform = $null
+$measuredCommit = $null
+foreach ($runRecord in $runs) {
+    $resultPath = Join-Path $resolvedArtifactsPath ([string]$runRecord.resultsPath)
+    $csvPath = Join-Path $repeatRoot ('run-{0:D2}.csv' -f [int]$runRecord.runIndex)
+    & node $extractorPath `
+        --input $resultPath `
+        --scope Standalone `
+        --output $csvPath `
+        --replace
+    if ($LASTEXITCODE -ne 0) {
+        throw "Could not extract player run $($runRecord.runIndex) into $csvPath."
+    }
+    $rows = @(Import-Csv -LiteralPath $csvPath)
+    foreach ($scenario in $expectedDxScenarios) {
+        $matchingRows = @($rows | Where-Object { $_.scenario -eq $scenario })
+        if ($matchingRows.Count -ne 1) {
+            throw "Player run $($runRecord.runIndex) recorded $($matchingRows.Count) rows for $scenario."
+        }
+        $rowPlatform = [string]$matchingRows[0].platform
+        $rowCommit = [string]$matchingRows[0].commit
+        if ($rowPlatform -notmatch '^Standalone IL2CPP x64 Release \(WindowsPlayer; Unity [^)]+\)$') {
+            throw "Player run $($runRecord.runIndex) recorded a non-published platform for ${scenario}: '$rowPlatform'."
+        }
+        if ([string]::IsNullOrWhiteSpace($rowCommit)) {
+            throw "Player run $($runRecord.runIndex) did not record the measured commit for $scenario."
+        }
+        if ($null -eq $measuredPlatform) {
+            $measuredPlatform = $rowPlatform
+            $measuredCommit = $rowCommit
+        } elseif ($rowPlatform -cne $measuredPlatform -or $rowCommit -cne $measuredCommit) {
+            throw "Player run $($runRecord.runIndex) did not preserve one platform and measured commit across repeat rows."
+        }
+        if (-not $measurements.ContainsKey($scenario)) {
+            $measurements[$scenario] = New-Object System.Collections.Generic.List[double]
+        }
+        $value = [double]::Parse(
+            $matchingRows[0].emitsPerSecond,
+            [Globalization.CultureInfo]::InvariantCulture
+        )
+        $measurements[$scenario].Add($value)
+    }
+}
+
+$reportRows = New-Object System.Collections.Generic.List[object]
+$markdown = New-Object System.Collections.Generic.List[string]
+$markdown.Add('# Same-player comparison stability')
+$markdown.Add('')
+$markdown.Add(
+    "Materiality band: maximum/minimum spread <= $($MaterialityBandPercent.ToString('F2', [Globalization.CultureInfo]::InvariantCulture))%. No median or outlier removal."
+)
+$markdown.Add('')
+$runHeaders = @($expectedRunIndexes | ForEach-Object { "Run $_" })
+$markdown.Add("| Scenario | $($runHeaders -join ' | ') | Max/min spread | Gate |")
+$markdown.Add("| --- | $(@($expectedRunIndexes | ForEach-Object { '---:' }) -join ' | ') | ---: | --- |")
+$allStable = $true
+foreach ($scenario in $expectedDxScenarios) {
+    $samples = @($measurements[$scenario].ToArray())
+    if (
+        $samples.Count -ne $ExpectedRunCount -or
+        @($samples | Where-Object { $_ -le 0 }).Count -gt 0
+    ) {
+        throw "$scenario did not produce $ExpectedRunCount positive throughput samples."
+    }
+    $minimum = [double]($samples | Measure-Object -Minimum).Minimum
+    $maximum = [double]($samples | Measure-Object -Maximum).Maximum
+    $spreadPercent = (($maximum / $minimum) - 1.0) * 100.0
+    $stable = $spreadPercent -le $MaterialityBandPercent
+    $allStable = $allStable -and $stable
+    $displayName = $scenario.Substring('Comparison_DxMessaging_'.Length)
+    $gate = if ($stable) { 'Pass' } else { 'Fail' }
+    $reportRows.Add([ordered]@{
+            scenario = $displayName
+            emitsPerSecond = $samples
+            minimum = $minimum
+            maximum = $maximum
+            maxMinSpreadPercent = $spreadPercent
+            withinMaterialityBand = $stable
+        })
+    $sampleCells = @($samples | ForEach-Object { $_.ToString('N0') })
+    $markdown.Add(
+        "| $displayName | $($sampleCells -join ' | ') | $($spreadPercent.ToString('N2'))% | $gate |"
+    )
+}
+
+$report = [ordered]@{
+    schemaVersion = 1
+    materialityBandPercent = $MaterialityBandPercent
+    calculation = '(maximum / minimum - 1) * 100'
+    platform = $measuredPlatform
+    commit = $measuredCommit
+    allRowsStable = $allStable
+    rows = @($reportRows.ToArray())
+}
+$utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+[IO.File]::WriteAllText(
+    (Join-Path $repeatRoot 'same-player-stability.json'),
+    ($report | ConvertTo-Json -Depth 8) + "`n",
+    $utf8NoBom
+)
+[IO.File]::WriteAllText(
+    (Join-Path $repeatRoot 'same-player-stability.md'),
+    ($markdown -join "`n") + "`n",
+    $utf8NoBom
+)
+if ($allStable) {
+    Write-Host "All same-player DxMessaging comparison rows stayed inside the $MaterialityBandPercent% band."
+} else {
+    Write-Host "::warning::At least one same-player DxMessaging comparison row exceeded the $MaterialityBandPercent% band; retain the report as an instability verdict."
+}
+Write-Host "Verified $ExpectedRunCount launches of one comparison player with host-condition evidence."

--- a/scripts/unity/require-same-player-stability.ps1.meta
+++ b/scripts/unity/require-same-player-stability.ps1.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 7cb29f627b9c4c75a7d9a902b483408f
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/scripts/unity/run-ci-tests.ps1
+++ b/scripts/unity/run-ci-tests.ps1
@@ -36,6 +36,9 @@ param(
 
     [switch]$ReleasePlayerBuild,
 
+    [ValidateRange(1, 10)]
+    [int]$StandalonePlayerRunCount = 1,
+
     [ValidateSet('Local', 'Central')]
     [string]$LicenseReturnOwner = 'Local',
 
@@ -2472,6 +2475,174 @@ function Get-StandaloneBuildTimeoutSeconds {
     return $Default
 }
 
+function Get-StandaloneHostConditionSnapshot {
+    # Capture host conditions OUTSIDE the benchmark player so the probes never
+    # execute inside a scenario's warmed five-second window. Every probe is
+    # best-effort: missing thermal firmware or a rejected CIM query is evidence,
+    # not a reason to discard an otherwise valid player run.
+    param([Parameter(Mandatory = $true)][string]$Phase)
+
+    $errors = New-Object System.Collections.Generic.List[string]
+    $logicalProcessors = New-Object System.Collections.Generic.List[object]
+    try {
+        $processorInformation = @(
+            Get-CimInstance `
+                -ClassName Win32_PerfFormattedData_Counters_ProcessorInformation `
+                -ErrorAction Stop
+        )
+        foreach ($logicalProcessor in $processorInformation) {
+            if ([string]$logicalProcessor.Name -notlike '*_Total') {
+                $logicalProcessors.Add([ordered]@{
+                        name = [string]$logicalProcessor.Name
+                        frequencyMhz = $logicalProcessor.ProcessorFrequency
+                        percentProcessorPerformance = $logicalProcessor.PercentProcessorPerformance
+                        loadPercent = $logicalProcessor.PercentProcessorTime
+                    })
+            }
+        }
+    } catch {
+        $errors.Add("Win32_PerfFormattedData_Counters_ProcessorInformation: $($_.Exception.Message)")
+    }
+
+    $processors = New-Object System.Collections.Generic.List[object]
+    try {
+        $processorInstances = @(Get-CimInstance -ClassName Win32_Processor -ErrorAction Stop)
+        for ($index = 0; $index -lt $processorInstances.Count; $index++) {
+            $processor = $processorInstances[$index]
+            $processors.Add([ordered]@{
+                    index = $index
+                    currentClockMhz = $processor.CurrentClockSpeed
+                    maxClockMhz = $processor.MaxClockSpeed
+                    loadPercent = $processor.LoadPercentage
+                    logicalProcessors = $processor.NumberOfLogicalProcessors
+                })
+        }
+    } catch {
+        $errors.Add("Win32_Processor: $($_.Exception.Message)")
+    }
+
+    $totalCpuLoadPercent = $null
+    try {
+        $cpuTotals = @(
+            Get-CimInstance `
+                -ClassName Win32_PerfFormattedData_PerfOS_Processor `
+                -Filter "Name='_Total'" `
+                -ErrorAction Stop
+        )
+        if ($cpuTotals.Count -gt 0) {
+            $totalCpuLoadPercent = $cpuTotals[0].PercentProcessorTime
+        }
+    } catch {
+        $errors.Add("Win32_PerfFormattedData_PerfOS_Processor: $($_.Exception.Message)")
+    }
+
+    $thermalRecords = New-Object System.Collections.Generic.List[object]
+    try {
+        $thermalZones = @(
+            Get-CimInstance `
+                -Namespace 'root/wmi' `
+                -ClassName MSAcpi_ThermalZoneTemperature `
+                -ErrorAction Stop
+        )
+        foreach ($thermalZone in $thermalZones) {
+            if ($null -ne $thermalZone.CurrentTemperature) {
+                $rawTemperature = [double]$thermalZone.CurrentTemperature
+                $temperature = ($rawTemperature / 10.0) - 273.15
+                $thermalRecords.Add([ordered]@{
+                        instanceName = [string]$thermalZone.InstanceName
+                        rawTenthsKelvin = $rawTemperature
+                        celsius = [math]::Round($temperature, 2)
+                    })
+            }
+        }
+    } catch {
+        $errors.Add("MSAcpi_ThermalZoneTemperature: $($_.Exception.Message)")
+    }
+
+    $harnessAffinity = $null
+    try {
+        $currentProcess = [System.Diagnostics.Process]::GetCurrentProcess()
+        $harnessAffinity = '0x{0:X}' -f $currentProcess.ProcessorAffinity.ToInt64()
+        $currentProcess.Dispose()
+    } catch {
+        $errors.Add("harness processor affinity: $($_.Exception.Message)")
+    }
+
+    return [ordered]@{
+        phase = $Phase
+        timestampUtc = [DateTime]::UtcNow.ToString('O')
+        processorCount = [Environment]::ProcessorCount
+        harnessProcessorAffinityMask = $harnessAffinity
+        logicalProcessors = @($logicalProcessors.ToArray())
+        processors = @($processors.ToArray())
+        totalCpuLoadPercent = $totalCpuLoadPercent
+        acpiThermalZones = [ordered]@{
+            available = $thermalRecords.Count -gt 0
+            zones = @($thermalRecords.ToArray())
+        }
+        probeErrors = @($errors.ToArray())
+    }
+}
+
+function Get-StandalonePlayerManifest {
+    # Hash every file present under the built player directory. Capturing the
+    # complete manifest before the first launch and after the last detects any
+    # changed, added, or removed player file without claiming which subset alone
+    # defines the launched IL2CPP program.
+    param([Parameter(Mandatory = $true)][string]$ExecutablePath)
+
+    if (-not (Test-Path -LiteralPath $ExecutablePath -PathType Leaf)) {
+        throw "Standalone player executable was not found at $ExecutablePath."
+    }
+    $playerDirectory = Split-Path -Parent $ExecutablePath
+    $files = @(Get-ChildItem -LiteralPath $playerDirectory -File -Recurse -Force)
+    if ($files.Count -eq 0) {
+        throw "Standalone player directory contains no files at $playerDirectory."
+    }
+
+    $filesByRelativePath = [System.Collections.Generic.Dictionary[string, System.IO.FileInfo]]::new(
+        [System.StringComparer]::Ordinal
+    )
+    foreach ($file in $files) {
+        $relativePath = $file.FullName.Substring($playerDirectory.Length).TrimStart(
+            [System.IO.Path]::DirectorySeparatorChar,
+            [System.IO.Path]::AltDirectorySeparatorChar
+        ).Replace('\', '/')
+        $filesByRelativePath.Add($relativePath, $file)
+    }
+    $relativePaths = [string[]]@($filesByRelativePath.Keys)
+    [Array]::Sort($relativePaths, [System.StringComparer]::Ordinal)
+    $entries = New-Object System.Collections.Generic.List[object]
+    foreach ($relativePath in $relativePaths) {
+        $file = $filesByRelativePath[$relativePath]
+        $entries.Add([ordered]@{
+                path = $relativePath
+                length = [long]$file.Length
+                sha256 = (Get-FileHash -LiteralPath $file.FullName -Algorithm SHA256).Hash
+            })
+    }
+    return [ordered]@{
+        schemaVersion = 1
+        fileCount = $entries.Count
+        files = @($entries.ToArray())
+    }
+}
+
+function Write-JsonArtifact {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)]$Value
+    )
+
+    $directory = Split-Path -Parent $Path
+    if ($directory -and -not (Test-Path -LiteralPath $directory -PathType Container)) {
+        New-Item -ItemType Directory -Force -Path $directory | Out-Null
+    }
+    $json = $Value | ConvertTo-Json -Depth 10
+    $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+    [System.IO.File]::WriteAllText($Path, $json + "`n", $utf8NoBom)
+}
+
 function ConvertTo-ProcessArgumentLine {
     # MIRROR of scripts/unity/ensure-editor.ps1 ConvertTo-ProcessArgumentLine
     # (run-ci-tests.ps1 does not import that script, so the helper is copied here
@@ -2594,6 +2765,9 @@ function Invoke-ProcessWithTreeKillTimeout {
     $exit = -1
     $timedOut = $false
     $reaped = $false
+    $processId = $null
+    $processorAffinityMask = $null
+    $processorAffinityError = $null
     try {
         $psi = New-Object System.Diagnostics.ProcessStartInfo
         $psi.FileName = $FilePath
@@ -2607,6 +2781,12 @@ function Invoke-ProcessWithTreeKillTimeout {
         $proc.StartInfo = $psi
 
         [void]$proc.Start()
+        $processId = $proc.Id
+        try {
+            $processorAffinityMask = '0x{0:X}' -f $proc.ProcessorAffinity.ToInt64()
+        } catch {
+            $processorAffinityError = $_.Exception.Message
+        }
 
         $outReader = $proc.StandardOutput
         $errReader = $proc.StandardError
@@ -2716,6 +2896,9 @@ function Invoke-ProcessWithTreeKillTimeout {
     return @{
         ExitCode = $exit
         TimedOut = [bool]$timedOut
+        ProcessId = $processId
+        ProcessorAffinityMask = $processorAffinityMask
+        ProcessorAffinityError = $processorAffinityError
     }
 }
 
@@ -2737,7 +2920,10 @@ function Invoke-StandaloneTestPlayer {
         [Parameter(Mandatory = $true)][string]$EditorBuiltExePath,
         [Parameter(Mandatory = $true)][string]$ResultsPath,
         [Parameter(Mandatory = $true)][string]$LogPath,
-        [int]$TimeoutSeconds = 1800
+        [int]$TimeoutSeconds = 1800,
+        [string]$HostConditionEvidencePath,
+        [int]$RunIndex = 1,
+        [int]$RunCount = 1
     )
 
     $playerArgs = @(
@@ -2747,12 +2933,34 @@ function Invoke-StandaloneTestPlayer {
         '-dxmTestResults', $ResultsPath
     )
 
+    $before = $null
+    if (-not [string]::IsNullOrWhiteSpace($HostConditionEvidencePath)) {
+        $before = Get-StandaloneHostConditionSnapshot -Phase 'before'
+    }
+
     $result = Invoke-ProcessWithTreeKillTimeout `
         -FilePath $EditorBuiltExePath `
         -Arguments $playerArgs `
         -TimeoutSeconds $TimeoutSeconds `
         -LogPath $LogPath `
         -Label 'Run standalone test player'
+
+    if (-not [string]::IsNullOrWhiteSpace($HostConditionEvidencePath)) {
+        $after = Get-StandaloneHostConditionSnapshot -Phase 'after'
+        $evidence = [ordered]@{
+            schemaVersion = 1
+            runIndex = $RunIndex
+            runCount = $RunCount
+            playerProcessId = $result.ProcessId
+            playerProcessorAffinityMask = $result.ProcessorAffinityMask
+            playerProcessorAffinityError = $result.ProcessorAffinityError
+            exitCode = $result.ExitCode
+            timedOut = $result.TimedOut
+            before = $before
+            after = $after
+        }
+        Write-JsonArtifact -Path $HostConditionEvidencePath -Value $evidence
+    }
 
     # Exit 2 means the player received no -dxmTestResults arg (a harness-contract
     # violation -- the harness always passes it), so no file can exist: fail fast.
@@ -2765,7 +2973,13 @@ function Invoke-StandaloneTestPlayer {
     # in -batchmode -nographics IL2CPP; the watchdog then tree-kills it (TimedOut) even
     # though the results are valid. The caller validates the FILE (the source of truth)
     # and decides, so a deferred-quit run is not turned into a spurious failure.
-    return @{ ExitCode = $result.ExitCode; TimedOut = $result.TimedOut }
+    return @{
+        ExitCode = $result.ExitCode
+        TimedOut = $result.TimedOut
+        ProcessId = $result.ProcessId
+        ProcessorAffinityMask = $result.ProcessorAffinityMask
+        ProcessorAffinityError = $result.ProcessorAffinityError
+    }
 }
 
 function Invoke-UnityEditor {
@@ -3442,6 +3656,7 @@ Write-Host "LibraryState: $LibraryState"
 Write-Host "ArtifactsPath: $ArtifactsPath"
 Write-Host "IncludeComparisons: $IncludeComparisons"
 Write-Host "StandaloneScriptingBackend: $StandaloneScriptingBackend"
+Write-Host "StandalonePlayerRunCount: $StandalonePlayerRunCount"
 Write-Host "ReleasePlayerBuild: $UseReleasePlayerBuild"
 Write-Host "ReleaseCodeOptimization: $UseReleaseCodeOptimization"
 Write-Host "Manifest:"
@@ -3729,46 +3944,128 @@ try {
             }
         }
 
-        # Delete any STALE results file before the player runs, so the
-        # timeout-honors-file branch below can only honor results THIS player run
-        # wrote -- never a prior run's leftover. (Defensive for local re-runs against
-        # the same -ArtifactsPath; CI checkout already cleans the gitignored
-        # .artifacts tree per job.)
-        if (Test-Path -LiteralPath $resultsPath -PathType Leaf) {
-            Remove-Item -LiteralPath $resultsPath -Force
+        # (2b) RUN the built exe directly (no PlayerConnection), under the watchdog.
+        # Run 1 keeps the canonical filenames consumed by publication. Optional
+        # same-player repeats use deliberately noncanonical names under a diagnostic
+        # subdirectory, so recursive results.xml/player.log discovery cannot mix
+        # those observations into the published first run.
+        $playerTimeoutSeconds = Get-StandaloneTestPlayerTimeoutSeconds
+        $captureSamePlayerEvidence = $StandalonePlayerRunCount -gt 1
+        $samePlayerEvidenceRoot = Join-Path $ArtifactsPath 'same-player-repeats'
+        $playerManifestBefore = $null
+        $playerRunRecords = New-Object System.Collections.Generic.List[object]
+        if ($captureSamePlayerEvidence) {
+            if (Test-Path -LiteralPath $samePlayerEvidenceRoot -PathType Container) {
+                Remove-Item -LiteralPath $samePlayerEvidenceRoot -Recurse -Force
+            }
+            New-Item -ItemType Directory -Force -Path $samePlayerEvidenceRoot | Out-Null
+            $playerManifestBefore = Get-StandalonePlayerManifest -ExecutablePath $standaloneExe
         }
 
-        # (2b) RUN the built exe directly (no PlayerConnection), under the watchdog.
-        $playerTimeoutSeconds = Get-StandaloneTestPlayerTimeoutSeconds
-        $playerResult = Invoke-StandaloneTestPlayer `
-            -EditorBuiltExePath $standaloneExe `
-            -ResultsPath $resultsPath `
-            -LogPath $playerLogPath `
-            -TimeoutSeconds $playerTimeoutSeconds
-
-        # A watchdog timeout is fatal ONLY when the player wrote no results. If the
-        # results file exists, honor it as the source of truth (Application.Quit can be
-        # deferred in -batchmode -nographics IL2CPP after RunFinished already wrote the
-        # file) and fall through to Test-NUnitResults; otherwise fail with the timeout.
-        $playerExitForValidation = $playerResult.ExitCode
-        if ($playerResult.TimedOut) {
-            if (Test-Path -LiteralPath $resultsPath -PathType Leaf) {
-                Write-Host "::warning::Standalone test player exceeded the ${playerTimeoutSeconds}s watchdog and was tree-killed, but it had already written $resultsPath; honoring that results file as the source of truth (Application.Quit was likely deferred in -batchmode IL2CPP). Raise DXM_STANDALONE_PLAYER_TIMEOUT_SECONDS if this recurs."
-                # The inline timeout warning above is the single, correctly-phrased
-                # notice for this case; pass exit 0 to the validator so it does NOT
-                # re-warn and MISLABEL the watchdog timeout (sentinel 124) as a
-                # native shutdown crash.
-                $playerExitForValidation = 0
+        for ($playerRunIndex = 1; $playerRunIndex -le $StandalonePlayerRunCount; $playerRunIndex++) {
+            $runNumber = '{0:D2}' -f $playerRunIndex
+            if ($playerRunIndex -eq 1) {
+                $currentResultsPath = $resultsPath
+                $currentPlayerLogPath = $playerLogPath
             } else {
-                throw "Standalone test player timed out after $playerTimeoutSeconds second(s) and was tree-killed before writing any results to $resultsPath. Raise the limit via DXM_STANDALONE_PLAYER_TIMEOUT_SECONDS (0 disables the timeout). See the player log at $playerLogPath."
+                $currentRunDirectory = Join-Path $samePlayerEvidenceRoot "run-$runNumber"
+                New-Item -ItemType Directory -Force -Path $currentRunDirectory | Out-Null
+                $currentResultsPath = Join-Path $currentRunDirectory "repeat-$runNumber-results.xml"
+                $currentPlayerLogPath = Join-Path $currentRunDirectory "repeat-$runNumber-player.log"
+            }
+            $hostConditionEvidencePath = if ($captureSamePlayerEvidence) {
+                Join-Path $samePlayerEvidenceRoot "run-$runNumber-host-conditions.json"
+            } else {
+                ''
+            }
+
+            # Delete STALE per-run outputs first. A timeout can then honor only the
+            # file written by THIS launch, never a prior local run's leftover.
+            foreach ($staleOutputPath in @($currentResultsPath, $currentPlayerLogPath, $hostConditionEvidencePath)) {
+                if (
+                    -not [string]::IsNullOrWhiteSpace($staleOutputPath) -and
+                    (Test-Path -LiteralPath $staleOutputPath -PathType Leaf)
+                ) {
+                    Remove-Item -LiteralPath $staleOutputPath -Force
+                }
+            }
+
+            $playerResult = Invoke-StandaloneTestPlayer `
+                -EditorBuiltExePath $standaloneExe `
+                -ResultsPath $currentResultsPath `
+                -LogPath $currentPlayerLogPath `
+                -TimeoutSeconds $playerTimeoutSeconds `
+                -HostConditionEvidencePath $hostConditionEvidencePath `
+                -RunIndex $playerRunIndex `
+                -RunCount $StandalonePlayerRunCount
+
+            # A watchdog timeout is fatal ONLY when the player wrote no results. If
+            # results exist, validate them and treat deferred Application.Quit as a
+            # post-work shutdown condition rather than a benchmark failure.
+            $playerExitForValidation = $playerResult.ExitCode
+            if ($playerResult.TimedOut) {
+                if (Test-Path -LiteralPath $currentResultsPath -PathType Leaf) {
+                    Write-Host "::warning::Standalone test player run $playerRunIndex/$StandalonePlayerRunCount exceeded the ${playerTimeoutSeconds}s watchdog and was tree-killed, but it had already written $currentResultsPath; honoring that results file as the source of truth (Application.Quit was likely deferred in -batchmode IL2CPP). Raise DXM_STANDALONE_PLAYER_TIMEOUT_SECONDS if this recurs."
+                    # Pass exit 0 so the validator does not mislabel watchdog sentinel
+                    # 124 as a native shutdown crash.
+                    $playerExitForValidation = 0
+                } else {
+                    throw "Standalone test player run $playerRunIndex/$StandalonePlayerRunCount timed out after $playerTimeoutSeconds second(s) and was tree-killed before writing results to $currentResultsPath. Raise the limit via DXM_STANDALONE_PLAYER_TIMEOUT_SECONDS (0 disables the timeout). See the player log at $currentPlayerLogPath."
+                }
+            }
+
+            # (2c) VALIDATE every repeat independently. A later failed repeat cannot
+            # hide behind the canonical first run's passing results.xml.
+            Test-NUnitResults `
+                -Path $currentResultsPath `
+                -Label "Unity $UnityVersion standalone run $playerRunIndex/$StandalonePlayerRunCount" `
+                -LogPath $currentPlayerLogPath `
+                -Project $ProjectPath `
+                -UnityExitCode $playerExitForValidation
+
+            if ($captureSamePlayerEvidence) {
+                $relativeResultsPath = $currentResultsPath.Substring($ArtifactsPath.Length).TrimStart(
+                    [System.IO.Path]::DirectorySeparatorChar,
+                    [System.IO.Path]::AltDirectorySeparatorChar
+                ).Replace('\', '/')
+                $relativePlayerLogPath = $currentPlayerLogPath.Substring($ArtifactsPath.Length).TrimStart(
+                    [System.IO.Path]::DirectorySeparatorChar,
+                    [System.IO.Path]::AltDirectorySeparatorChar
+                ).Replace('\', '/')
+                $playerRunRecords.Add([ordered]@{
+                        runIndex = $playerRunIndex
+                        resultsPath = $relativeResultsPath
+                        playerLogPath = $relativePlayerLogPath
+                        hostConditionsFile = [System.IO.Path]::GetFileName($hostConditionEvidencePath)
+                        processId = $playerResult.ProcessId
+                        processorAffinityMask = $playerResult.ProcessorAffinityMask
+                        timedOut = $playerResult.TimedOut
+                    })
             }
         }
 
-        # (2c) VALIDATE the FILE (the source of truth). The player log carries the
-        # diagnostics for a missing/empty file (its stdout no longer flows through
-        # unity.log). The player exit code is advisory only: a valid passing file
-        # with a non-zero player exit gets a benign-crash ::warning::, not a failure.
-        Test-NUnitResults -Path $resultsPath -Label "Unity $UnityVersion standalone" -LogPath $playerLogPath -Project $ProjectPath -UnityExitCode $playerExitForValidation
+        if ($captureSamePlayerEvidence) {
+            $playerManifestAfter = Get-StandalonePlayerManifest -ExecutablePath $standaloneExe
+            $manifestBeforeJson = $playerManifestBefore | ConvertTo-Json -Depth 10 -Compress
+            $manifestAfterJson = $playerManifestAfter | ConvertTo-Json -Depth 10 -Compress
+            $playerDirectoryManifestMatches = $manifestBeforeJson -ceq $manifestAfterJson
+            $samePlayerEvidence = [ordered]@{
+                schemaVersion = 1
+                runCount = $StandalonePlayerRunCount
+                canonicalPublishedRunIndex = 1
+                playerDirectoryManifestMatches = $playerDirectoryManifestMatches
+                playerDirectoryManifestBefore = $playerManifestBefore
+                playerDirectoryManifestAfter = $playerManifestAfter
+                runs = @($playerRunRecords.ToArray())
+            }
+            Write-JsonArtifact `
+                -Path (Join-Path $samePlayerEvidenceRoot 'same-player-evidence.json') `
+                -Value $samePlayerEvidence
+            if (-not $playerDirectoryManifestMatches) {
+                throw 'Standalone player directory manifest changed between same-player repeats.'
+            }
+            Write-CiNotice "Standalone same-player evidence captured $StandalonePlayerRunCount validated launches with an unchanged player directory manifest."
+        }
     } else {
         # MUST NOT include '-quit' alongside '-runTests': per the Unity Editor manual
         # (https://docs.unity3d.com/Manual/EditorCommandLineArguments.html), if the


### PR DESCRIPTION
## Why

Three fresh-build controls on one host moved by 3.04% to 25.41%. That drift blocks attribution of a 3% runtime change for #414. The benchmark needs a same-build control before another runtime candidate is valid.

## What changed

The comparison job now builds one Standalone IL2CPP Release player and launches it three times. Only run 1 remains a publication input.

Each launch records host CPU conditions and the actual process affinity. A full player-directory manifest proves that all launches use unchanged files.

The evidence gate checks exact paths, schemas, timestamps, platform, commit, and every expected row. It reports the maximum/minimum spread without a median or outlier removal. A spread above 3% remains a warning verdict, not a performance regression.

## How we know

The full script suite passes 453 tests. The focused same-player regression passed ten consecutive runs. Stable, unstable, timed-out, malformed, and wrong-profile fixtures exercise the production evidence gate.

Two Unity MCP comparison runs each passed 25 tests with 20 unsupported cases skipped and no failures. Repository validation, strict docs, workflow lint, and pre-commit checks pass. The final adversarial review reported zero findings.

All current-head CI, Unity, performance, devcontainer, docs, and formatting workflows are green. Performance Numbers run [32876164110](https://github.com/Ambiguous-Interactive/DxMessaging/actions/runs/32876164110) produced three valid launches of the same unchanged 626-file player. Eight of nine DxMessaging rows exceeded the 3% band, with spreads from 6.58% to 11.85%; only `SubUnsub` stayed inside at 1.64%.

## What remains open

The experiment proves that the exact same player is unstable at runtime on this host. The #414 runtime-candidate gate remains closed. Follow-up work must stabilize the host or define a predeclared within-process paired protocol before another runtime optimization.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI perf gating and the Unity test runner’s standalone launch path; malformed evidence fails comparisons, but published numbers still come only from run 1.
> 
> **Overview**
> Comparison perf CI now **builds one Standalone IL2CPP Release player and launches it three times** instead of a single run. Run 1 still uses canonical `results.xml` / `player.log` for publication; runs 2–3 write under `same-player-repeats/` so published discovery cannot pick them up.
> 
> **`run-ci-tests.ps1`** gains `-StandalonePlayerRunCount`, a repeat loop around the existing player launch, full player-directory SHA-256 manifests before/after repeats, per-run host CPU/thermal snapshots outside benchmark windows, and process affinity capture from the process helper.
> 
> A new **`require-same-player-stability.ps1`** step (wired in **`perf-numbers.yml`** for the comparisons matrix) fail-closes on missing or malformed evidence and computes max/min throughput spread across all three runs for the nine DxMessaging comparison scenarios (3% materiality band). Spread above 3% emits a **warning** and records instability—it does not fail the job or count as a regression.
> 
> The perf benchmark runbook documents the methodology; **`unity-perf.test.js`** and **`same-player-repeat-evidence.test.ps1`** exercise the gate and helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d520908c61f6dd134199ccf3f0a4a870571f56e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->