### PR TITLE
Stop accepting shared benchmark drift as a speedup

### DIFF
--- a/.github/workflows/perf-numbers.yml
+++ b/.github/workflows/perf-numbers.yml
@@ -355,6 +355,15 @@ jobs:
         with:
           node-version: "22.18.0"
 
+      - name: Validate the predeclared paired bracket manifest
+        if: ${{ hashFiles('scripts/unity/paired-bracket-manifest.json') != '' }}
+        timeout-minutes: 2
+        shell: pwsh
+        run: >-
+          node scripts/unity/reduce-paired-bracket.js
+          --validate-manifest
+          --manifest scripts/unity/paired-bracket-manifest.json
+
       # Each suite opts into only its own test assemblies. The separate matrix
       # entries build separate players and therefore separate managed heaps.
       - name: Compute benchmark assembly list
@@ -1173,13 +1182,19 @@ jobs:
           if ($LASTEXITCODE -ne 0) {
             throw 'Comparison baseline extraction failed.'
           }
-          ./scripts/unity/require-comparison-rows.ps1 `
-            -BaselinePath $currentBaseline `
-            -EvidencePaths $evidenceInputs `
-            -ProcessEvidencePath (Join-Path $artifactsPath 'standalone-process.json') `
-            -CpuProfilePath (Join-Path $artifactsPath 'performance-cpu-profile.json') `
-            -SummaryJsonPath (Join-Path $artifactsPath 'paired-comparison-summary.json') `
-            -SummaryMarkdownPath (Join-Path $artifactsPath 'paired-comparison-summary.md')
+          $comparisonGateArguments = @{
+            BaselinePath = $currentBaseline
+            EvidencePaths = $evidenceInputs
+            ProcessEvidencePath = Join-Path $artifactsPath 'standalone-process.json'
+            CpuProfilePath = Join-Path $artifactsPath 'performance-cpu-profile.json'
+            SummaryJsonPath = Join-Path $artifactsPath 'paired-comparison-summary.json'
+            SummaryMarkdownPath = Join-Path $artifactsPath 'paired-comparison-summary.md'
+          }
+          $bracketManifestPath = 'scripts/unity/paired-bracket-manifest.json'
+          if (Test-Path -LiteralPath $bracketManifestPath -PathType Leaf) {
+            $comparisonGateArguments.BracketManifestPath = $bracketManifestPath
+          }
+          ./scripts/unity/require-comparison-rows.ps1 @comparisonGateArguments
           Get-Content `
             -LiteralPath (Join-Path $artifactsPath 'paired-comparison-summary.md') `
             -Raw | Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY
@@ -1385,8 +1400,8 @@ jobs:
             --jq '.[] | [.filename, .previous_filename] | .[] | select(. != null)')"
           methodology_pattern='^(Tests/(Runtime|Editor)/(Benchmarks|Comparisons|Allocations)/'
           methodology_pattern+='|Tests/Runtime/Scripts/Messages/Simple(Targeted|Untargeted|Broadcast)Message\.cs$'
-          methodology_pattern+='|scripts/unity/(extract-perf-baseline|perf-scenarios|render-perf|run-ci-tests|resolve-performance-cpu-profile)'
-          methodology_pattern+='|scripts/unity/post-route-perf-scenarios\.json$'
+          methodology_pattern+='|scripts/unity/(extract-perf-baseline|perf-scenarios|reduce-paired-bracket|render-perf|run-ci-tests|resolve-performance-cpu-profile)'
+          methodology_pattern+='|scripts/unity/(paired-bracket-manifest|post-route-perf-scenarios)\.json$'
           methodology_pattern+='|scripts/unity/lib/asmdef-discovery\.js$'
           methodology_pattern+='|\.github/comparison-packages\.json$'
           methodology_pattern+='|\.github/unity-versions\.json$'

--- a/.llm/skills/benchmark-methodology/SKILL.md
+++ b/.llm/skills/benchmark-methodology/SKILL.md
@@ -86,20 +86,19 @@ Never median-of-runs, never discard an outlier, never use a single untimed pass.
   Windows CPU-set `EfficiencyClass`; keep Normal priority; verify and retain topology and process
   settings. Fail closed on topology or setting drift. Historical deltas require an exact committed
   sidecar match on profile ID, affinity mask, and priority; otherwise omit them.
-- After preparing both paired workloads, settle the heap once outside timed work, then warm both.
-  Run four cycles; each repeats 10000-operation batches in ABBA/BAAB order until both workloads
-  reach 625 ms active time. This keeps the control milliseconds away and balances ordinal position.
+- Settle once, warm both workloads, then run four 625-ms cycles of 10000-operation ABBA/BAAB batches.
 - Treat the ratio as common-mode only when host movement affects both bridges approximately
   multiplicatively. Workload-specific GC/cache effects or frequency sensitivity stay in spread.
-- Divide each cycle's aggregate workload rates, geometrically combine all four cycle ratios for
-  the headline, and report their max/min spread. Do not take a
+- Geometrically combine all four cycle rate ratios and report their max/min spread. Do not take a
   median, remove an outlier, or turn a spread warning into a performance regression.
-- Pair DxMessaging with an unchanged in-process control such as the same MessagePipe scenario.
-  Candidate/control/candidate verdicts compare the paired ratio so host-wide movement shared by
-  both workloads does not masquerade as route-specific movement.
-- Reduce candidate/control/candidate paired headlines as `sqrt(C1 * C2) / R - 1`. Retain every
-  summary and raw cycle. Reject the verdict unless both outer same-code ratios and every run's raw
-  cycle spread stay within the 3% band; require a strictly greater than 3% effect for a candidate.
+- Pair DxMessaging with the same unchanged in-process MessagePipe scenario so shared host movement
+  does not masquerade as route-specific movement.
+- Predeclare each paired row and the exact candidate `Runtime/` paths in the committed manifest
+  before run one. Require at least one target and two sentinels; keep the manifest unchanged.
+- Use `scripts/unity/reduce-paired-bracket.js` only. It validates the manifest, distinct commits,
+  whole-tree and candidate-source digests, full profile, protocol, cycles, spreads, sentinels, and
+  normalized effects. Require stability within 3%, every target above 3%, and no affected regression
+  beyond 3%.
 - Keep exact fan-out assertions over warm-up plus every paired measured operation. Allocation
   evidence remains on the canonical rows; do not enable a profiler recorder inside paired batches.
   Do not pair an allocation-heavy workload whose collections can spill into the other side's batch;
@@ -133,7 +132,8 @@ Never median-of-runs, never discard an outlier, never use a single untimed pass.
 - Do not repeat a rejected candidate without new evidence or a materially different
   representation. The campaign decision reference records accepted and rejected work.
 - Claims need a fresh A/B/A bracket, an interpretable paired result, and an effect
-  strictly greater than 3%.
+  strictly greater than 3%, as accepted by `reduce-paired-bracket.js` from the immutable manifest
+  and all three retained summaries.
 - Do not read `MessageBusConstruction_1000` or cold teardown rows as dispatch
   regressions - they are wall-time first-touch rows and move independently.
 - Do not attribute a result to branch, cache, or memory stalls: no CPU-sampling

--- a/.llm/skills/benchmark-methodology/references/benchmark-methodology-total-over-window.md
+++ b/.llm/skills/benchmark-methodology/references/benchmark-methodology-total-over-window.md
@@ -114,12 +114,24 @@ and do not run the allocation recorder inside timed batches. Allocation-heavy sc
 can spill into the other workload's batch stay on their canonical continuous window. The canonical
 rows still own allocation evidence and the published absolute throughput table.
 
-For candidate/control/candidate (`C1/R/C2`), predeclare the reduction as
-`sqrt(C1 * C2) / R - 1`. Retain all three summaries and raw cycles. The experiment is
-uninterpretable when `(max(C1, C2) / min(C1, C2) - 1) * 100` exceeds 3% or any run's raw cycle
-spread exceeds 3%; do not discard or replace a run. A candidate must then exceed 3% in the
-intended direction and pass its scenario-specific regression and allocation gates. Invert the
-formula for control/candidate/control.
+Before the first bracket run, commit `scripts/unity/paired-bracket-manifest.json`. Classify every
+paired row as a primary `target`, reachable `affected` row, or causally unreachable `sentinel`.
+Declare at least one target, two sentinels, and the exact `Runtime/` paths containing the candidate
+mechanism. Keep the manifest byte-for-byte unchanged through all three runs; the workflow embeds its
+SHA-256 digest and a Git-derived digest of those candidate paths in every summary.
+
+Let `q1`, `q2`, and `q3` be the first, center, and last paired headlines. The candidate factor is
+`sqrt(q1 * q3) / q2` for candidate/control/candidate and `q2 / sqrt(q1 * q3)` for
+control/candidate/control. Run `scripts/unity/reduce-paired-bracket.js` with the manifest and all
+three retained summaries. It verifies three distinct commits, equal outer and different center
+whole trees and candidate-source digests, the exact manifest digest, profile, protocol, complete
+ordered row set, retained cycle ratios, raw spreads, outer spreads, every sentinel, and each target
+and affected-row effect
+normalized by the geometric mean of all sentinel factors. The experiment is
+uninterpretable when a raw or outer spread exceeds 3% or any sentinel effect leaves +/-3%. A stable
+candidate is rejected when a normalized affected row regresses by more than 3% or a normalized
+target effect does not strictly exceed 3%. Do not discard or replace a run. Allocation gates remain
+separate.
 
 ## The Window Contract
 

--- a/.llm/skills/benchmark-methodology/references/runtime-performance-campaign-decisions.md
+++ b/.llm/skills/benchmark-methodology/references/runtime-performance-campaign-decisions.md
@@ -3,10 +3,9 @@
 <!-- cspell:ignore gshared -->
 
 > **One-line summary**: Keep the measured physical-two handler-entry map,
-> holder-local flat-dispatch count read, and same-trial deregistration
-> diagnostic; the targeted post-phase state bundle and other small-container,
-> dispatch-switch, and private-pool candidates failed explicit timing or storage
-> gates and were reverted.
+> holder-local flat-dispatch count read, same-trial deregistration diagnostic,
+> and controlled one-process comparison profile. Reject performance attribution
+> when causally untouched sentinels move with the target.
 
 ## Decision rule
 
@@ -39,6 +38,17 @@ separately.
 
 ## Accepted measurement method
 
+- Keep the controlled one-process comparison profile from PR #467. The
+  Standalone IL2CPP Release player uses the highest Windows CPU-set
+  `EfficiencyClass`, affinity `0xFFFF`, Normal priority, four retained
+  `ABBABAAB` cycles, and at least 625 ms of active time per workload per cycle.
+  All seven paired raw-cycle spreads passed the fixed 3% limit on the accepted
+  host. This proves within-process stability only. A candidate/control/candidate
+  verdict must also commit the complete target/affected/sentinel manifest before
+  the first run and keep it unchanged through the bracket. The workflow embeds
+  its digest in every summary. Only `reduce-paired-bracket.js` produces the
+  verdict from all three summaries and every declared row. See the developer
+  runbook for the schema and gates.
 - Keep the joint deregistration palindrome. Its predecessor minimized four
   independent seven-trial windows, so the reported H/B/B/H arms could come from
   four different host phases. The corrected diagnostic prepares four fresh
@@ -64,6 +74,25 @@ separately.
 
 ## Rejected runtime candidates
 
+- Do not retain `AggressiveInlining` on `InterceptorCache<T>.EnsureFlat` from
+  PR #468. The native artifacts proved the intended call disappeared, and every
+  raw-cycle and outer-candidate spread passed 3%, but the center control was not
+  representative across builds. `GlobalToOne` and `StructNoBox` cannot call
+  `EnsureFlat`; they nevertheless reported +7.285% and +7.341%, matching the
+  `Filtered` target's +7.334%. Both sentinel effects exceed the fixed 3% bound,
+  so the bracket is uninterpretable. All five unreachable paired rows produce a
+  diagnostic normalized `Filtered` effect of +4.754%, but no target effect from
+  this failed bracket is acceptance evidence. The attribute and its user-facing
+  performance claim were reverted.
+- Caller-side duplication of the settled
+  `AcquireDispatchSnapshotFast<TMessage>` branch improved `PostProcess` by only
+  1.19% in a fresh Standalone candidate/control/candidate bracket. Keep the
+  shared helper until a materially different representation removes more work.
+- Inlining all of `RunUntargetedInterceptors<T>` removed the intended native
+  call and improved the four-interceptor internal row by 19.15%, but the old
+  cross-process comparison bracket moved unrelated rows by 4% to 27%. The
+  candidate was reverted. Do not retry it until the causal-sentinel protocol
+  first produces an interpretable bracket for the smaller `EnsureFlat` change.
 - Do not bundle `RunTargetedPostPhases<TMessage>`'s immutable arguments into a
   readonly struct passed by `in`. Fresh Standalone IL2CPP Release A/B/B/A means
   regressed targeted stable, rewritten-empty-final, and
@@ -125,6 +154,18 @@ separately.
 
 ## Rejected measurement methods
 
+- Do not accept a cross-build target effect merely because every raw cycle and
+  both outer candidate arms are stable. PR #468's one anomalous control moved
+  two impossible-to-affect routes by the same roughly 7.3% as the target. The
+  old gate rejected only non-target regressions, so correlated positive movement
+  passed. Require bounded causal sentinels and a target-specific normalized
+  effect for every future bracket.
+- Do not treat PR #437's cross-build comparison against the historical PR #434
+  baseline as authoritative route-cache attribution. Unrelated rows moved from
+  -11.22% to +19.41%, and no fresh Standalone three-run bracket existed. Keep
+  the tested route-cache mechanism, but describe it factually and do not claim
+  a measured throughput improvement until the immutable-manifest reducer accepts
+  a fresh bracket.
 - The original marginal-registration rows timed one sub-millisecond
   1000-registration pass while the Mono allocation recorder was active. Five
   candidate launches compared against that single historical master row are not a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Improve untargeted dispatch throughput for steady-state routes without optional hooks and for
-  filtered routes with interceptors, while retaining zero allocations
-  ([#414](https://github.com/Ambiguous-Interactive/DxMessaging/issues/414)).
 - Reduce repeated message-handler subscribe/unsubscribe churn by six managed allocation calls per
   cycle ([#414](https://github.com/Ambiguous-Interactive/DxMessaging/issues/414)).
 - **BREAKING (diagnostics output):** Diagnostic emission records no longer capture the emission-site

--- a/Runtime/Core/MessageBus/MessageBus.cs
+++ b/Runtime/Core/MessageBus/MessageBus.cs
@@ -676,7 +676,6 @@ namespace DxMessaging.Core.MessageBus
             /// the NEXT emission, matching the handler path's snapshot freeze
             /// (see <see cref="DispatchSnapshot"/>).
             /// </summary>
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public TValue[] EnsureFlat(out int count)
             {
                 if (_flatDirty)

--- a/docs/architecture/performance.md
+++ b/docs/architecture/performance.md
@@ -19,9 +19,6 @@ their resolved handler route across steady-state emissions. Registration changes
 the route. Dispatch keeps live handler-state and reset checks while preserving the zero-allocation
 steady-state contract.
 
-Filtered routes inline their steady-state interceptor-cache access. Registration changes still
-rebuild the cached snapshot on the next emission, outside the common clean-cache branch.
-
 ## How to read these tables
 
 - **Scopes.** Each dispatch table is labeled by execution scope and backend.

--- a/docs/runbooks/perf-benchmark-methodology.md
+++ b/docs/runbooks/perf-benchmark-methodology.md
@@ -490,22 +490,101 @@ but assembly boundaries still separate the complete matrix. Use the paired
 DxMessaging/MessagePipe ratios for candidate/control/candidate attribution when
 absolute rates move together.
 
-Predeclare the reduction before launching candidate/control/candidate (`C1/R/C2`).
-Let each symbol be that run's paired DxMessaging/MessagePipe headline ratio:
+Before the first run, commit `scripts/unity/paired-bracket-manifest.json`. Keep it
+byte-for-byte unchanged through all three runs. The workflow embeds the file's
+SHA-256 digest in each paired summary. The manifest assigns every paired row one
+of three roles:
 
-```text
-candidate_effect = sqrt(C1 * C2) / R - 1
-outer_spread_percent = (maximum(C1, C2) / minimum(C1, C2) - 1) * 100
+- `target`: a primary row whose sentinel-normalized effect must strictly exceed 3%.
+- `affected`: a row the changed call path can reach whose sentinel-normalized regression must not
+  exceed 3%.
+- `sentinel`: a row the changed call path cannot reach whose absolute effect must stay within 3%.
+
+Declare at least one target and two sentinels. Prove every role from the
+production call path during review. Do not classify a row after any bracket run
+has started. Declare the exact `Runtime/` files or directories that contain the candidate mechanism
+in `candidatePaths`. Every path must exist in all three arms. Do not use a broad path to make an
+unrelated runtime edit satisfy the candidate-source check. Manifest preflight checks exact tracked
+path case at the current `HEAD`; later artifact reduction uses retained digests and stays replayable
+if a subsequent change renames or removes the source path.
+
+The file uses this exact schema and every paired row in canonical summary order. Change only the
+bracket ID, orientation, candidate paths, and call-path-proven roles:
+
+```json
+{
+  "schemaVersion": 1,
+  "bracketId": "issue-414-candidate-name",
+  "orientation": "candidate-control-candidate",
+  "materialityBandPercent": 3,
+  "candidatePaths": ["Runtime/Core/MessageBus/MessageBus.cs"],
+  "rows": [
+    { "scenario": "GlobalToOne", "role": "sentinel" },
+    { "scenario": "GlobalToMany", "role": "sentinel" },
+    { "scenario": "KeyedToOne", "role": "sentinel" },
+    { "scenario": "Filtered", "role": "target" },
+    { "scenario": "PostProcess", "role": "sentinel" },
+    { "scenario": "FilteredPostProcess", "role": "affected" },
+    { "scenario": "StructNoBox", "role": "sentinel" }
+  ]
+}
 ```
 
-Retain all three summary files and every raw cycle ratio. Report a candidate
-verdict only when `outer_spread_percent <= 3` and every run's raw cycle spread is
-also at most 3%. Otherwise report the experiment as uninterpretable and do not
-discard or replace a run. A performance candidate must additionally produce a
-strictly greater than 3% effect in its intended direction and satisfy its
-scenario-specific regression and allocation gates. For control/candidate/control,
-invert the reduction: `candidate_effect = R / sqrt(C1 * C2) - 1`, where `R` is
-the center candidate ratio and the outer values are controls.
+Let `q1`, `q2`, and `q3` be the first, center, and last paired
+DxMessaging/MessagePipe headline ratios. The positional reductions are:
+
+```text
+candidate/control/candidate: candidate_effect = sqrt(q1 * q3) / q2 - 1
+control/candidate/control: candidate_effect = q2 / sqrt(q1 * q3) - 1
+outer_spread_percent = (maximum(q1, q3) / minimum(q1, q3) - 1) * 100
+```
+
+The reducer performs these calculations in log space and rejects non-finite results. Compute
+`candidate_effect` for every row. Let `sentinel_reference` be the geometric mean of all sentinel
+effect factors (`1 + candidate_effect`). Compute each target and affected row's normalized effect
+as:
+
+```text
+sentinel_normalized_effect = (1 + candidate_effect) / sentinel_reference - 1
+```
+
+Run the repository reducer; do not reproduce this arithmetic in an issue comment:
+
+```bash
+node scripts/unity/reduce-paired-bracket.js \
+  --manifest scripts/unity/paired-bracket-manifest.json \
+  --first <first-summary.json> \
+  --center <center-summary.json> \
+  --last <last-summary.json> \
+  --output <bracket-verdict.json>
+```
+
+The producer requires checked-out `HEAD` to equal the published commit and rejects tracked runtime
+or benchmark-source dirt. It derives the whole-tree ID and a SHA-256 digest of the predeclared
+candidate paths from that commit. The reducer requires three distinct commit stamps, equal outer
+whole-tree and candidate-source IDs, different center whole-tree and candidate-source IDs, and the
+exact manifest digest, execution profile, protocol, materiality band, and complete ordered row set
+in all three summaries. It recomputes each headline and raw spread from the four retained cycle
+ratios. It
+returns `accepted` only when all of these conditions hold:
+
+- Every run's raw-cycle spread and every row's outer spread are at most 3%.
+- Every causally untouched sentinel has an absolute candidate effect at most 3%.
+- Every sentinel-normalized target effect is strictly greater than 3% in the intended direction.
+- Every sentinel-normalized affected row regresses by no more than 3%.
+
+It returns `uninterpretable` for a raw, outer, or sentinel stability failure and
+`rejected` for a stable target or affected-row failure. Both non-accepted states
+exit nonzero. Retain the manifest, all summaries, every commit and source-tree ID, every raw cycle
+ratio, and the verdict. Do not discard or replace a run. Allocation gates remain separate. A
+low raw-cycle spread proves stability inside one player process; it does not
+prove that the center run is representative across builds.
+
+Rows without a valid paired control stay canonical-only. `SubUnsub` remains on
+its allocation-heavy continuous window. Its separate deregistration palindrome
+is diagnostic-only and is not candidate acceptance evidence. `PriorityOrdered`
+also remains canonical-only until a causally independent paired workload exists.
+Neither row is a causal sentinel or candidate evidence.
 
 Capability cells follow the pinned libraries' public APIs. MessagePipe uses predicate
 subscription and pre/post filters, UniRx uses `Where`, Zenject uses signal identifiers,

--- a/scripts/__tests__/reduce-paired-bracket.test.js
+++ b/scripts/__tests__/reduce-paired-bracket.test.js
@@ -1,0 +1,801 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+const test = require("node:test");
+
+const {
+  manifestSha256,
+  parseArgs,
+  reducePairedBracket,
+  validateManifest
+} = require("../unity/reduce-paired-bracket.js");
+
+test("manifest-only validation has an explicit CLI shape", () => {
+  const options = parseArgs(["node", "script", "--validate-manifest", "--manifest", "gate.json"]);
+  assert.equal(options.validateManifest, true);
+  assert.equal(options.manifest, "gate.json");
+  assert.throws(
+    () => parseArgs(["node", "script", "--validateManifest", "true"]),
+    /Unknown option/
+  );
+});
+
+const TARGET = "Filtered";
+const AFFECTED = "FilteredPostProcess";
+const DEFAULT_ROWS = [
+  { scenario: "GlobalToOne", role: "sentinel" },
+  { scenario: "GlobalToMany", role: "sentinel" },
+  { scenario: "KeyedToOne", role: "sentinel" },
+  { scenario: TARGET, role: "target" },
+  { scenario: "PostProcess", role: "sentinel" },
+  { scenario: AFFECTED, role: "affected" },
+  { scenario: "StructNoBox", role: "sentinel" }
+];
+const DEFAULT_FACTORS = Object.fromEntries(DEFAULT_ROWS.map((row) => [row.scenario, 1]));
+DEFAULT_FACTORS[TARGET] = 1.06;
+DEFAULT_FACTORS[AFFECTED] = 0.99;
+const COMMITS = ["1".repeat(40), "2".repeat(40), "3".repeat(40)];
+const OUTER_TREE = "a".repeat(40);
+const CENTER_TREE = "b".repeat(40);
+const OUTER_CANDIDATE_SOURCE = "c".repeat(64);
+const CENTER_CANDIDATE_SOURCE = "d".repeat(64);
+
+function makeManifest(orientation = "candidate-control-candidate", rows = DEFAULT_ROWS) {
+  return {
+    schemaVersion: 1,
+    bracketId: "test-bracket",
+    orientation,
+    materialityBandPercent: 3,
+    candidatePaths: ["Runtime/Core/MessageBus/MessageBus.cs"],
+    rows
+  };
+}
+
+function encodeManifest(manifest) {
+  return Buffer.from(`${JSON.stringify(manifest, null, 2)}\n`);
+}
+
+function makeCycleRatios(headline, spread) {
+  const halfRange = Math.sqrt(1 + spread / 100);
+  return [headline / halfRange, headline / halfRange, headline * halfRange, headline * halfRange];
+}
+
+function makeSummary(
+  manifestBytes,
+  manifest,
+  ratios,
+  spreads = {},
+  {
+    commit = COMMITS[0],
+    sourceTree = OUTER_TREE,
+    candidateSourceSha256 = OUTER_CANDIDATE_SOURCE
+  } = {}
+) {
+  return {
+    schemaVersion: 2,
+    platform: "Standalone IL2CPP x64 Release (WindowsPlayer; Unity 6000.5.2f1)",
+    commit,
+    sourceTree,
+    candidateSourceSha256,
+    bracketManifestSha256: manifestSha256(manifestBytes),
+    executionProfile: {
+      id: "highest-efficiency-class-affinity-normal-v1",
+      cpuModel: "13th Gen Intel(R) Core(TM) i9-13900KF",
+      source: "GetSystemCpuSetInformation",
+      selectionPolicy: "maximum EfficiencyClass",
+      selectedEfficiencyClass: 1,
+      selectedLogicalProcessorIndices: Array.from({ length: 16 }, (_, index) => index),
+      affinityMask: "0xFFFF",
+      priorityClass: "Normal"
+    },
+    protocol: "interleaved-abba-baab-v1",
+    cycles: 4,
+    minimumCycleActiveMilliseconds: 625,
+    batchOperations: 10000,
+    materialityBandPercent: 3,
+    rows: manifest.rows.map((row) => {
+      const headline = ratios[row.scenario];
+      const spread = spreads[row.scenario] ?? 1;
+      return {
+        scenario: row.scenario,
+        firstToSecondRatio: headline,
+        aggregateRateRatio: headline,
+        cycleRatioSpreadPercent: spread,
+        withinMaterialityBand: spread <= 3,
+        cycleRatios: makeCycleRatios(headline, spread)
+      };
+    })
+  };
+}
+
+function makeBracket({
+  orientation = "candidate-control-candidate",
+  factors = {},
+  spreads = {},
+  outerScales = {}
+} = {}) {
+  const manifest = makeManifest(orientation);
+  const manifestBytes = encodeManifest(manifest);
+  const resolvedFactors = { ...DEFAULT_FACTORS, ...factors };
+  const firstRatios = {};
+  const centerRatios = {};
+  const lastRatios = {};
+  for (const row of manifest.rows) {
+    const factor = resolvedFactors[row.scenario];
+    const scale = outerScales[row.scenario] ?? 1;
+    if (orientation === "candidate-control-candidate") {
+      firstRatios[row.scenario] = factor / scale;
+      centerRatios[row.scenario] = 1;
+      lastRatios[row.scenario] = factor * scale;
+    } else {
+      firstRatios[row.scenario] = 1 / scale;
+      centerRatios[row.scenario] = factor;
+      lastRatios[row.scenario] = scale;
+    }
+  }
+  return {
+    manifest,
+    manifestBytes,
+    summaries: [
+      makeSummary(manifestBytes, manifest, firstRatios, spreads.first, {
+        commit: COMMITS[0],
+        sourceTree: OUTER_TREE
+      }),
+      makeSummary(manifestBytes, manifest, centerRatios, spreads.center, {
+        commit: COMMITS[1],
+        sourceTree: CENTER_TREE,
+        candidateSourceSha256: CENTER_CANDIDATE_SOURCE
+      }),
+      makeSummary(manifestBytes, manifest, lastRatios, spreads.last, {
+        commit: COMMITS[2],
+        sourceTree: OUTER_TREE
+      })
+    ]
+  };
+}
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function writeBracket(directory, bracket) {
+  const manifestPath = path.join(directory, "manifest.json");
+  fs.writeFileSync(manifestPath, bracket.manifestBytes);
+  const summaryPaths = bracket.summaries.map((summary, index) => {
+    const summaryPath = path.join(directory, `summary-${index}.json`);
+    fs.writeFileSync(summaryPath, `${JSON.stringify(summary)}\n`);
+    return summaryPath;
+  });
+  return { manifestPath, summaryPaths };
+}
+
+function spawnReducer(arguments_) {
+  return spawnSync(
+    process.execPath,
+    [path.resolve(__dirname, "../unity/reduce-paired-bracket.js"), ...arguments_],
+    { encoding: "utf8" }
+  );
+}
+
+test("CLI validates manifests and preserves the accepted, rejected, and invalid exit contract", async (t) => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "dxm-paired-reducer-"));
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
+
+  await t.test("manifest preflight", () => {
+    const { manifestPath } = writeBracket(directory, makeBracket());
+    const result = spawnReducer(["--validate-manifest", "--manifest", manifestPath]);
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /^[0-9a-f]{64}\n$/);
+  });
+
+  await t.test("accepted stdout", () => {
+    const { manifestPath, summaryPaths } = writeBracket(directory, makeBracket());
+    const result = spawnReducer([
+      "--manifest",
+      manifestPath,
+      "--first",
+      summaryPaths[0],
+      "--center",
+      summaryPaths[1],
+      "--last",
+      summaryPaths[2]
+    ]);
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(JSON.parse(result.stdout).status, "accepted");
+  });
+
+  await t.test("rejected output file before status 2", () => {
+    const bracket = makeBracket({ factors: { [TARGET]: 1.01 } });
+    const { manifestPath, summaryPaths } = writeBracket(directory, bracket);
+    const outputPath = path.join(directory, "verdict.json");
+    const result = spawnReducer([
+      "--manifest",
+      manifestPath,
+      "--first",
+      summaryPaths[0],
+      "--center",
+      summaryPaths[1],
+      "--last",
+      summaryPaths[2],
+      "--output",
+      outputPath
+    ]);
+    assert.equal(result.status, 2, result.stderr);
+    assert.equal(JSON.parse(fs.readFileSync(outputPath, "utf8")).status, "rejected");
+  });
+
+  await t.test("malformed evidence status 1", () => {
+    const { manifestPath, summaryPaths } = writeBracket(directory, makeBracket());
+    fs.writeFileSync(summaryPaths[1], "not-json\n");
+    const result = spawnReducer([
+      "--manifest",
+      manifestPath,
+      "--first",
+      summaryPaths[0],
+      "--center",
+      summaryPaths[1],
+      "--last",
+      summaryPaths[2]
+    ]);
+    assert.equal(result.status, 1);
+    assert.notEqual(result.stderr.trim(), "");
+  });
+});
+
+test("candidate-control-candidate accepts a stable target-specific improvement", () => {
+  const bracket = makeBracket();
+  const result = reducePairedBracket(bracket.manifestBytes, bracket.summaries);
+  assert.equal(result.status, "accepted");
+  assert.deepEqual(result.reasons, []);
+  assert.deepEqual(
+    result.provenance.map((entry) => entry.commit),
+    COMMITS
+  );
+  assert.ok(
+    result.rows.find((row) => row.scenario === TARGET).sentinelNormalizedEffectPercent > 3,
+    "The target should exceed the fixed target-specific threshold."
+  );
+});
+
+test("control-candidate-control uses the mirrored positional reduction", () => {
+  const bracket = makeBracket({ orientation: "control-candidate-control" });
+  const result = reducePairedBracket(bracket.manifestBytes, bracket.summaries);
+  assert.equal(result.status, "accepted");
+  assert.ok(
+    Math.abs(result.rows.find((row) => row.scenario === TARGET).candidateEffectPercent - 6) < 1e-10,
+    "The center candidate should retain the declared positive effect."
+  );
+});
+
+test("a stable bracket rejects a target at or below three percent", () => {
+  const bracket = makeBracket({
+    factors: { [TARGET]: 1.03, [AFFECTED]: 1 }
+  });
+  const result = reducePairedBracket(bracket.manifestBytes, bracket.summaries);
+  assert.equal(result.status, "rejected");
+  assert.match(result.reasons.join("\n"), /Filtered sentinel-normalized target effect/);
+});
+
+test("a stable bracket rejects an affected-row regression beyond three percent", () => {
+  const bracket = makeBracket({
+    factors: { [TARGET]: 1.06, [AFFECTED]: 0.96 }
+  });
+  const result = reducePairedBracket(bracket.manifestBytes, bracket.summaries);
+  assert.equal(result.status, "rejected");
+  assert.match(result.reasons.join("\n"), /FilteredPostProcess sentinel-normalized affected-row/);
+});
+
+test("affected regressions are normalized against the same common-mode sentinel shift", () => {
+  const bracket = makeBracket({
+    factors: {
+      [TARGET]: 1.08,
+      [AFFECTED]: 0.998,
+      GlobalToOne: 1.029,
+      GlobalToMany: 1.029,
+      KeyedToOne: 1.029,
+      PostProcess: 1.029,
+      StructNoBox: 1.029
+    },
+    spreads: { first: {}, center: {}, last: {} }
+  });
+  const result = reducePairedBracket(bracket.manifestBytes, bracket.summaries);
+  const affected = result.rows.find((row) => row.scenario === AFFECTED);
+  assert.equal(result.status, "rejected");
+  assert.ok(affected.sentinelNormalizedEffectPercent < -3);
+  assert.match(result.reasons.join("\n"), /sentinel-normalized affected-row/);
+});
+
+test("raw-cycle spread above three percent makes the bracket uninterpretable", () => {
+  const bracket = makeBracket({ spreads: { center: { [TARGET]: 3.01 } } });
+  const result = reducePairedBracket(bracket.manifestBytes, bracket.summaries);
+  assert.equal(result.status, "uninterpretable");
+  assert.match(result.reasons.join("\n"), /Filtered raw-cycle spread/);
+});
+
+test("outer same-code spread above three percent makes the bracket uninterpretable", () => {
+  const bracket = makeBracket({ outerScales: { [TARGET]: 1.02 } });
+  const result = reducePairedBracket(bracket.manifestBytes, bracket.summaries);
+  assert.equal(result.status, "uninterpretable");
+  assert.match(result.reasons.join("\n"), /Filtered outer spread/);
+});
+
+test("a sentinel effect outside three percent makes the bracket uninterpretable", () => {
+  const bracket = makeBracket({
+    factors: { GlobalToOne: 1.031 }
+  });
+  const result = reducePairedBracket(bracket.manifestBytes, bracket.summaries);
+  assert.equal(result.status, "uninterpretable");
+  assert.match(result.reasons.join("\n"), /GlobalToOne sentinel effect/);
+});
+
+test("the session 240 artifact-shaped bracket fails its sentinel gate", () => {
+  const rows = [
+    { scenario: "GlobalToOne", role: "sentinel" },
+    { scenario: "GlobalToMany", role: "sentinel" },
+    { scenario: "KeyedToOne", role: "sentinel" },
+    { scenario: "Filtered", role: "target" },
+    { scenario: "PostProcess", role: "sentinel" },
+    { scenario: "FilteredPostProcess", role: "affected" },
+    { scenario: "StructNoBox", role: "sentinel" }
+  ];
+  const manifest = makeManifest("candidate-control-candidate", rows);
+  manifest.bracketId = "session-240-inline-interceptor-flat-access";
+  const manifestBytes = encodeManifest(manifest);
+  const c1 = [
+    0.3664825458329125, 0.9638895979446739, 1.1749603478334951, 0.4139565263871168,
+    0.30839240772835985, 0.35066743667156336, 0.41332080747580546
+  ];
+  const control = [
+    0.3397850194262837, 0.967803075233871, 1.1798167374564192, 0.3863364779458949,
+    0.31514396784308657, 0.3446972097633311, 0.38286598713193026
+  ];
+  const c2 = [
+    0.3626055198992972, 0.9684320021425954, 1.198908896941916, 0.41538562631333986,
+    0.3070944651881458, 0.3511185780464608, 0.4086341036570222
+  ];
+  const spreads = [
+    [
+      0.8204612835834624, 1.9333897889375118, 2.6835356075866956, 0.9103789875130497,
+      0.5659055890008702, 0.8146324113570858, 0.9451177125524346
+    ],
+    [
+      1.1028308453360225, 2.516331076690048, 1.831094466025407, 2.6269405956543146,
+      1.2355279753484494, 0.45885913299001935, 0.7936012788094526
+    ],
+    [
+      0.9706598505605957, 0.9008923477044295, 2.021145035917682, 0.8933299443459664,
+      0.6974634572843197, 1.335523904224556, 0.6007602409331403
+    ]
+  ];
+  const toMap = (values) =>
+    Object.fromEntries(rows.map((row, index) => [row.scenario, values[index]]));
+  const summaries = [c1, control, c2].map((values, index) =>
+    makeSummary(manifestBytes, manifest, toMap(values), toMap(spreads[index]), {
+      commit: COMMITS[index],
+      sourceTree: index === 1 ? CENTER_TREE : OUTER_TREE,
+      candidateSourceSha256: index === 1 ? CENTER_CANDIDATE_SOURCE : OUTER_CANDIDATE_SOURCE
+    })
+  );
+
+  const result = reducePairedBracket(manifestBytes, summaries);
+  const filtered = result.rows.find((row) => row.scenario === "Filtered");
+  assert.equal(result.status, "uninterpretable");
+  assert.match(result.reasons.join("\n"), /GlobalToOne sentinel effect/);
+  assert.match(result.reasons.join("\n"), /StructNoBox sentinel effect/);
+  assert.ok(
+    Math.abs(filtered.sentinelNormalizedEffectPercent - 4.753994) < 0.00001,
+    "The diagnostic must normalize against all five sentinels without cherry-picking."
+  );
+});
+
+test("manifest validation rejects incomplete, reordered, unknown, and unsupported classifications", async (t) => {
+  const cases = [
+    [
+      "empty candidate source scope",
+      { ...makeManifest(), candidatePaths: [] },
+      /candidatePaths must be a non-empty array/
+    ],
+    [
+      "candidate path outside Runtime",
+      { ...makeManifest(), candidatePaths: ["docs/architecture/performance.md"] },
+      /normalized path below Runtime/
+    ],
+    [
+      "fewer than two sentinels",
+      makeManifest(
+        undefined,
+        DEFAULT_ROWS.map((row, index) =>
+          row.role === "sentinel" && index > 0 ? { ...row, role: "affected" } : row
+        )
+      ),
+      /at least two sentinel/
+    ],
+    [
+      "no target",
+      makeManifest(
+        undefined,
+        DEFAULT_ROWS.map((row) => ({ ...row, role: "sentinel" }))
+      ),
+      /at least one target/
+    ],
+    [
+      "omitted scenario",
+      makeManifest(undefined, DEFAULT_ROWS.slice(0, -1)),
+      /classify every paired scenario/
+    ],
+    [
+      "reordered scenario",
+      makeManifest(undefined, [DEFAULT_ROWS[1], DEFAULT_ROWS[0], ...DEFAULT_ROWS.slice(2)]),
+      /classify every paired scenario/
+    ],
+    [
+      "unknown scenario",
+      makeManifest(
+        undefined,
+        DEFAULT_ROWS.map((row, index) =>
+          index === DEFAULT_ROWS.length - 1 ? { ...row, scenario: "Unknown" } : row
+        )
+      ),
+      /classify every paired scenario/
+    ],
+    [
+      "canonical-only role",
+      makeManifest(
+        undefined,
+        DEFAULT_ROWS.map((row, index) => (index === 1 ? { ...row, role: "canonical-only" } : row))
+      ),
+      /unsupported role/
+    ]
+  ];
+  for (const [name, manifest, pattern] of cases) {
+    await t.test(name, () => assert.throws(() => validateManifest(manifest), pattern));
+  }
+});
+
+test("manifest preflight rejects wrong-case and untracked candidate paths", async (t) => {
+  const cases = [
+    ["wrong case", "Runtime/Core/MessageBus/messageBus.cs"],
+    ["untracked", "Runtime/UntrackedCandidate.cs"]
+  ];
+  for (const [name, candidatePath] of cases) {
+    await t.test(name, () => {
+      const manifest = { ...makeManifest(), candidatePaths: [candidatePath] };
+      assert.throws(
+        () => validateManifest(manifest, { requireTrackedCandidatePaths: true }),
+        /not tracked at HEAD with exact case/
+      );
+    });
+  }
+});
+
+test("retained artifact reduction does not depend on the current HEAD path inventory", () => {
+  const bracket = makeBracket();
+  const historicalManifest = {
+    ...bracket.manifest,
+    candidatePaths: ["Runtime/RenamedAfterThisBracket.cs"]
+  };
+  const historicalManifestBytes = encodeManifest(historicalManifest);
+  const summaries = clone(bracket.summaries);
+  const digest = manifestSha256(historicalManifestBytes);
+  summaries.forEach((summary) => {
+    summary.bracketManifestSha256 = digest;
+  });
+  assert.equal(reducePairedBracket(historicalManifestBytes, summaries).status, "accepted");
+});
+
+test("summary validation rejects omitted, extra, reordered, and mismatched-manifest evidence", async (t) => {
+  const bracket = makeBracket();
+  const cases = [
+    ["omitted row", (summaries) => summaries[0].rows.pop(), /row count/],
+    [
+      "extra row",
+      (summaries) =>
+        summaries[0].rows.push({
+          scenario: "Extra",
+          firstToSecondRatio: 1,
+          cycleRatioSpreadPercent: 1,
+          cycleRatios: [1, 1, 1, 1]
+        }),
+      /row count/
+    ],
+    ["reordered row", (summaries) => summaries[0].rows.reverse(), /summary row 0/],
+    [
+      "duplicated row",
+      (summaries) => {
+        summaries[0].rows[1] = clone(summaries[0].rows[0]);
+      },
+      /summary row 1/
+    ],
+    [
+      "manifest digest mismatch",
+      (summaries) => {
+        summaries[1].bracketManifestSha256 = "0".repeat(64);
+      },
+      /manifest digest/
+    ],
+    [
+      "execution profile mismatch",
+      (summaries) => {
+        summaries[2].executionProfile.affinityMask = "0xFFFFFFFF";
+      },
+      /execution profile/
+    ],
+    [
+      "duplicate commit provenance",
+      (summaries) => {
+        summaries[2].commit = summaries[0].commit;
+      },
+      /distinct commits/
+    ],
+    [
+      "different outer source trees",
+      (summaries) => {
+        summaries[2].sourceTree = "c".repeat(40);
+      },
+      /outer summaries.*same source tree/
+    ],
+    [
+      "identical center source tree",
+      (summaries) => {
+        summaries[1].sourceTree = summaries[0].sourceTree;
+      },
+      /outer and center.*different source trees/
+    ],
+    [
+      "different outer candidate source",
+      (summaries) => {
+        summaries[2].candidateSourceSha256 = "e".repeat(64);
+      },
+      /outer summaries.*same candidate-source digest/
+    ],
+    [
+      "unchanged candidate source in center",
+      (summaries) => {
+        summaries[1].candidateSourceSha256 = summaries[0].candidateSourceSha256;
+      },
+      /outer and center.*different candidate-source digests/
+    ]
+  ];
+  for (const [name, mutate, pattern] of cases) {
+    await t.test(name, () => {
+      const summaries = clone(bracket.summaries);
+      mutate(summaries);
+      assert.throws(() => reducePairedBracket(bracket.manifestBytes, summaries), pattern);
+    });
+  }
+});
+
+test("summary validation recomputes headline and spread from four retained cycle ratios", async (t) => {
+  const bracket = makeBracket();
+  const cases = [
+    [
+      "missing cycles",
+      (row) => {
+        delete row.cycleRatios;
+      },
+      /exactly 4/
+    ],
+    [
+      "short cycles",
+      (row) => {
+        row.cycleRatios.pop();
+      },
+      /exactly 4/
+    ],
+    [
+      "non-positive cycle",
+      (row) => {
+        row.cycleRatios[0] = 0;
+      },
+      /must be positive/
+    ],
+    [
+      "non-finite cycle",
+      (row) => {
+        row.cycleRatios[0] = Number.NaN;
+      },
+      /finite number/
+    ],
+    [
+      "fabricated headline",
+      (row) => {
+        row.firstToSecondRatio *= 1.01;
+      },
+      /geometric mean/
+    ],
+    [
+      "fabricated spread",
+      (row) => {
+        row.cycleRatioSpreadPercent = 0;
+      },
+      /spread does not match/
+    ]
+  ];
+  for (const [name, mutate, pattern] of cases) {
+    await t.test(name, () => {
+      const summaries = clone(bracket.summaries);
+      mutate(summaries[0].rows[0]);
+      assert.throws(() => reducePairedBracket(bracket.manifestBytes, summaries), pattern);
+    });
+  }
+});
+
+test("extreme finite inputs cannot overflow or underflow into an accepted verdict", async (t) => {
+  await t.test("raw cycle spread overflow", () => {
+    const bracket = makeBracket();
+    const row = bracket.summaries[0].rows[0];
+    row.cycleRatios = [Number.MAX_VALUE, Number.MAX_VALUE, Number.MIN_VALUE, Number.MIN_VALUE];
+    row.firstToSecondRatio = Math.exp(
+      row.cycleRatios.reduce((sum, value) => sum + Math.log(value), 0) / row.cycleRatios.length
+    );
+    row.cycleRatioSpreadPercent = 0;
+    assert.throws(
+      () => reducePairedBracket(bracket.manifestBytes, bracket.summaries),
+      /spread does not match/
+    );
+  });
+
+  await t.test("bracket factor overflow", () => {
+    const bracket = makeBracket();
+    for (const [index, value] of [Number.MAX_VALUE, Number.MIN_VALUE, Number.MAX_VALUE].entries()) {
+      const row = bracket.summaries[index].rows.find((candidate) => candidate.scenario === TARGET);
+      row.firstToSecondRatio = value;
+      row.cycleRatioSpreadPercent = 0;
+      row.cycleRatios = [value, value, value, value];
+    }
+    assert.throws(
+      () => reducePairedBracket(bracket.manifestBytes, bracket.summaries),
+      /non-finite bracket reduction/
+    );
+  });
+});
+
+test("three consistently wrong summaries cannot define their own profile or protocol", async (t) => {
+  const bracket = makeBracket();
+  const cases = [
+    [
+      "missing commit",
+      (summary) => {
+        delete summary.commit;
+      },
+      /summary commit/
+    ],
+    [
+      "missing source tree",
+      (summary) => {
+        delete summary.sourceTree;
+      },
+      /sourceTree/
+    ],
+    [
+      "missing candidate source",
+      (summary) => {
+        delete summary.candidateSourceSha256;
+      },
+      /candidateSourceSha256/
+    ],
+    [
+      "Mono platform",
+      (summary) => {
+        summary.platform = "PlayMode Mono";
+      },
+      /platform/
+    ],
+    [
+      "missing profile",
+      (summary) => {
+        delete summary.executionProfile;
+      },
+      /execution profile/
+    ],
+    [
+      "CPU model",
+      (summary) => {
+        summary.executionProfile.cpuModel = "other";
+      },
+      /profile topology/
+    ],
+    [
+      "missing CPU model",
+      (summary) => {
+        delete summary.executionProfile.cpuModel;
+      },
+      /must contain exactly/
+    ],
+    [
+      "profile source",
+      (summary) => {
+        summary.executionProfile.source = "other";
+      },
+      /profile topology/
+    ],
+    [
+      "selection policy",
+      (summary) => {
+        summary.executionProfile.selectionPolicy = "other";
+      },
+      /profile topology/
+    ],
+    [
+      "efficiency class",
+      (summary) => {
+        summary.executionProfile.selectedEfficiencyClass = -1;
+      },
+      /profile topology/
+    ],
+    [
+      "logical processors",
+      (summary) => {
+        summary.executionProfile.selectedLogicalProcessorIndices = [1, 2];
+      },
+      /profile topology/
+    ],
+    [
+      "profile",
+      (summary) => {
+        summary.executionProfile.id = "other";
+      },
+      /execution profile/
+    ],
+    [
+      "affinity",
+      (summary) => {
+        summary.executionProfile.affinityMask = "0xFFFFFFFF";
+      },
+      /execution profile/
+    ],
+    [
+      "priority",
+      (summary) => {
+        summary.executionProfile.priorityClass = "High";
+      },
+      /execution profile/
+    ],
+    [
+      "missing protocol",
+      (summary) => {
+        delete summary.protocol;
+      },
+      /protocol constants/
+    ],
+    [
+      "protocol",
+      (summary) => {
+        summary.protocol = "other";
+      },
+      /protocol constants/
+    ],
+    [
+      "cycles",
+      (summary) => {
+        summary.cycles = 1;
+      },
+      /protocol constants/
+    ],
+    [
+      "active time",
+      (summary) => {
+        summary.minimumCycleActiveMilliseconds = 1;
+      },
+      /protocol constants/
+    ],
+    [
+      "batch",
+      (summary) => {
+        summary.batchOperations = 1;
+      },
+      /protocol constants/
+    ]
+  ];
+  for (const [name, mutate, pattern] of cases) {
+    await t.test(name, () => {
+      const summaries = clone(bracket.summaries);
+      summaries.forEach(mutate);
+      assert.throws(() => reducePairedBracket(bracket.manifestBytes, summaries), pattern);
+    });
+  }
+});

--- a/scripts/__tests__/reduce-paired-bracket.test.js.meta
+++ b/scripts/__tests__/reduce-paired-bracket.test.js.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 99c381b7767fe2eb8811a9e5f1e2b13f
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/scripts/__tests__/unity-perf.test.js
+++ b/scripts/__tests__/unity-perf.test.js
@@ -524,7 +524,18 @@ test("performance workflow publishes exact player-size and codegen evidence", ()
     path.join(REPO_ROOT, ".github", "workflows", "perf-numbers.yml"),
     "utf8"
   );
-  assert.match(workflow, /post-route-perf-scenarios\\\.json\$/);
+  assert.match(
+    workflow,
+    /scripts\/unity\/\(paired-bracket-manifest\|post-route-perf-scenarios\)\\\.json\$/
+  );
+  assert.match(
+    workflow,
+    /\$bracketManifestPath = 'scripts\/unity\/paired-bracket-manifest\.json'[\s\S]*\$comparisonGateArguments\.BracketManifestPath = \$bracketManifestPath[\s\S]*require-comparison-rows\.ps1 @comparisonGateArguments/
+  );
+  assert.match(
+    workflow,
+    /Validate the predeclared paired bracket manifest\n\s+if: \$\{\{ hashFiles\('scripts\/unity\/paired-bracket-manifest\.json'\) != '' \}\}[\s\S]*reduce-paired-bracket\.js[\s\S]*--validate-manifest[\s\S]*paired-bracket-manifest\.json/
+  );
   assert.match(
     workflow,
     /Get-ChildItem -LiteralPath \$playerDir -File -Recurse -Force[\s\S]*player-size\.json[\s\S]*Set-StrictMode -Version Latest[\s\S]*HashSet\[string\][\s\S]*StringComparer\]::Ordinal(?![A-Za-z0-9_])[\s\S]*DefinitionLocations[\s\S]*repeated identical body[\s\S]*case-distinct bodies[\s\S]*StringComparison\]::Ordinal[\s\S]*Generated-method extractor self-test passed[\s\S]*DeregistrationAttributionState_Execute_m[\s\S]*TypedHandlerDeregistrationState_Deregister_m[\s\S]*MessageBus_Deregister_Tis[\s\S]*GenericInterface[\s\S]*_\+messageBus[\s\S]*typedCallSymbol[\s\S]*typedSharedCallSymbol[\s\S]*directBusCallSymbol[\s\S]*typedInterfaceDispatchEvidenceLineCount[\s\S]*typedDirectBusDispatchEvidenceLineCount[\s\S]*typedBusDispatchRecognized[\s\S]*directBusDispatchEvidenceLineCount[\s\S]*definitionOccurrenceCount[\s\S]*definitionLocation=[\s\S]*typed-deregistration-codegen\.txt[\s\S]*Capture dispatch-route codegen and native layout[\s\S]*benchmark-suite == 'comparisons'[\s\S]*standalone-comparisons[\s\S]*\.artifacts\/unity\/perf\/\$\{\{ matrix\.unity-version \}\}-standalone-comparisons[\s\S]*capture-dispatch-codegen\.ps1[\s\S]*native-layout-inventory\.txt[\s\S]*native-line-map\.txt[\s\S]*requiredTargetsResolved=True[\s\S]*native-disassembly\.txt/

--- a/scripts/unity/__tests__/require-comparison-rows.test.ps1
+++ b/scripts/unity/__tests__/require-comparison-rows.test.ps1
@@ -2,6 +2,7 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..' '..')).Path
+$headCommit = (& git -C $repoRoot rev-parse HEAD).Trim()
 $scriptPath = Join-Path $repoRoot 'scripts' 'unity' 'require-comparison-rows.ps1'
 $tempDirectory = Join-Path ([System.IO.Path]::GetTempPath()) "dxm-comparison-row-gate-$([guid]::NewGuid())"
 $baselinePath = Join-Path $tempDirectory 'comparison-rows.csv'
@@ -12,12 +13,13 @@ $processEvidencePath = Join-Path $tempDirectory 'standalone-process.json'
 $cpuProfilePath = Join-Path $tempDirectory 'performance-cpu-profile.json'
 $summaryJsonPath = Join-Path $tempDirectory 'paired-comparison-summary.json'
 $summaryMarkdownPath = Join-Path $tempDirectory 'paired-comparison-summary.md'
+$bracketManifestPath = Join-Path $tempDirectory 'paired-bracket-manifest.json'
 $csvHeader = 'scenario,platform,commit,runIndex,emitsPerSec,gcAllocations,wallClockMs,gcAllocatedBytes'
 
 function Write-Baseline {
     param(
         [string[]]$Scenarios,
-        [string]$Commit = 'abc1234',
+        [string]$Commit = $headCommit,
         [string]$Platform = 'Standalone IL2CPP x64 Release (WindowsPlayer; Unity 6000.3.16f1)'
     )
 
@@ -30,6 +32,7 @@ function New-PairedRecord {
         [string]$Scenario,
         [string]$First = 'DxMessaging',
         [string]$Second = 'MessagePipe',
+        [string]$Commit = $headCommit,
         [double[]]$Ratios = @(0.5, 0.51, 0.49, 0.505)
     )
 
@@ -55,7 +58,7 @@ function New-PairedRecord {
         first = $First
         second = $Second
         platform = 'Standalone IL2CPP x64 Release (WindowsPlayer; Unity 6000.3.16f1)'
-        commit = 'abc1234'
+        commit = $Commit
         protocol = 'interleaved-abba-baab-v1'
         cycles = 4
         minimumCycleActiveMilliseconds = 625
@@ -146,15 +149,23 @@ function Write-ExecutionEvidence {
 }
 
 function Invoke-Gate {
-    param([string[]]$EvidenceInputs = @($evidencePath, $playerLogPath))
+    param(
+        [string[]]$EvidenceInputs = @($evidencePath, $playerLogPath),
+        [bool]$IncludeBracketManifest = $true
+    )
 
-    & $scriptPath `
-        -BaselinePath $baselinePath `
-        -EvidencePaths $EvidenceInputs `
-        -ProcessEvidencePath $processEvidencePath `
-        -CpuProfilePath $cpuProfilePath `
-        -SummaryJsonPath $summaryJsonPath `
-        -SummaryMarkdownPath $summaryMarkdownPath
+    $arguments = @{
+        BaselinePath = $baselinePath
+        EvidencePaths = $EvidenceInputs
+        ProcessEvidencePath = $processEvidencePath
+        CpuProfilePath = $cpuProfilePath
+        SummaryJsonPath = $summaryJsonPath
+        SummaryMarkdownPath = $summaryMarkdownPath
+    }
+    if ($IncludeBracketManifest) {
+        $arguments.BracketManifestPath = $bracketManifestPath
+    }
+    & $scriptPath @arguments
 }
 
 function Assert-GateFails {
@@ -181,6 +192,11 @@ function Assert-GateFails {
 
 try {
     [System.IO.Directory]::CreateDirectory($tempDirectory) | Out-Null
+    [System.IO.File]::WriteAllText(
+        $bracketManifestPath,
+        '{"schemaVersion":1,"bracketId":"test","orientation":"candidate-control-candidate","materialityBandPercent":3,"candidatePaths":["Runtime/Core/MessageBus/MessageBus.cs"],"rows":[]}' + "`n"
+    )
+    $bracketManifestSha256 = (Get-FileHash -LiteralPath $bracketManifestPath -Algorithm SHA256).Hash.ToLowerInvariant()
     $pairedFixturePath = Join-Path $repoRoot 'Tests/Runtime/Comparisons/Paired/PairedDxMessagingMessagePipeTests.cs'
     $pairedFixture = Get-Content -LiteralPath $pairedFixturePath -Raw
     $pairedHarnessPath = Join-Path $repoRoot 'Tests/Runtime/Comparisons/PairedComparisonHarness.cs'
@@ -208,20 +224,37 @@ try {
     Write-Baseline -Scenarios $expected
     Write-Evidence -Records $validRecords
     Write-ExecutionEvidence
+    Invoke-Gate -IncludeBracketManifest $false
+    $summaryWithoutManifest = Get-Content -LiteralPath $summaryJsonPath -Raw | ConvertFrom-Json
+    $markdownWithoutManifest = Get-Content -LiteralPath $summaryMarkdownPath -Raw
+    if (
+        $null -ne $summaryWithoutManifest.bracketManifestSha256 -or
+        $null -ne $summaryWithoutManifest.candidateSourceSha256 -or
+        $markdownWithoutManifest.Contains('Bracket manifest SHA-256')
+    ) {
+        throw 'The default comparison path emitted a bracket manifest digest without a manifest.'
+    }
+
     Invoke-Gate
     $summary = Get-Content -LiteralPath $summaryJsonPath -Raw | ConvertFrom-Json
     $summaryMarkdown = Get-Content -LiteralPath $summaryMarkdownPath -Raw
     if (
         $summary.schemaVersion -ne 2 -or
+        $summary.sourceTree -cnotmatch '^[0-9a-f]{40}$' -or
+        $summary.candidateSourceSha256 -cnotmatch '^[0-9a-f]{64}$' -or
         $summary.protocol -ne 'interleaved-abba-baab-v1' -or
         $summary.executionProfile.id -cne 'highest-efficiency-class-affinity-normal-v1' -or
         $summary.executionProfile.affinityMask -cne '0xFFFF' -or
         $summary.executionProfile.priorityClass -cne 'Normal' -or
+        $summary.bracketManifestSha256 -cne $bracketManifestSha256 -or
         @($summary.rows).Count -ne 7 -or
         $summary.allRowsWithinMaterialityBand -ne $false -or
         @($summary.rows | Where-Object { $_.withinMaterialityBand -ne $false }).Count -ne 0 -or
         -not $summaryMarkdown.Contains('| no |') -or
-        -not $summaryMarkdown.Contains('highest-efficiency-class-affinity-normal-v1')
+        -not $summaryMarkdown.Contains('highest-efficiency-class-affinity-normal-v1') -or
+        -not $summaryMarkdown.Contains($summary.sourceTree) -or
+        -not $summaryMarkdown.Contains($summary.candidateSourceSha256) -or
+        -not $summaryMarkdown.Contains($bracketManifestSha256)
     ) {
         throw 'The paired comparison gate did not write the expected summary artifacts.'
     }
@@ -245,6 +278,24 @@ try {
     ) {
         throw 'Stable paired records did not render a passing user-facing verdict.'
     }
+
+    $mismatchedCommit = 'f' * 40
+    $mismatchedCommitRecords = @($pairedScenarios | ForEach-Object {
+        New-PairedRecord -Scenario $_ -Commit $mismatchedCommit
+    })
+    Write-Baseline -Scenarios $expected -Commit $mismatchedCommit
+    Write-Evidence -Records $mismatchedCommitRecords
+    try {
+        Invoke-Gate
+        throw 'The comparison gate accepted a published commit different from checked-out HEAD.'
+    }
+    catch {
+        if ($_.Exception.Message -notmatch 'Checked-out HEAD.*does not match published commit') {
+            throw
+        }
+    }
+    Write-Baseline -Scenarios $expected
+    Write-Evidence -Records $stableRecords
 
     $invalidProcessEvidence = Get-Content -LiteralPath $processEvidencePath -Raw | ConvertFrom-Json
     $invalidProcessEvidence.actualProcessorAffinityMask = '0xFFFFFFFF'

--- a/scripts/unity/reduce-paired-bracket.js
+++ b/scripts/unity/reduce-paired-bracket.js
@@ -1,0 +1,577 @@
+"use strict";
+
+const crypto = require("crypto");
+const fs = require("fs");
+const path = require("path");
+const { execFileSync } = require("child_process");
+const supportedScenarios = require("./comparison-supported-scenarios.json");
+
+const SCHEMA_VERSION = 1;
+const MATERIALITY_BAND_PERCENT = 3;
+const COMPARISON_TOLERANCE_PERCENT = 1e-9;
+const EXECUTION_PROFILE_ID = "highest-efficiency-class-affinity-normal-v1";
+const AFFINITY_MASK = "0xFFFF";
+const PRIORITY_CLASS = "Normal";
+const PROTOCOL = "interleaved-abba-baab-v1";
+const CYCLES = 4;
+const MINIMUM_CYCLE_ACTIVE_MILLISECONDS = 625;
+const BATCH_OPERATIONS = 10000;
+const ORIENTATIONS = new Set(["candidate-control-candidate", "control-candidate-control"]);
+const ROW_ROLES = new Set(["target", "affected", "sentinel"]);
+const CANONICAL_ONLY_SCENARIOS = new Set(["PriorityOrdered", "SubUnsub"]);
+const PAIRED_SCENARIOS = supportedScenarios.MessagePipe.filter(
+  (scenario) => !CANONICAL_ONLY_SCENARIOS.has(scenario)
+);
+const RELATIVE_TOLERANCE = 1e-12;
+const SPREAD_TOLERANCE_PERCENT = 1e-9;
+const REPO_ROOT = path.resolve(__dirname, "../..");
+const EXPECTED_CPU_MODEL = "13th Gen Intel(R) Core(TM) i9-13900KF";
+const EXPECTED_LOGICAL_PROCESSORS = Array.from({ length: 16 }, (_, index) => index);
+let trackedRuntimePaths;
+
+function usage() {
+  return `Usage: node scripts/unity/reduce-paired-bracket.js --manifest <json> --first <summary.json> --center <summary.json> --last <summary.json> [--output <json>]
+
+Reduces one predeclared three-run paired benchmark bracket. The manifest must be
+present, byte-for-byte unchanged, in all three retained summary files.
+Use --validate-manifest with --manifest to validate the declaration before run one.
+`;
+}
+
+function parseArgs(argv) {
+  const options = {
+    manifest: "",
+    first: "",
+    center: "",
+    last: "",
+    output: "",
+    validateManifest: false,
+    help: false
+  };
+  for (let index = 2; index < argv.length; index++) {
+    const argument = argv[index];
+    if (argument === "--help" || argument === "-h") {
+      options.help = true;
+      continue;
+    }
+    if (argument === "--validate-manifest") {
+      options.validateManifest = true;
+      continue;
+    }
+    const optionName = argument.startsWith("--") ? argument.slice(2) : "";
+    if (!["manifest", "first", "center", "last", "output"].includes(optionName)) {
+      throw new Error(`Unknown option: ${argument}`);
+    }
+    const value = argv[++index];
+    if (!value || value.startsWith("--")) {
+      throw new Error(`${argument} requires a value.`);
+    }
+    options[optionName] = value;
+  }
+  if (!options.help) {
+    const required = options.validateManifest
+      ? ["manifest"]
+      : ["manifest", "first", "center", "last"];
+    for (const name of required) {
+      if (!options[name]) {
+        throw new Error(`--${name} is required.`);
+      }
+    }
+  }
+  return options;
+}
+
+function isObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function requireFiniteNumber(value, field) {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new Error(`${field} must be a finite number.`);
+  }
+  return value;
+}
+
+function requireExactKeys(value, keys, field) {
+  const actual = Object.keys(value).sort();
+  const expected = [...keys].sort();
+  if (actual.length !== expected.length || actual.some((key, index) => key !== expected[index])) {
+    throw new Error(`${field} must contain exactly: ${expected.join(", ")}.`);
+  }
+}
+
+function getTrackedRuntimePaths() {
+  if (trackedRuntimePaths === undefined) {
+    const output = execFileSync(
+      "git",
+      ["-C", REPO_ROOT, "ls-tree", "-r", "--name-only", "HEAD", "--", "Runtime"],
+      { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }
+    );
+    trackedRuntimePaths = output.split(/\r?\n/).filter(Boolean);
+  }
+  return trackedRuntimePaths;
+}
+
+function validateManifest(manifest, { requireTrackedCandidatePaths = false } = {}) {
+  if (!isObject(manifest)) {
+    throw new Error("The bracket manifest must be an object.");
+  }
+  requireExactKeys(
+    manifest,
+    [
+      "schemaVersion",
+      "bracketId",
+      "orientation",
+      "materialityBandPercent",
+      "candidatePaths",
+      "rows"
+    ],
+    "The bracket manifest"
+  );
+  if (manifest.schemaVersion !== SCHEMA_VERSION) {
+    throw new Error(`The bracket manifest schemaVersion must be ${SCHEMA_VERSION}.`);
+  }
+  if (typeof manifest.bracketId !== "string" || manifest.bracketId.trim() === "") {
+    throw new Error("The bracket manifest bracketId must be a non-empty string.");
+  }
+  if (!ORIENTATIONS.has(manifest.orientation)) {
+    throw new Error(`Unsupported bracket orientation: ${manifest.orientation}`);
+  }
+  if (manifest.materialityBandPercent !== MATERIALITY_BAND_PERCENT) {
+    throw new Error(`The bracket materiality band must remain ${MATERIALITY_BAND_PERCENT}%.`);
+  }
+  if (!Array.isArray(manifest.candidatePaths) || manifest.candidatePaths.length === 0) {
+    throw new Error("The bracket manifest candidatePaths must be a non-empty array.");
+  }
+  const candidatePaths = new Set();
+  for (const [index, candidatePath] of manifest.candidatePaths.entries()) {
+    if (
+      typeof candidatePath !== "string" ||
+      !candidatePath.startsWith("Runtime/") ||
+      candidatePath.endsWith("/") ||
+      candidatePath.includes("\\") ||
+      candidatePath
+        .split("/")
+        .some((segment) => segment === "" || segment === "." || segment === "..")
+    ) {
+      throw new Error(
+        `Manifest candidatePaths[${index}] must be a normalized path below Runtime/.`
+      );
+    }
+    if (candidatePaths.has(candidatePath)) {
+      throw new Error(`Manifest candidate path '${candidatePath}' is duplicated.`);
+    }
+    if (requireTrackedCandidatePaths) {
+      const trackedPaths = getTrackedRuntimePaths();
+      if (
+        !trackedPaths.includes(candidatePath) &&
+        !trackedPaths.some((trackedPath) => trackedPath.startsWith(`${candidatePath}/`))
+      ) {
+        throw new Error(
+          `Manifest candidate path '${candidatePath}' is not tracked at HEAD with exact case.`
+        );
+      }
+    }
+    candidatePaths.add(candidatePath);
+  }
+  if (!Array.isArray(manifest.rows) || manifest.rows.length === 0) {
+    throw new Error("The bracket manifest rows must be a non-empty array.");
+  }
+  if (
+    manifest.rows.length !== PAIRED_SCENARIOS.length ||
+    manifest.rows.some((row, index) => !isObject(row) || row.scenario !== PAIRED_SCENARIOS[index])
+  ) {
+    throw new Error(
+      `The bracket manifest must classify every paired scenario in this order: ${PAIRED_SCENARIOS.join(
+        ", "
+      )}.`
+    );
+  }
+
+  const scenarios = new Set();
+  let targetCount = 0;
+  let sentinelCount = 0;
+  for (const [index, row] of manifest.rows.entries()) {
+    if (!isObject(row)) {
+      throw new Error(`Manifest row ${index} must be an object.`);
+    }
+    requireExactKeys(row, ["scenario", "role"], `Manifest row ${index}`);
+    if (typeof row.scenario !== "string" || row.scenario.trim() === "") {
+      throw new Error(`Manifest row ${index} scenario must be a non-empty string.`);
+    }
+    if (scenarios.has(row.scenario)) {
+      throw new Error(`Manifest scenario '${row.scenario}' is duplicated.`);
+    }
+    scenarios.add(row.scenario);
+    if (!ROW_ROLES.has(row.role)) {
+      throw new Error(`Manifest scenario '${row.scenario}' has unsupported role '${row.role}'.`);
+    }
+    targetCount += row.role === "target" ? 1 : 0;
+    sentinelCount += row.role === "sentinel" ? 1 : 0;
+  }
+  if (targetCount === 0) {
+    throw new Error("The bracket manifest must declare at least one target row.");
+  }
+  if (sentinelCount < 2) {
+    throw new Error("The bracket manifest must declare at least two sentinel rows.");
+  }
+  return manifest;
+}
+
+function manifestSha256(manifestBytes) {
+  return crypto.createHash("sha256").update(manifestBytes).digest("hex");
+}
+
+function requireCycleEvidence(row, label, ratio, spread) {
+  if (!Array.isArray(row.cycleRatios) || row.cycleRatios.length !== CYCLES) {
+    throw new Error(`${label} cycleRatios must contain exactly ${CYCLES} values.`);
+  }
+  const cycleRatios = row.cycleRatios.map((value, index) => {
+    const cycleRatio = requireFiniteNumber(value, `${label} cycleRatios[${index}]`);
+    if (cycleRatio <= 0) {
+      throw new Error(`${label} cycleRatios[${index}] must be positive.`);
+    }
+    return cycleRatio;
+  });
+  const logs = cycleRatios.map(Math.log);
+  const headlineLog = logs.reduce((sum, value) => sum + value, 0) / CYCLES;
+  const recomputedHeadline = Math.exp(headlineLog);
+  if (
+    !Number.isFinite(recomputedHeadline) ||
+    recomputedHeadline <= 0 ||
+    Math.abs(Math.log(ratio) - headlineLog) > Math.log1p(RELATIVE_TOLERANCE)
+  ) {
+    throw new Error(`${label} headline is not the geometric mean of its cycleRatios.`);
+  }
+  const logRange = Math.max(...logs) - Math.min(...logs);
+  const recomputedSpread = Math.expm1(logRange) * 100;
+  if (
+    !Number.isFinite(recomputedSpread) ||
+    Math.abs(spread - recomputedSpread) > SPREAD_TOLERANCE_PERCENT
+  ) {
+    throw new Error(`${label} spread does not match its cycleRatios.`);
+  }
+}
+
+function validateSummary(summary, label, manifest, expectedDigest) {
+  if (!isObject(summary)) {
+    throw new Error(`${label} summary must be an object.`);
+  }
+  if (summary.schemaVersion !== 2) {
+    throw new Error(`${label} summary schemaVersion must be 2.`);
+  }
+  if (typeof summary.commit !== "string" || !/^[0-9a-f]{40}$/.test(summary.commit)) {
+    throw new Error(`${label} summary commit must be a full lowercase Git SHA-1.`);
+  }
+  if (typeof summary.sourceTree !== "string" || !/^[0-9a-f]{40}$/.test(summary.sourceTree)) {
+    throw new Error(`${label} summary sourceTree must be a full lowercase Git tree SHA-1.`);
+  }
+  if (
+    typeof summary.candidateSourceSha256 !== "string" ||
+    !/^[0-9a-f]{64}$/.test(summary.candidateSourceSha256)
+  ) {
+    throw new Error(`${label} summary candidateSourceSha256 must be a lowercase SHA-256.`);
+  }
+  if (
+    typeof summary.platform !== "string" ||
+    !/^Standalone IL2CPP x64 Release \(WindowsPlayer; Unity \d+\.\d+\.\d+f\d+\)$/.test(
+      summary.platform
+    )
+  ) {
+    throw new Error(`${label} summary platform is not the pinned Standalone IL2CPP Release shape.`);
+  }
+  if (
+    !isObject(summary.executionProfile) ||
+    summary.executionProfile.id !== EXECUTION_PROFILE_ID ||
+    summary.executionProfile.affinityMask !== AFFINITY_MASK ||
+    summary.executionProfile.priorityClass !== PRIORITY_CLASS
+  ) {
+    throw new Error(`${label} summary execution profile does not match the pinned profile.`);
+  }
+  requireExactKeys(
+    summary.executionProfile,
+    [
+      "id",
+      "cpuModel",
+      "source",
+      "selectionPolicy",
+      "selectedEfficiencyClass",
+      "selectedLogicalProcessorIndices",
+      "affinityMask",
+      "priorityClass"
+    ],
+    `${label} summary execution profile`
+  );
+  if (
+    summary.executionProfile.cpuModel !== EXPECTED_CPU_MODEL ||
+    summary.executionProfile.source !== "GetSystemCpuSetInformation" ||
+    summary.executionProfile.selectionPolicy !== "maximum EfficiencyClass" ||
+    !Number.isInteger(summary.executionProfile.selectedEfficiencyClass) ||
+    summary.executionProfile.selectedEfficiencyClass < 0 ||
+    !Array.isArray(summary.executionProfile.selectedLogicalProcessorIndices) ||
+    summary.executionProfile.selectedLogicalProcessorIndices.length !==
+      EXPECTED_LOGICAL_PROCESSORS.length ||
+    summary.executionProfile.selectedLogicalProcessorIndices.some(
+      (logicalProcessor, index) => logicalProcessor !== EXPECTED_LOGICAL_PROCESSORS[index]
+    )
+  ) {
+    throw new Error(`${label} summary execution profile topology does not match the pinned host.`);
+  }
+  if (
+    summary.protocol !== PROTOCOL ||
+    summary.cycles !== CYCLES ||
+    summary.minimumCycleActiveMilliseconds !== MINIMUM_CYCLE_ACTIVE_MILLISECONDS ||
+    summary.batchOperations !== BATCH_OPERATIONS
+  ) {
+    throw new Error(`${label} summary protocol constants do not match the pinned protocol.`);
+  }
+  if (summary.bracketManifestSha256 !== expectedDigest) {
+    throw new Error(`${label} summary does not match the predeclared bracket manifest digest.`);
+  }
+  if (!Array.isArray(summary.rows)) {
+    throw new Error(`${label} summary rows must be an array.`);
+  }
+  if (summary.materialityBandPercent !== manifest.materialityBandPercent) {
+    throw new Error(`${label} summary materiality band does not match the manifest.`);
+  }
+  if (summary.rows.length !== manifest.rows.length) {
+    throw new Error(`${label} summary row count does not match the manifest.`);
+  }
+
+  const rows = new Map();
+  for (let index = 0; index < manifest.rows.length; index++) {
+    const expected = manifest.rows[index].scenario;
+    const row = summary.rows[index];
+    if (!isObject(row) || row.scenario !== expected) {
+      throw new Error(`${label} summary row ${index} must be '${expected}'.`);
+    }
+    if (rows.has(row.scenario)) {
+      throw new Error(`${label} summary scenario '${row.scenario}' is duplicated.`);
+    }
+    const ratio = requireFiniteNumber(
+      row.firstToSecondRatio,
+      `${label} summary '${row.scenario}' firstToSecondRatio`
+    );
+    if (ratio <= 0) {
+      throw new Error(`${label} summary '${row.scenario}' ratio must be positive.`);
+    }
+    const spread = requireFiniteNumber(
+      row.cycleRatioSpreadPercent,
+      `${label} summary '${row.scenario}' cycleRatioSpreadPercent`
+    );
+    if (spread < 0) {
+      throw new Error(`${label} summary '${row.scenario}' spread must not be negative.`);
+    }
+    requireCycleEvidence(row, `${label} summary '${row.scenario}'`, ratio, spread);
+    rows.set(row.scenario, { ratio, spread });
+  }
+  return rows;
+}
+
+function stableIdentity(summary) {
+  return JSON.stringify({
+    platform: summary.platform,
+    executionProfile: summary.executionProfile,
+    protocol: summary.protocol,
+    cycles: summary.cycles,
+    minimumCycleActiveMilliseconds: summary.minimumCycleActiveMilliseconds,
+    batchOperations: summary.batchOperations,
+    materialityBandPercent: summary.materialityBandPercent
+  });
+}
+
+function reducePairedBracket(manifestBytes, summaries) {
+  if (!Buffer.isBuffer(manifestBytes) && typeof manifestBytes !== "string") {
+    throw new Error("Manifest bytes must be a Buffer or string.");
+  }
+  if (!Array.isArray(summaries) || summaries.length !== 3) {
+    throw new Error("Exactly three retained summaries are required.");
+  }
+  const manifestText = manifestBytes.toString();
+  const manifest = validateManifest(JSON.parse(manifestText));
+  const digest = manifestSha256(manifestBytes);
+  const labels = ["first", "center", "last"];
+  const rowsByRun = summaries.map((summary, index) =>
+    validateSummary(summary, labels[index], manifest, digest)
+  );
+  const identity = stableIdentity(summaries[0]);
+  for (let index = 1; index < summaries.length; index++) {
+    if (stableIdentity(summaries[index]) !== identity) {
+      throw new Error(`${labels[index]} summary protocol or execution profile does not match.`);
+    }
+  }
+  if (new Set(summaries.map((summary) => summary.commit)).size !== 3) {
+    throw new Error("The three summaries must come from distinct commits.");
+  }
+  if (summaries[0].sourceTree !== summaries[2].sourceTree) {
+    throw new Error("The two outer summaries must contain the same source tree.");
+  }
+  if (summaries[0].sourceTree === summaries[1].sourceTree) {
+    throw new Error("The outer and center summaries must contain different source trees.");
+  }
+  if (summaries[0].candidateSourceSha256 !== summaries[2].candidateSourceSha256) {
+    throw new Error("The two outer summaries must contain the same candidate-source digest.");
+  }
+  if (summaries[0].candidateSourceSha256 === summaries[1].candidateSourceSha256) {
+    throw new Error(
+      "The outer and center summaries must contain different candidate-source digests."
+    );
+  }
+
+  const band = manifest.materialityBandPercent;
+  const rowResults = [];
+  const sentinelFactors = [];
+  for (const declaration of manifest.rows) {
+    const first = rowsByRun[0].get(declaration.scenario);
+    const center = rowsByRun[1].get(declaration.scenario);
+    const last = rowsByRun[2].get(declaration.scenario);
+    const outerLogMean = (Math.log(first.ratio) + Math.log(last.ratio)) / 2;
+    const candidateLogFactor =
+      manifest.orientation === "candidate-control-candidate"
+        ? outerLogMean - Math.log(center.ratio)
+        : Math.log(center.ratio) - outerLogMean;
+    const candidateFactor = Math.exp(candidateLogFactor);
+    const candidateEffectPercent = Math.expm1(candidateLogFactor) * 100;
+    const outerSpreadPercent =
+      Math.expm1(Math.abs(Math.log(first.ratio) - Math.log(last.ratio))) * 100;
+    if (
+      !Number.isFinite(candidateFactor) ||
+      candidateFactor <= 0 ||
+      !Number.isFinite(candidateEffectPercent) ||
+      !Number.isFinite(outerSpreadPercent)
+    ) {
+      throw new Error(`${declaration.scenario} produced a non-finite bracket reduction.`);
+    }
+    const maximumRawSpreadPercent = Math.max(first.spread, center.spread, last.spread);
+    if (declaration.role === "sentinel") {
+      sentinelFactors.push(candidateFactor);
+    }
+    rowResults.push({
+      scenario: declaration.scenario,
+      role: declaration.role,
+      candidateLogFactor,
+      candidateEffectPercent,
+      outerSpreadPercent,
+      maximumRawSpreadPercent
+    });
+  }
+
+  const sentinelLogReference =
+    sentinelFactors.reduce((sum, factor) => sum + Math.log(factor), 0) / sentinelFactors.length;
+  const sentinelReference = Math.exp(sentinelLogReference);
+  if (!Number.isFinite(sentinelReference) || sentinelReference <= 0) {
+    throw new Error("The sentinel reference is not finite and positive.");
+  }
+  for (const row of rowResults) {
+    row.sentinelNormalizedEffectPercent =
+      row.role === "sentinel"
+        ? null
+        : Math.expm1(row.candidateLogFactor - sentinelLogReference) * 100;
+    if (
+      row.sentinelNormalizedEffectPercent !== null &&
+      !Number.isFinite(row.sentinelNormalizedEffectPercent)
+    ) {
+      throw new Error(`${row.scenario} produced a non-finite sentinel-normalized effect.`);
+    }
+  }
+
+  const unstableReasons = [];
+  const rejectionReasons = [];
+  for (const row of rowResults) {
+    if (row.maximumRawSpreadPercent > band + COMPARISON_TOLERANCE_PERCENT) {
+      unstableReasons.push(`${row.scenario} raw-cycle spread exceeds ${band}%.`);
+    }
+    if (row.outerSpreadPercent > band + COMPARISON_TOLERANCE_PERCENT) {
+      unstableReasons.push(`${row.scenario} outer spread exceeds ${band}%.`);
+    }
+    if (
+      row.role === "sentinel" &&
+      Math.abs(row.candidateEffectPercent) > band + COMPARISON_TOLERANCE_PERCENT
+    ) {
+      unstableReasons.push(`${row.scenario} sentinel effect exceeds +/-${band}%.`);
+    }
+    if (
+      row.role === "target" &&
+      row.sentinelNormalizedEffectPercent <= band + COMPARISON_TOLERANCE_PERCENT
+    ) {
+      rejectionReasons.push(
+        `${row.scenario} sentinel-normalized target effect does not exceed ${band}%.`
+      );
+    }
+    if (
+      row.role === "affected" &&
+      row.sentinelNormalizedEffectPercent < -band - COMPARISON_TOLERANCE_PERCENT
+    ) {
+      rejectionReasons.push(
+        `${row.scenario} sentinel-normalized affected-row regression exceeds ${band}%.`
+      );
+    }
+  }
+
+  const status =
+    unstableReasons.length > 0
+      ? "uninterpretable"
+      : rejectionReasons.length > 0
+        ? "rejected"
+        : "accepted";
+  return {
+    schemaVersion: SCHEMA_VERSION,
+    bracketId: manifest.bracketId,
+    orientation: manifest.orientation,
+    bracketManifestSha256: digest,
+    materialityBandPercent: band,
+    provenance: summaries.map((summary, index) => ({
+      position: labels[index],
+      commit: summary.commit,
+      sourceTree: summary.sourceTree,
+      candidateSourceSha256: summary.candidateSourceSha256
+    })),
+    sentinelReference,
+    status,
+    reasons: status === "uninterpretable" ? unstableReasons : rejectionReasons,
+    rows: rowResults.map(({ candidateLogFactor, ...row }) => row)
+  };
+}
+
+function runCli(argv) {
+  const options = parseArgs(argv);
+  if (options.help) {
+    process.stdout.write(usage());
+    return 0;
+  }
+  const manifestBytes = fs.readFileSync(options.manifest);
+  if (options.validateManifest) {
+    validateManifest(JSON.parse(manifestBytes.toString()), { requireTrackedCandidatePaths: true });
+    process.stdout.write(`${manifestSha256(manifestBytes)}\n`);
+    return 0;
+  }
+  const summaries = [options.first, options.center, options.last].map((file) =>
+    JSON.parse(fs.readFileSync(file, "utf8"))
+  );
+  const result = reducePairedBracket(manifestBytes, summaries);
+  const output = `${JSON.stringify(result, null, 2)}\n`;
+  if (options.output) {
+    fs.writeFileSync(options.output, output);
+  } else {
+    process.stdout.write(output);
+  }
+  return result.status === "accepted" ? 0 : 2;
+}
+
+if (require.main === module) {
+  try {
+    process.exitCode = runCli(process.argv);
+  } catch (error) {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 1;
+  }
+}
+
+module.exports = {
+  MATERIALITY_BAND_PERCENT,
+  manifestSha256,
+  parseArgs,
+  reducePairedBracket,
+  runCli,
+  validateManifest
+};

--- a/scripts/unity/reduce-paired-bracket.js.meta
+++ b/scripts/unity/reduce-paired-bracket.js.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 1250e81aed4c2464e712df22919080ef
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/scripts/unity/require-comparison-rows.ps1
+++ b/scripts/unity/require-comparison-rows.ps1
@@ -16,7 +16,9 @@ param(
     [string]$SummaryJsonPath,
 
     [Parameter(Mandatory = $true)]
-    [string]$SummaryMarkdownPath
+    [string]$SummaryMarkdownPath,
+
+    [string]$BracketManifestPath = ''
 )
 
 Set-StrictMode -Version Latest
@@ -27,6 +29,25 @@ if (-not (Test-Path -LiteralPath $BaselinePath -PathType Leaf)) {
 }
 
 $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
+$bracketManifestSha256 = $null
+$candidatePaths = @()
+if (-not [string]::IsNullOrWhiteSpace($BracketManifestPath)) {
+    $resolvedBracketManifestPath = if ([System.IO.Path]::IsPathRooted($BracketManifestPath)) {
+        $BracketManifestPath
+    }
+    else {
+        Join-Path $repoRoot $BracketManifestPath
+    }
+    if (-not (Test-Path -LiteralPath $resolvedBracketManifestPath -PathType Leaf)) {
+        throw "Bracket manifest does not exist: $resolvedBracketManifestPath"
+    }
+    $bracketManifestSha256 = (Get-FileHash -LiteralPath $resolvedBracketManifestPath -Algorithm SHA256).Hash.ToLowerInvariant()
+    $bracketManifest = Get-Content -LiteralPath $resolvedBracketManifestPath -Raw | ConvertFrom-Json
+    $candidatePaths = @($bracketManifest.candidatePaths)
+    if ($candidatePaths.Count -eq 0) {
+        throw 'Bracket manifest candidatePaths must contain at least one runtime source path.'
+    }
+}
 # SYNC: BenchmarkProtocol.PairedProtocolId, PairedMeasurementCycles,
 # PairedMinimumCycleActiveMilliseconds, BatchSize, and PairedMaterialityBandPercent define these values.
 $pairedProtocol = 'interleaved-abba-baab-v1'
@@ -289,8 +310,75 @@ try {
     if ([string]::IsNullOrWhiteSpace($publishedCommit)) {
         throw 'Published comparison rows must carry a non-empty commit.'
     }
+    if ($publishedCommit -cnotmatch '^[0-9a-f]{40}$') {
+        throw "Published comparison rows must carry a full lowercase Git SHA-1: '$publishedCommit'."
+    }
     if ($publishedPlatform -cnotmatch '^Standalone IL2CPP x64 Release \(WindowsPlayer; Unity [^)]+\)$') {
         throw "Published comparison rows use an invalid platform: '$publishedPlatform'."
+    }
+
+    $headCommitOutput = @(& git -C $repoRoot rev-parse HEAD 2>&1)
+    if ($LASTEXITCODE -ne 0 -or $headCommitOutput.Count -ne 1) {
+        throw 'Could not resolve the checked-out Git commit for paired comparison provenance.'
+    }
+    $headCommit = ([string]$headCommitOutput[0]).Trim()
+    if ($headCommit -cne $publishedCommit) {
+        throw "Checked-out HEAD '$headCommit' does not match published commit '$publishedCommit'."
+    }
+    $measuredSourcePaths = @(
+        'Runtime',
+        'Tests/Runtime/Benchmarks',
+        'Tests/Runtime/Comparisons',
+        'Tests/Runtime/Scripts/Messages'
+    )
+    & git -C $repoRoot diff --quiet -- $measuredSourcePaths
+    $workingDiffExitCode = $LASTEXITCODE
+    if ($workingDiffExitCode -eq 1) {
+        throw 'Measured runtime or benchmark sources differ from the checked-out commit.'
+    }
+    if ($workingDiffExitCode -ne 0) {
+        throw "Could not verify measured working-tree sources; git diff exited $workingDiffExitCode."
+    }
+    & git -C $repoRoot diff --cached --quiet -- $measuredSourcePaths
+    $indexDiffExitCode = $LASTEXITCODE
+    if ($indexDiffExitCode -eq 1) {
+        throw 'The index contains measured runtime or benchmark source changes.'
+    }
+    if ($indexDiffExitCode -ne 0) {
+        throw "Could not verify measured index sources; git diff exited $indexDiffExitCode."
+    }
+    $sourceTreeOutput = @(& git -C $repoRoot rev-parse "${publishedCommit}^{tree}" 2>&1)
+    if ($LASTEXITCODE -ne 0 -or $sourceTreeOutput.Count -ne 1) {
+        throw 'Could not resolve the published Git source tree for paired comparison provenance.'
+    }
+    $sourceTree = ([string]$sourceTreeOutput[0]).Trim()
+    if ($sourceTree -cnotmatch '^[0-9a-f]{40}$') {
+        throw "Paired comparison source tree is not a full lowercase Git tree SHA-1: '$sourceTree'."
+    }
+    $candidateSourceSha256 = $null
+    if ($candidatePaths.Count -ne 0) {
+        foreach ($candidatePath in $candidatePaths) {
+            $candidatePathRows = @(& git -C $repoRoot ls-tree -r --full-tree $publishedCommit -- $candidatePath 2>&1)
+            if ($LASTEXITCODE -ne 0 -or $candidatePathRows.Count -eq 0) {
+                throw "Could not resolve candidate source path '$candidatePath' at the published commit."
+            }
+        }
+        $gitArguments = @('-C', $repoRoot, 'ls-tree', '-r', '--full-tree', $publishedCommit, '--') + $candidatePaths
+        $candidateSourceRows = @(& git @gitArguments 2>&1)
+        if ($LASTEXITCODE -ne 0 -or $candidateSourceRows.Count -eq 0) {
+            throw 'Could not resolve every predeclared candidate source path at the published commit.'
+        }
+        $candidateSourcePayload = ($candidateSourceRows -join "`n") + "`n"
+        $sha256 = [System.Security.Cryptography.SHA256]::Create()
+        try {
+            $candidateSourceHash = $sha256.ComputeHash(
+                [System.Text.Encoding]::UTF8.GetBytes($candidateSourcePayload)
+            )
+        }
+        finally {
+            $sha256.Dispose()
+        }
+        $candidateSourceSha256 = -join @($candidateSourceHash | ForEach-Object { $_.ToString('x2') })
     }
 
     # SYNC: PairedDxMessagingMessagePipeTests.cs uses this MessagePipe capability set and
@@ -500,6 +588,8 @@ try {
         schemaVersion = 2
         platform = $publishedPlatform
         commit = $publishedCommit
+        sourceTree = $sourceTree
+        candidateSourceSha256 = $candidateSourceSha256
         executionProfile = [ordered]@{
             id = $cpuProfile.executionProfileId
             cpuModel = $cpuProfile.cpuModel
@@ -515,6 +605,7 @@ try {
         minimumCycleActiveMilliseconds = $pairedMinimumCycleActiveMilliseconds
         batchOperations = $pairedBatchOperations
         materialityBandPercent = $pairedMaterialityBandPercent
+        bracketManifestSha256 = $bracketManifestSha256
         allRowsWithinMaterialityBand = @($summaryRows | Where-Object { -not $_.withinMaterialityBand }).Count -eq 0
         rows = $summaryRows
     }
@@ -533,8 +624,14 @@ try {
     $markdown = [System.Collections.Generic.List[string]]::new()
     $markdown.Add('### In-process paired comparison')
     $markdown.Add('')
-    $markdown.Add("Protocol: ``$($summary.protocol)``; commit: ``$publishedCommit``; platform: $publishedPlatform.")
+    $markdown.Add("Protocol: ``$($summary.protocol)``; commit: ``$publishedCommit``; source tree: ``$sourceTree``; platform: $publishedPlatform.")
+    if ($null -ne $summary.candidateSourceSha256) {
+        $markdown.Add("Candidate source SHA-256: ``$($summary.candidateSourceSha256)``.")
+    }
     $markdown.Add("Execution profile: ``$($summary.executionProfile.id)``; affinity: ``$($summary.executionProfile.affinityMask)``; priority: ``$($summary.executionProfile.priorityClass)``.")
+    if ($null -ne $summary.bracketManifestSha256) {
+        $markdown.Add("Bracket manifest SHA-256: ``$($summary.bracketManifestSha256)``.")
+    }
     $markdown.Add('')
     $markdown.Add("| Scenario | DxMessaging / MessagePipe | Raw cycle spread | Within $pairedMaterialityBandPercent% band |")
     $markdown.Add('| --- | ---: | ---: | :---: |')

--- a/scripts/validate-js-loc-budget.js
+++ b/scripts/validate-js-loc-budget.js
@@ -141,7 +141,14 @@ const path = require("path");
 //     actions and a new ci-aggregate-workflow test enforces the ignore list,
 //     converting every future bump into one manual commit across workflows
 //     and docs, plus the 7 lines this entry itself adds: 18398.
-const TOTAL_BUDGET = 18398;
+// 083 Fail closed on confounded three-run performance attribution. A 577-line
+//     reducer validates the manifest, canonical roster, source-tree provenance,
+//     profile, protocol, retained cycles, spreads, sentinels, and normalized
+//     target and affected rows. Its 801-line suite covers both bracket orders,
+//     CLI exit states, malformed evidence, non-finite arithmetic, and the exact
+//     PR #468 ratios. Workflow and PowerShell tests pin manifest and source-tree
+//     provenance into each authoritative summary: 19780.
+const TOTAL_BUDGET = 19780;
 const LARGEST_FILE_COUNT = 10;
 const REPO_ROOT = path.resolve(__dirname, "..");
 

--- a/scripts/validate-unity-pr-policy.py
+++ b/scripts/validate-unity-pr-policy.py
@@ -3329,11 +3329,14 @@ def validate_perf_pr_policy() -> None:
         ),
         (
             benchmark,
-            r"require-comparison-rows\.ps1[\s\S]*?"
-            r"-BaselinePath \$currentBaseline[\s\S]*?"
-            r"-EvidencePaths \$evidenceInputs[\s\S]*?"
-            r"-SummaryJsonPath \(Join-Path \$artifactsPath 'paired-comparison-summary\.json'\)[\s\S]*?"
-            r"-SummaryMarkdownPath \(Join-Path \$artifactsPath 'paired-comparison-summary\.md'\)[\s\S]*?"
+            r"\$comparisonGateArguments = @\{[\s\S]*?"
+            r"BaselinePath = \$currentBaseline[\s\S]*?"
+            r"EvidencePaths = \$evidenceInputs[\s\S]*?"
+            r"SummaryJsonPath = Join-Path \$artifactsPath 'paired-comparison-summary\.json'[\s\S]*?"
+            r"SummaryMarkdownPath = Join-Path \$artifactsPath 'paired-comparison-summary\.md'[\s\S]*?"
+            r"\$bracketManifestPath = 'scripts/unity/paired-bracket-manifest\.json'[\s\S]*?"
+            r"\$comparisonGateArguments\.BracketManifestPath = \$bracketManifestPath[\s\S]*?"
+            r"require-comparison-rows\.ps1 @comparisonGateArguments[\s\S]*?"
             r"GITHUB_STEP_SUMMARY",
             "exact supported comparison row and paired evidence gate",
         ),


### PR DESCRIPTION
## Why

PR #468 removed a native call, but causally untouched `GlobalToOne` and `StructNoBox` moved about +7.3% with `Filtered`. The bracket was confounded, so its speedup claim was unsupported.

## What changed

- Revert the unsupported `EnsureFlat` inline hint and remove its performance claim.
- Predeclare the complete target, affected, sentinel, and candidate-source scope before run one.
- Bind summaries to commits, source trees, candidate blobs, the full CPU profile, protocol, and retained cycles.
- Reduce both bracket orders in log space and fail closed on unstable sentinels or normalized target and affected rows.

## How we know

- 523 script tests pass, including 70 reducer assertions and the PowerShell producer contract.
- Unity allocation tests pass 274/274. Two full PlayMode passes each report 1,133 passed, zero failed, and one expected skip. Two paired fixture passes each report 7/7.
- Repository validation, formatting, spelling, actionlint, CSharpier, and pre-commit pass.

## What remains

#414 stays open. The next runtime candidate waits for the corrected default-branch baseline after this change merges.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches dispatch hot-path attributes and tightens CI provenance gates for performance attribution; runtime behavior change is small (removed inlining) but benchmark acceptance rules are stricter.
> 
> **Overview**
> **Stops treating shared benchmark drift as a proven speedup** after PR #468’s `EnsureFlat` inline hint moved causally unreachable paired rows (~7%) with the target. The attribute and changelog/docs throughput claims are **reverted**; `InterceptorCache<T>.EnsureFlat` no longer uses `AggressiveInlining`.
> 
> **Adds a fail-closed candidate/control/candidate gate:** commit `scripts/unity/paired-bracket-manifest.json` up front (targets, affected rows, sentinels, `Runtime/` candidate paths). **`reduce-paired-bracket.js`** is the sole reducer—manifest validation, three distinct commits, outer/center tree and candidate-source digests, pinned profile/protocol, retained cycles, sentinel bounds, and sentinel-normalized target/affected checks (3% band). CI **preflights** the manifest when present and **`require-comparison-rows.ps1`** embeds manifest, source-tree, and candidate-source digests only when a manifest is supplied; it also requires **HEAD = published commit** and a clean measured tree.
> 
> Methodology runbooks, campaign decisions, and workflow/policy tests are updated to match; a large Node test suite locks reducer behavior including the PR #468 artifact shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb020d99263fb65d97d32e14b6f2ab69d856d018. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->