### PR TITLE
Fix Asset Store release staging

### DIFF
--- a/.github/workflows/asset-store-unsupported-upload-research.yml
+++ b/.github/workflows/asset-store-unsupported-upload-research.yml
@@ -1,4 +1,5 @@
 name: Asset Store Unsupported Upload Research
+# cspell:ignore tlsv
 
 on:
   workflow_dispatch:
@@ -9,7 +10,7 @@ on:
         type: string
 
 concurrency:
-  group: asset-store-unsupported-upload-research
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -23,9 +24,11 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Refuse accidental execution
+        env:
+          ACKNOWLEDGE_RISKS: ${{ inputs.acknowledge_risks }}
         run: |
           set -euo pipefail
-          if [ "${{ inputs.acknowledge_risks }}" != "I understand" ]; then
+          if [ "${ACKNOWLEDGE_RISKS}" != "I understand" ]; then
             echo "::error::This workflow is quarantined. Re-run manually with acknowledge_risks set to 'I understand'."
             exit 1
           fi
@@ -34,21 +37,69 @@ jobs:
             exit 1
           fi
 
-      - name: Document unsupported upload risk
+      - name: Capture official public documentation
         run: |
           set -euo pipefail
-          cat <<'RISK'
-          This workflow is a research quarantine only. It must not upload to the
-          Unity Asset Store, persist Unity publisher credentials, harvest browser
-          sessions, or call undocumented publisher endpoints.
+          evidence_dir=".artifacts/asset-store-research"
+          mkdir -p "${evidence_dir}"
+          sources=(
+            "https://assetstore.unity.com/publishing/upm-publishing|UPM publishing"
+            "https://docs.unity.com/en-us/asset-store/publishing/upm-packages/apply|Enroll as a UPM publisher"
+            "https://docs.unity.com/en-us/asset-store/publishing/upm-packages/validate|Validate and upload a UPM package"
+            "https://docs.unity.com/en-us/asset-store/publishing/upm-packages/submit|Submit a UPM product for approval"
+            "https://docs.unity.com/en-us/asset-store/publishing/asset-packages/upload|Validate and upload assets to your package"
+          )
+          : > "${evidence_dir}/SOURCES.txt"
+          : > "${evidence_dir}/FAILURES.txt"
+          index=0
+          for source in "${sources[@]}"; do
+            index=$((index + 1))
+            IFS='|' read -r url marker <<< "${source}"
+            output="${evidence_dir}/official-${index}.html"
+            if curl --proto '=https' --tlsv1.2 --location --fail-with-body \
+                --connect-timeout 5 --max-time 15 --output "${output}" "${url}" \
+                && grep -Fqi -- "${marker}" "${output}"; then
+              status="captured"
+            else
+              status="unavailable-or-unrecognized"
+              printf '%s\n' "${url}" >> "${evidence_dir}/FAILURES.txt"
+              touch "${output}"
+            fi
+            digest="$(sha256sum "${output}" | cut -d ' ' -f 1)"
+            printf '%s\t%s\t%s\n' "${status}" "${digest}" "${url}" >> "${evidence_dir}/SOURCES.txt"
+          done
+          cat > "${evidence_dir}/SUMMARY.md" <<'SUMMARY'
+          # Asset Store Automation Research
 
-          Research topics that stay outside release.yml:
-          - BatchSubmitter-style Editor API automation.
-          - Whether com.unity.upm-publishing-tools exposes a documented public Editor API and service authentication model.
-          - Prerequisites for an owner-run, sanctioned two-version publication that can test whether the Asset Store registry preserves _upm.changelog.
-          - Official Unity changes that might introduce a supported non-interactive API.
+          This artifact captures Unity's public publishing documentation for a
+          manual research run. It does not upload a package or prove that an
+          undocumented API is safe.
 
-          Before any CI upload wiring exists, Unity must document a supported
-          non-interactive upload path with service credentials that do not depend
-          on an interactive Unity ID session or 2FA browser cookie.
-          RISK
+          The release workflow must stay manual unless Unity documents both:
+
+          1. A supported non-interactive upload entry point.
+          1. A service credential that does not use a Unity ID browser session
+             or an interactive two-factor authentication challenge.
+
+          After an enrolled owner installs `com.unity.upm-publishing-tools`,
+          inspect its public API only to locate the matching Unity documentation.
+          Do not call internal methods or publisher endpoints. Record any new
+          official URLs in the issue before changing `release.yml`.
+          SUMMARY
+
+      - name: Upload research evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: asset-store-automation-research
+          path: .artifacts/asset-store-research/
+          if-no-files-found: error
+          retention-days: 30
+          overwrite: true
+
+      - name: Require complete official evidence
+        if: always()
+        run: |
+          set -euo pipefail
+          test -f .artifacts/asset-store-research/FAILURES.txt
+          test ! -s .artifacts/asset-store-research/FAILURES.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -894,7 +894,7 @@ jobs:
 
       - name: Assemble the Asset Store submission staging artifact
         # The official classic and UPM publishing tools document Editor UI,
-        # not a sanctioned headless API (re-verified 2026-08-24).
+        # not a sanctioned headless API (re-verified 2026-08-28).
         # This tested generator STAGES the
         # submission inputs, store media, manifest, and manual
         # checklists. It runs before npm publish so missing store collateral
@@ -908,6 +908,19 @@ jobs:
             --unitypackage-file "${{ steps.unitypackage_asset.outputs.unitypackage-file }}" \
             --unitypackage-checksum "${{ steps.unitypackage_asset.outputs.unitypackage-checksum }}" \
             --tag "${{ needs.verify-tag.outputs.tag }}"
+
+      - name: Upload the Asset Store submission staging artifact
+        # Upload before npm publication so a green irreversible registry step
+        # never precedes delivery of the operator's exact staged inputs.
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: asset-store-submission
+          path: .artifacts/asset-store-submission/
+          if-no-files-found: error
+          # overwrite: a release workflow re-run may replace the artifact from
+          # an earlier attempt before the idempotent npm/release steps resume.
+          overwrite: true
+          retention-days: 30
 
       # ORDERING INVARIANT: a published GitHub Release must never exist without
       # the matching npm version. The IRREVERSIBLE npm publish runs FIRST; the
@@ -996,16 +1009,3 @@ jobs:
             exit 1
           fi
           echo "::notice::Release ${tag} has all ${#expected[@]} expected assets."
-
-      - name: Upload the Asset Store submission staging artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: asset-store-submission
-          path: .artifacts/asset-store-submission/
-          if-no-files-found: error
-          # overwrite: the documented unitypackage-failure recovery is a workflow
-          # re-run, and attempt 1 already uploaded this artifact; without
-          # overwrite the re-run 409s here AFTER npm publish + the GitHub
-          # release succeeded, leaving a misleading red run.
-          overwrite: true
-          retention-days: 30

--- a/docs/ops/npm-release-publishing.md
+++ b/docs/ops/npm-release-publishing.md
@@ -106,8 +106,8 @@ The release workflow creates:
 - npm package version published with provenance
 - the `asset-store-submission` workflow artifact (the `.unitypackage`, the
   `.tgz`, checksums, store media, `CLASSIC-UPLOAD-CHECKLIST.md`,
-  `UPM-UPLOAD-CHECKLIST.md`, and
-  `MANIFEST.json`) staged for the manual Unity Asset Store upload before npm
+  `UPM-UPLOAD-CHECKLIST.md`, `EXPECTED-UPM-FIELDS.json`, and `MANIFEST.json`)
+  staged and uploaded for the manual Unity Asset Store upload before npm
   publish; the release-time procedure is the
   [Asset Store Publishing runbook](../runbooks/asset-store-publishing.md)
 

--- a/docs/ops/release-operations.md
+++ b/docs/ops/release-operations.md
@@ -121,16 +121,17 @@ The release workflow performs these gates:
 1. Assemble the `asset-store-submission` workflow artifact before the npm
    publish. The tested generator copies the `.unitypackage`, the `.tgz`,
    checksums, store media, and generated classic/UPM upload checklists plus
-   `MANIFEST.json`. Missing store collateral fails here before the irreversible
-   registry action.
+   `EXPECTED-UPM-FIELDS.json` and `MANIFEST.json`. Upload the workflow
+   artifact immediately; missing or invalid store collateral fails before the
+   irreversible registry action.
 1. Publish to npm with Trusted Publishing and provenance.
 1. Create or update the GitHub Release. The body is the matching `## [version]`
    `CHANGELOG.md` section plus an install footer, rendered by the shared
    `scripts/release/release-notes.js` extractor. Assets are the `.tgz`, its
    `.sha256`, the `.unitypackage`, and its `.sha256`; a final step asserts the
    published release carries all four.
-1. Upload the already-generated `asset-store-submission` workflow artifact for
-   the manual Unity Asset Store upload; the release-time procedure is the
+1. Follow the generated `asset-store-submission` workflow artifact for the
+   manual Unity Asset Store upload; the release-time procedure is the
    [Asset Store Publishing runbook](../runbooks/asset-store-publishing.md)
    (account onboarding: [Unity Asset Store UPM](./unity-asset-store-upm.md)).
 

--- a/docs/ops/unity-asset-store-upm.md
+++ b/docs/ops/unity-asset-store-upm.md
@@ -94,6 +94,10 @@ The duplication is checked rather than hidden.
 The other brand PNGs are direct renders of a single SVG and are not produced by
 this script: `icon-256.png` and `dxmessaging-store-icon-320.png` come from
 `dxmessaging-icon-tile.svg`, and the favicons come from `dxmessaging-mark.svg`.
+The release staging generator pins the SHA-256 of every Asset Store SVG source
+and PNG output. After an intentional render change, update the matching
+`STORE_MEDIA` source/output hashes in `scripts/release/asset-store-submission.js`;
+otherwise release staging fails before publication.
 
 ## Release Staging Artifact
 
@@ -105,8 +109,8 @@ artifact containing:
 - the npm `.tgz` (the exact UPM payload, for reference and diffing)
 - `.sha256` checksums for both
 - tracked store media under `media/`
-- generated `CLASSIC-UPLOAD-CHECKLIST.md`, `UPM-UPLOAD-CHECKLIST.md`, and
-  `MANIFEST.json`
+- generated `CLASSIC-UPLOAD-CHECKLIST.md`, `UPM-UPLOAD-CHECKLIST.md`,
+  `EXPECTED-UPM-FIELDS.json`, and `MANIFEST.json`
 
 The export stages the `npm pack` payload into an ephemeral Unity project
 under `Assets/WallstopStudios/DxMessaging/` with two Assets-form changes:
@@ -117,7 +121,7 @@ generator and analyzer from the RoslynAnalyzer-labeled DLLs shipped under
 import visibly.
 
 There is no sanctioned CLI or API for Unity Asset Store uploads (re-verified
-2026-08-24). Unity now ships the official `com.unity.upm-publishing-tools`
+2026-08-28). Unity now ships the official `com.unity.upm-publishing-tools`
 package alongside the classic publishing tool, but the official material for
 both describes interactive Editor workflows and does not document a headless
 entry point or service credential. Community batch uploaders still drive
@@ -141,10 +145,23 @@ the `.unitypackage` upload:
 
 1. Open an editor version listed as compatible with the installed UPM publishing
    tool, then install the tool from Unity's official channel.
-1. Validate the package with Unity's tooling.
-1. Upload the UPM package through the UPM publishing workflow.
+1. Add the staged `.tgz` through
+   `Window > Package Manager > Add package from tarball...`.
+1. Open `Window > Tools > Asset Store > Validator`, select the UPM validation
+   type, and validate the installed package.
+1. Open `Window > Tools > Asset Store > Uploader`, select the `UPM Packages`
+   tab, and upload the exact package version.
 1. Complete Asset Store metadata, screenshots, compatibility, and review fields.
 1. Submit for review.
+1. Repeat for two versions. In a clean Unity project where neither version is
+   installed, open Package Manager Version History, expand both versions, and
+   verify that each non-installed row displays its own expected release notes.
+   This UI result is the acceptance proof.
+1. If the Publisher Portal or supported Unity tooling exposes a version
+   manifest, also compare its `name`, `version`, and `_upm.changelog` values
+   with `EXPECTED-UPM-FIELDS.json`. This file records expected field values; it
+   is not a complete response schema. Do not query undocumented endpoints to
+   obtain the manifest.
 
 If Ambiguous does not have `Active` UPM admittance:
 

--- a/docs/runbooks/asset-store-publishing.md
+++ b/docs/runbooks/asset-store-publishing.md
@@ -9,20 +9,21 @@ rules, and the UPM-vs-classic submission choice, see
 The Asset Store upload is **manual by design**: Unity now provides official
 Editor tools for both classic and UPM submissions, but neither tool documents a
 non-interactive upload path (see the determination below). The release pipeline
-removes every manual step it can -- it stages the exact upload payload and a
-generated checklist as a workflow artifact -- so the human step is reduced to
+removes every manual step it can -- it stages the release source payloads and
+generated checklists as a workflow artifact -- so the human step is reduced to
 "download the artifact, then drive the Editor uploader." Treat this runbook as
 the source of truth for that step; keep account IDs, screenshots, and review
 correspondence out of it.
 
-## Automation determination (re-verified 2026-08-24)
+## Automation determination (re-verified 2026-08-28)
 
 There is **no sanctioned (official, documented, supported) CLI, API, or headless
 mode** for uploading a package to the Unity Asset Store. The upload must be
 driven interactively through the Unity Editor by a signed-in publisher. Evidence:
 
 1. **Official Asset Store Publishing Tools** (`com.unity.asset-store-tools`):
-   its documented workflow is the Editor GUI (`Tools > Asset Store > Uploader`),
+   its documented workflow is the Editor GUI
+   (`Tools > Asset Store > Uploader`),
    which requires an interactive Unity ID login and an upload button click.
    There is no documented `-batchmode`, `-executeMethod`, command-line,
    API-token, or CI entry point.
@@ -53,25 +54,23 @@ driven interactively through the Unity Editor by a signed-in publisher. Evidence
 
 **Decision (accepted by the maintainer):** auto-publish was approved _only if_ a
 sanctioned non-interactive path exists. Because none does, the project does
-**not** fake one against an internal API. The publish step stays one-click
-manual, backed by the staged artifact below. This is revisited each release; see
+**not** fake one against an internal API. The publish step stays an interactive
+Editor procedure, backed by the staged artifact below. This is revisited each release; see
 [Re-evaluating automation](#re-evaluating-automation).
 
-Unsupported upload experiments are quarantined in the manual-only
+Public-documentation checks for unsupported upload experiments are quarantined in the manual-only
 `Asset Store Unsupported Upload Research` workflow. It has no tag trigger,
 requires the protected `asset-store-experimental` environment, and is limited to
-documenting risks around BatchSubmitter-style Editor API automation, whether the
-official UPM tool exposes a documented public Editor API and service
-authentication model, Asset Store registry metadata, and any future official
-Unity API. It must not upload, store publisher credentials, or harvest Unity ID
-browser sessions.
+recording the official source URLs and the current supported-automation verdict.
+It cannot inspect the package until an enrolled owner installs it, and it must
+not upload, store publisher credentials, call undocumented endpoints, or
+harvest Unity ID browser sessions.
 
 ## What the release pipeline stages for you
 
 Every tagged release runs the `publish` job in
 [`.github/workflows/release.yml`](https://github.com/Ambiguous-Interactive/DxMessaging/blob/master/.github/workflows/release.yml).
-After the
-npm publish and the GitHub Release succeed, that job uploads an
+Before npm publish, that job uploads an
 `asset-store-submission` workflow artifact (30-day retention) containing the
 exact inputs for the Asset Store upload:
 
@@ -85,6 +84,9 @@ exact inputs for the Asset Store upload:
 - generated `CLASSIC-UPLOAD-CHECKLIST.md` and
   `UPM-UPLOAD-CHECKLIST.md` files carrying package metadata and the matching
   changelog section;
+- `EXPECTED-UPM-FIELDS.json` with the exact package name, version, and
+  `_upm.changelog` field values expected after registry publication. This is a
+  field-value reference, not a complete registry response schema;
 - `MANIFEST.json` with filenames, sizes, and SHA-256 hashes for the staged
   files.
 
@@ -99,6 +101,9 @@ Asset Store.
 
 Run this once the release workflow for the tag is green.
 
+1. **Choose the submission format.** Use the classic path unless the account has
+   `Active` UPM admittance and the UPM Publisher Portal is visible. Use the UPM
+   path after both conditions hold.
 1. **Get the payload.** Download the `asset-store-submission` artifact from the
    release workflow run (Actions tab -> the `release` run for the tag ->
    Artifacts), or download the `.unitypackage` from the matching GitHub Release
@@ -106,23 +111,36 @@ Run this once the release workflow for the tag is green.
    beside you -- it is generated for this exact version. Use
    `UPM-UPLOAD-CHECKLIST.md` only after the account reaches `Active` UPM
    admittance and the UPM Publisher Portal appears.
-1. **Verify integrity.** Confirm the `.unitypackage` SHA-256 matches its
-   `.sha256` sidecar before uploading (use `Get-FileHash` on Windows,
-   `shasum -a 256` elsewhere). This catches a truncated download before it
-   reaches review.
-1. **Sign in.** Open a Unity Editor (any version on the supported matrix; the
-   payload was exported from the pinned 2022.3.45f1), install the **Asset Store
-   Publishing Tools** package, and sign in to the publisher account via the
-   Editor's Unity ID login. Complete two-factor authentication when prompted --
-   this is the step that cannot be automated, because the upload is bound to an
-   interactive, 2FA-gated session.
-1. **Select the draft.** In `Tools > Asset Store > Uploader`, select the
-   DxMessaging package draft (create the draft once in the publisher portal if
-   it does not exist yet).
-1. **Import and upload.** Import the staged `.unitypackage` into a clean project
-   and upload its content through the uploader (`Export and Upload`). Do not
-   re-export from a working tree -- upload the staged payload so the Asset Store
-   build matches the npm/UPM build byte-for-byte.
+1. **Verify integrity.** Confirm the selected `.unitypackage` or `.tgz` SHA-256
+   matches its `.sha256` sidecar before uploading (use `Get-FileHash` on
+   Windows, `shasum -a 256` elsewhere). This catches a truncated download
+   before it reaches review.
+1. **Sign in.** Open a Unity Editor (any version on the supported matrix for the
+   classic path; an editor version supported by the installed UPM publishing
+   tool for the UPM path). The classic payload was exported from the pinned
+   2022.3.45f1. Install the applicable official Asset Store publishing tool and
+   sign in to the publisher account via the Editor's Unity ID login. Complete
+   two-factor authentication when prompted. This cannot be automated because
+   the documented upload is bound to an interactive Unity ID session and Unity
+   documents no service credential.
+1. **Upload the classic package.** Skip this step for a UPM submission. Import
+   the staged `.unitypackage` into a
+   clean project. Confirm the import created
+   `Assets/WallstopStudios/DxMessaging/` and no unrelated top-level content.
+   Resolve every import or duplicate-GUID error in the Unity Console. Open
+   `Tools > Asset Store > Validator`, add the DxMessaging folder, run
+   validation, and resolve every finding. In
+   `Tools > Asset Store > Uploader`, select the DxMessaging draft and
+   run `Export and Upload`. The official tool creates a new archive from the
+   inspected imported assets; archive hashes are not expected to match.
+1. **Upload the UPM package.** Skip this step for a classic submission. Choose
+   `Window > Package Manager > Add package from tarball...` and select the
+   staged `.tgz`. Open `Window > Tools > Asset Store > Validator`, select the
+   UPM validation type, and validate the installed package. Open
+   `Window > Tools > Asset Store > Uploader`, select the `UPM Packages` tab,
+   select the exact package version, and upload it. Follow
+   `UPM-UPLOAD-CHECKLIST.md` from the artifact; do not install a working-tree
+   copy.
 1. **Fill metadata.** Set the version to the released version and paste the
    release notes from the matching `## [X.Y.Z]` section of
    [`CHANGELOG.md`](https://github.com/Ambiguous-Interactive/DxMessaging/blob/master/CHANGELOG.md).
@@ -132,6 +150,16 @@ Run this once the release workflow for the tag is green.
 1. **Submit for review.** Submit the draft and record that the version was
    submitted (date + reviewer-facing version) in the approved tracker, not in
    this repository.
+1. **Check UPM Version History.** After Unity publishes a UPM version, use a
+   clean Unity project where it is not installed. Open Package Manager Version
+   History, expand the version, and confirm its notes match
+   `EXPECTED-UPM-FIELDS.json`. For the
+   [per-version changelog experiment](https://github.com/Ambiguous-Interactive/DxMessaging/issues/403),
+   repeat this for two versions and verify that both non-installed rows display
+   their own expected notes. If the Publisher Portal or supported Unity tooling
+   exposes a version manifest, also compare its `name`, `version`, and
+   `_upm.changelog` values with the expected fields. Do not query undocumented
+   endpoints to obtain it; the Version History result is the acceptance proof.
 
 If the `.unitypackage` export itself failed, the whole release is blocked rather
 than shipping a half-release (the export is a required asset); fix the export and
@@ -144,9 +172,9 @@ credential is the **Unity publisher account**, used interactively in the Editor:
 
 - The account must be an approved Asset Store publisher with the package draft
   created, and the person uploading must hold a publisher role that can submit.
-- Two-factor authentication is required and is the hard blocker against
-  automation: a non-interactive job cannot satisfy the 2FA challenge, and Unity
-  exposes no service-account or upload-token alternative.
+- Complete two-factor authentication when the account requires it. More
+  generally, Unity documents only interactive Unity ID authentication and no
+  service-account or upload-token alternative.
 - Do not store the publisher password, recovery codes, or session cookies in the
   repository or in CI secrets. Keep them in the approved organization password
   manager. (If automation ever becomes sanctioned, wire its credentials as

--- a/scripts/__tests__/asset-store-submission.test.js
+++ b/scripts/__tests__/asset-store-submission.test.js
@@ -1,158 +1,120 @@
 "use strict";
-
 const { test } = require("node:test");
 const assert = require("node:assert/strict");
 const crypto = require("node:crypto");
 const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
-
+// prettier-ignore
 const { parseArgs, stageAssetStoreSubmission } = require("../release/asset-store-submission.js");
-
-function sha256(filePath) {
-  return crypto.createHash("sha256").update(fs.readFileSync(filePath)).digest("hex");
+function sha256(file) {
+  return crypto.createHash("sha256").update(fs.readFileSync(file)).digest("hex");
 }
-
-function writeFile(filePath, content = "") {
-  fs.mkdirSync(path.dirname(filePath), { recursive: true });
-  fs.writeFileSync(filePath, content);
-  return filePath;
+function write(file, content = "") {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, content);
+  return file;
 }
-
-function makeFixture(t) {
+// prettier-ignore
+function fixture(t) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "dxm-asset-store-"));
   t.after(() => fs.rmSync(root, { recursive: true, force: true }));
-  writeFile(
-    path.join(root, "package.json"),
-    JSON.stringify(
-      {
-        name: "com.example.fixture",
-        version: "1.2.3",
-        displayName: "Fixture Messaging",
-        unity: "2021.3",
-        description: "Fixture package.",
-        documentationUrl: "https://example.test/docs",
-        licensesUrl: "https://example.test/license"
-      },
-      null,
-      2
-    )
-  );
-  writeFile(
-    path.join(root, "CHANGELOG.md"),
-    ["# Changelog", "", "## [1.2.3]", "", "### Added", "", "- Release note.", ""].join("\n")
-  );
-  for (const name of "dxmessaging-store-icon-320.png dxmessaging-store-card-420x280.png dxmessaging-og-1200x630.png".split(
-    " "
-  )) {
-    writeFile(path.join(root, "docs", "images", name), `media:${name}`);
-  }
-  const releaseDir = path.join(root, "release");
-  const packageFile = writeFile(path.join(releaseDir, "fixture-1.2.3.tgz"), "tgz");
-  const unitypackageFile = writeFile(
-    path.join(releaseDir, "fixture-1.2.3.unitypackage"),
-    "unitypackage"
-  );
-  const packageChecksum = writeFile(
-    `${packageFile}.sha256`,
-    `${sha256(packageFile)}  ${path.basename(packageFile)}\n`
-  );
-  const unitypackageChecksum = writeFile(
-    `${unitypackageFile}.sha256`,
-    `${sha256(unitypackageFile)}  ${path.basename(unitypackageFile)}\n`
-  );
+  write(path.join(root, "package.json"), '{"name":"com.example.fixture","version":"1.2.3","_upm":{"changelog":"### Added\\n\\n- Release note."}}');
+  write(path.join(root, "CHANGELOG.md"), "# Changelog\n\n## [1.2.3]\n\n### Added\n\n- Release note.\n");
+  fs.cpSync(path.resolve(__dirname, "../../docs/images"), path.join(root, "docs", "images"), { recursive: true });
+  const packageFile = write(path.join(root, "release", "fixture-1.2.3.tgz"), "tgz");
+  const unitypackageFile = write(path.join(root, "release", "fixture-1.2.3.unitypackage"), "unitypackage");
+  const packageChecksum = write(`${packageFile}.sha256`, `${sha256(packageFile)}  ${path.basename(packageFile)}\n`);
+  const unitypackageChecksum = write(`${unitypackageFile}.sha256`, `${sha256(unitypackageFile)}  ${path.basename(unitypackageFile)}\n`);
   return { root, packageFile, packageChecksum, unitypackageFile, unitypackageChecksum };
 }
-
-function stageFixture(fixture, outDir = ".artifacts/asset-store-submission") {
-  return stageAssetStoreSubmission({ ...fixture, repoRoot: fixture.root, outDir });
+function stage(data, options = {}) {
+  return stageAssetStoreSubmission({
+    ...data,
+    repoRoot: data.root,
+    outDir: ".artifacts/asset-store-submission",
+    ...options
+  });
 }
-
-test("parseArgs requires all source files and parses optional tag/output", () => {
-  assert.deepEqual(
-    parseArgs([
-      "--out",
-      "out",
-      "--package-file",
-      "pkg.tgz",
-      "--package-checksum",
-      "pkg.tgz.sha256",
-      "--unitypackage-file",
-      "pkg.unitypackage",
-      "--unitypackage-checksum",
-      "pkg.unitypackage.sha256",
-      "--tag",
-      "v1.2.3"
-    ]),
-    {
-      outDir: "out",
-      packageFile: "pkg.tgz",
-      packageChecksum: "pkg.tgz.sha256",
-      unitypackageFile: "pkg.unitypackage",
-      unitypackageChecksum: "pkg.unitypackage.sha256",
-      tag: "v1.2.3"
-    }
-  );
-  assert.throws(() => parseArgs(["--out", "out"]), /Missing required arguments/);
-});
-
-test("stageAssetStoreSubmission copies assets, checklists, and manifest", (t) => {
-  const fixture = makeFixture(t);
-  const outDir = path.join(fixture.root, ".artifacts", "asset-store-submission");
-
-  const result = stageFixture(fixture, outDir);
-
+test("stageAssetStoreSubmission creates a verified operator artifact", (t) => {
+  const data = fixture(t);
+  const result = stage(data);
+  const output = result.outDir;
   assert.equal(result.version, "1.2.3");
-  assert.deepEqual(fs.readdirSync(outDir).sort(), [
-    "CLASSIC-UPLOAD-CHECKLIST.md",
-    "MANIFEST.json",
-    "UPM-UPLOAD-CHECKLIST.md",
-    "fixture-1.2.3.tgz",
-    "fixture-1.2.3.tgz.sha256",
-    "fixture-1.2.3.unitypackage",
-    "fixture-1.2.3.unitypackage.sha256",
-    "media"
-  ]);
-  assert.deepEqual(fs.readdirSync(path.join(outDir, "media")).sort(), [
-    "dxmessaging-og-1200x630.png",
-    "dxmessaging-store-card-420x280.png",
-    "dxmessaging-store-icon-320.png"
-  ]);
-  const classic = fs.readFileSync(path.join(outDir, "CLASSIC-UPLOAD-CHECKLIST.md"), "utf8");
-  assert.match(classic, /Fixture Messaging/);
-  assert.match(classic, /fixture-1\.2\.3\.unitypackage/);
-  assert.match(classic, /Release note\./);
-  assert.match(classic, /Review the listing draft in the Unity Publisher Portal/);
-  const upm = fs.readFileSync(path.join(outDir, "UPM-UPLOAD-CHECKLIST.md"), "utf8");
-  assert.match(upm, /fixture-1\.2\.3\.tgz/);
-  assert.match(upm, /Unity 2021\.3[\s\S]*editor version listed.*Active admittance/);
-
-  const manifest = JSON.parse(fs.readFileSync(path.join(outDir, "MANIFEST.json"), "utf8"));
-  assert.equal(manifest.schemaVersion, 1);
-  assert.equal(manifest.package.name, "com.example.fixture");
-  assert.equal(manifest.package.version, "1.2.3");
-  assert.ok(manifest.files.some((file) => file.path === "media/dxmessaging-store-icon-320.png"));
-  assert.ok(manifest.files.every((file) => /^[0-9a-f]{64}$/.test(file.sha256)));
-});
-
-test("stageAssetStoreSubmission refuses unsafe output directories", (t) => {
-  const fixture = makeFixture(t);
-  for (const outDir of [".", "docs", path.dirname(fixture.root)]) {
-    assert.throws(() => stageFixture(fixture, outDir), /Refusing unsafe output directory/);
+  const classic = fs.readFileSync(path.join(output, "CLASSIC-UPLOAD-CHECKLIST.md"), "utf8");
+  const upm = fs.readFileSync(path.join(output, "UPM-UPLOAD-CHECKLIST.md"), "utf8");
+  assert.match(
+    classic,
+    /Unity Console[\s\S]*Tools > Asset Store > Validator[\s\S]*Tools > Asset Store > Uploader/
+  );
+  assert.match(
+    upm,
+    /Add package from tarball[\s\S]*Window > Tools > Asset Store > Validator[\s\S]*UPM Packages/
+  );
+  assert.deepEqual(JSON.parse(fs.readFileSync(path.join(output, "EXPECTED-UPM-FIELDS.json"))), {
+    name: "com.example.fixture",
+    version: "1.2.3",
+    _upm: { changelog: "### Added\n\n- Release note." }
+  });
+  const manifest = JSON.parse(fs.readFileSync(path.join(output, "MANIFEST.json")));
+  assert.ok(manifest.files.some((file) => file.path === "EXPECTED-UPM-FIELDS.json"));
+  for (const file of manifest.files) {
+    const actual = path.join(output, file.path);
+    assert.equal(file.bytes, fs.statSync(actual).size, file.path);
+    assert.equal(file.sha256, sha256(actual), file.path);
   }
-
+});
+test("stageAssetStoreSubmission rejects unsafe and inconsistent inputs", (t) => {
+  const data = fixture(t);
+  for (const outDir of [".", "docs", path.dirname(data.root)])
+    assert.throws(() => stage(data, { outDir }), /Refusing unsafe output directory/);
   const outside = fs.mkdtempSync(path.join(os.tmpdir(), "dxm-asset-store-outside-"));
   t.after(() => fs.rmSync(outside, { recursive: true, force: true }));
-  fs.symlinkSync(outside, path.join(fixture.root, ".artifacts"), "dir");
-  assert.throws(() => stageFixture(fixture), /Refusing unsafe symlinked output path/);
+  fs.symlinkSync(outside, path.join(data.root, ".artifacts"), "dir");
+  assert.throws(() => stage(data), /Refusing unsafe symlinked output path/);
+  fs.rmSync(path.join(data.root, ".artifacts"));
+  assert.throws(() => stage(data, { tag: "v9.9.9" }), /does not match package version/);
+  write(data.packageChecksum, `${"0".repeat(64)}  ${path.basename(data.packageFile)}\n`);
+  assert.throws(() => stage(data), /Checksum mismatch/);
 });
-
-test("stageAssetStoreSubmission rejects stale checksums and missing media", (t) => {
-  const fixture = makeFixture(t);
-  fs.writeFileSync(fixture.packageChecksum, `${"0".repeat(64)}  fixture-1.2.3.tgz\n`);
-  assert.throws(() => stageFixture(fixture), /Checksum mismatch/);
-
-  const second = makeFixture(t);
-  fs.rmSync(path.join(second.root, "docs", "images", "dxmessaging-store-card-420x280.png"));
-  assert.throws(() => stageFixture(second), /Required store media is missing/);
+test("stageAssetStoreSubmission rejects missing, corrupt, and stale collateral", (t) => {
+  const missing = fixture(t);
+  fs.rmSync(path.join(missing.root, "docs", "images", "dxmessaging-store-card-420x280.png"));
+  assert.throws(() => stage(missing), /Store media is missing/);
+  const corrupt = fixture(t);
+  write(path.join(corrupt.root, "docs", "images", "dxmessaging-store-icon-320.png"), "junk");
+  assert.throws(() => stage(corrupt), /lacks the required PNG structure/);
+  const wrongSize = fixture(t);
+  fs.copyFileSync(
+    path.resolve(__dirname, "../../docs/images/dxmessaging-store-card-420x280.png"),
+    path.join(wrongSize.root, "docs", "images", "dxmessaging-og-1200x630.png")
+  );
+  assert.throws(() => stage(wrongSize), /420x280; expected 1200x630/);
+  const staleMedia = fixture(t);
+  write(path.join(staleMedia.root, "docs", "images", "dxmessaging-og-1200x630.svg"), "stale");
+  assert.throws(() => stage(staleMedia), /source\/output lock is stale/);
+  const stale = fixture(t);
+  const manifest = JSON.parse(fs.readFileSync(path.join(stale.root, "package.json")));
+  manifest._upm.changelog = "stale";
+  write(path.join(stale.root, "package.json"), JSON.stringify(manifest));
+  assert.throws(() => stage(stale), /_upm\.changelog does not match/);
+});
+// prettier-ignore
+test("Asset Store workflows stay quarantined and stage before npm publication", () => {
+  const release = fs.readFileSync(path.resolve(__dirname, "../../.github/workflows/release.yml"), "utf8");
+  const steps = ["Assemble the Asset Store", "Upload the Asset Store", "Publish to npm"];
+  const positions = steps.map((step) => release.indexOf(`- name: ${step}`));
+  assert.ok(positions[0] >= 0 && positions[0] < positions[1] && positions[1] < positions[2]);
+  assert.match(release, /Upload the Asset Store[\s\S]*if-no-files-found: error[\s\S]*overwrite: true[\s\S]*retention-days: 30/);
+  assert.match(release, /asset-store-submission\.js[\s\S]*--package-file[\s\S]*--package-checksum[\s\S]*--unitypackage-file[\s\S]*--unitypackage-checksum[\s\S]*--tag/);
+  const research = fs.readFileSync(path.resolve(__dirname, "../../.github/workflows/asset-store-unsupported-upload-research.yml"), "utf8");
+  assert.equal(research.match(/\$\{\{ inputs\.acknowledge_risks \}\}/g)?.length, 1);
+  assert.match(research, /ACKNOWLEDGE_RISKS: \$\{\{ inputs\.acknowledge_risks \}\}/);
+  assert.equal(research.match(/^            "https:/gm)?.length, 5);
+  assert.match(research, /environment: asset-store-experimental[\s\S]*GITHUB_REF_TYPE[\s\S]*--max-time 15[\s\S]*grep -Fqi[\s\S]*FAILURES\.txt[\s\S]*test ! -s/);
+  assert.match(research, /Upload research evidence\n\s+if: always\(\)[\s\S]*overwrite: true[\s\S]*Require complete official evidence/);
+});
+test("asset-store CLI rejects unknown and missing values", () => {
+  assert.throws(() => parseArgs(["--unknown"]), /Unknown argument/);
+  assert.throws(() => parseArgs(["--out", "--package-file"]), /Missing value/);
 });

--- a/scripts/release/asset-store-submission.js
+++ b/scripts/release/asset-store-submission.js
@@ -1,34 +1,77 @@
 #!/usr/bin/env node
-"use strict";
-
+"use strict"; // cspell:ignore IDAT IEND
 const crypto = require("node:crypto");
 const fs = require("node:fs");
 const path = require("node:path");
+const { crc32, inflateSync } = require("node:zlib");
 const { extractSection } = require("./changelog.js");
 const { toPosixPath } = require("../lib/path-classifier.js");
-
 const REQUIRED_ARGS =
   "outDir packageFile packageChecksum unitypackageFile unitypackageChecksum".split(" ");
-const STORE_MEDIA =
-  "dxmessaging-store-icon-320.png dxmessaging-store-card-420x280.png dxmessaging-og-1200x630.png".split(
-    " "
-  );
-
+const STORE_MEDIA = [
+  "dxmessaging-store-icon-320.png|320|320|dxmessaging-icon-tile.svg|7519ef9ee3a299f377a53ef308e09db00a0e3f47a1692c5ed3666caf79a75843|982e6eb194ed863a7af446c45557aecb222b0b02e2933f60ca60cb20afe70fbe",
+  "dxmessaging-store-card-420x280.png|420|280|dxmessaging-store-card-420x280.svg|31c25bc776a17b65e3ea1e1a9750cfaef0688c9417e42276fed08fd6d6d76220|d9a5fb6bf1027ad4e9526dfdaf05333ca658efa51e16edbb000c169fe43adf54",
+  "dxmessaging-og-1200x630.png|1200|630|dxmessaging-og-1200x630.svg|1dec23fe6a2e2e14d3b13e870201c599c4b0e8039d20891f7ba2ed5f1cd11d61|fa294d4c821adb0339fcf5cfafb2bbc8a81987ba68cd61fa6af55a9f590a82fe"
+].map((entry) => entry.split("|"));
 function sha256(filePath) {
   return crypto.createHash("sha256").update(fs.readFileSync(filePath)).digest("hex");
 }
-
 function copyFile(source, target) {
   fs.mkdirSync(path.dirname(target), { recursive: true });
   fs.copyFileSync(source, target);
 }
-
+function writeText(dir, name, content) {
+  fs.writeFileSync(path.join(dir, name), `${content}\n`, "utf8");
+}
 function assertFile(filePath, label) {
   if (!fs.existsSync(filePath) || !fs.statSync(filePath).isFile()) {
     throw new Error(`${label} is missing: ${toPosixPath(filePath)}`);
   }
 }
-
+function validatePng(filePath, expectedWidth, expectedHeight) {
+  assertFile(filePath, "Store media");
+  const content = fs.readFileSync(filePath);
+  if (content.subarray(0, 8).toString("hex") !== "89504e470d0a1a0a") {
+    throw new Error(`Store media lacks the required PNG structure: ${toPosixPath(filePath)}`);
+  }
+  let offset = 8;
+  let width;
+  let height;
+  let ended = false;
+  const imageData = [];
+  while (offset + 12 <= content.length) {
+    const length = content.readUInt32BE(offset);
+    const end = offset + 12 + length;
+    const type = content.toString("ascii", offset + 4, offset + 8);
+    const dataEnd = offset + 8 + length;
+    if (
+      end > content.length ||
+      content.readUInt32BE(dataEnd) !== crc32(content.subarray(offset + 4, dataEnd))
+    ) {
+      throw new Error(`Store media has an invalid PNG chunk: ${toPosixPath(filePath)}`);
+    }
+    if (offset === 8 && type === "IHDR" && length === 13) {
+      width = content.readUInt32BE(offset + 8);
+      height = content.readUInt32BE(offset + 12);
+    } else if (type === "IDAT") imageData.push(content.subarray(offset + 8, dataEnd));
+    else if (type === "IEND") {
+      ended = length === 0 && end === content.length;
+      break;
+    }
+    offset = end;
+  }
+  try {
+    if (!width || !height || !ended || imageData.length === 0) throw new Error("missing chunk");
+    inflateSync(Buffer.concat(imageData));
+  } catch {
+    throw new Error(`Store media lacks the required PNG structure: ${toPosixPath(filePath)}`);
+  }
+  if (width !== expectedWidth || height !== expectedHeight) {
+    throw new Error(
+      `Store media ${toPosixPath(filePath)} is ${width}x${height}; expected ${expectedWidth}x${expectedHeight}.`
+    );
+  }
+}
 function readChecksum(checksumPath) {
   const lines = fs
     .readFileSync(checksumPath, "utf8")
@@ -44,7 +87,6 @@ function readChecksum(checksumPath) {
   }
   return { hash: match[1].toLowerCase(), fileName: match[2].trim() };
 }
-
 function validateChecksum(filePath, checksumPath) {
   assertFile(filePath, "Release file");
   assertFile(checksumPath, "Checksum file");
@@ -62,23 +104,18 @@ function validateChecksum(filePath, checksumPath) {
     );
   }
 }
-
 function collectFiles(root) {
   const result = [];
   function walk(dir) {
     for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
       const fullPath = path.join(dir, entry.name);
-      if (entry.isDirectory()) {
-        walk(fullPath);
-      } else if (entry.isFile() && entry.name !== "MANIFEST.json") {
-        result.push(fullPath);
-      }
+      if (entry.isDirectory()) walk(fullPath);
+      else if (entry.isFile() && entry.name !== "MANIFEST.json") result.push(fullPath);
     }
   }
   walk(root);
   return result.sort((left, right) => toPosixPath(left).localeCompare(toPosixPath(right), "en"));
 }
-
 function relativeEntry(root, filePath) {
   const stat = fs.statSync(filePath);
   return {
@@ -87,18 +124,25 @@ function relativeEntry(root, filePath) {
     sha256: sha256(filePath)
   };
 }
-
 function buildChecklist({ mode, pkg, tag, packageName, unitypackageName, changelogSection }) {
   const isClassic = mode === "classic";
-  const heading = isClassic
-    ? `# Classic Asset Store Upload Checklist (${tag})`
-    : `# UPM Asset Store Upload Checklist (${tag})`;
+  const heading = `# ${isClassic ? "Classic" : "UPM"} Asset Store Upload Checklist (${tag})`;
   const payload = isClassic
-    ? `Classic payload: ${unitypackageName}`
-    : `UPM reference payload: ${packageName}`;
-  const pathStep = isClassic
-    ? "Upload through the in-Editor Asset Store Publishing Tools window."
-    : "Use an editor version listed as compatible with the installed official UPM tool only after enrollment reaches Active admittance.";
+    ? `Classic source payload: ${unitypackageName}`
+    : `UPM payload: ${packageName}`;
+  const uploadSteps = isClassic
+    ? `1. Import \`${unitypackageName}\` into a clean project.
+1. Confirm the import created \`Assets/WallstopStudios/DxMessaging/\` and no unrelated top-level content. Resolve every import or duplicate-GUID error in the Unity Console.
+1. Open \`Tools > Asset Store > Validator\`, add \`Assets/WallstopStudios/DxMessaging/\`, run validation, and resolve every finding.
+1. Open \`Tools > Asset Store > Uploader\` and select the package draft.
+1. Run \`Export and Upload\`. The official tool creates a new archive from the inspected imported assets; archive hashes are not expected to match.`
+    : `1. Continue only after UPM enrollment reaches Active admittance and the UPM Publisher Portal appears.
+1. Open a clean project in an editor version supported by the installed official UPM publishing tool.
+1. In \`Window > Package Manager\`, choose \`Add package from tarball...\` and select \`${packageName}\` from this artifact.
+1. Open \`Window > Tools > Asset Store > Validator\`, select the UPM validation type, and validate the installed package.
+1. Open \`Window > Tools > Asset Store > Uploader\`, select the \`UPM Packages\` tab, select ${pkg.name} ${pkg.version}, and upload it.
+1. After Unity publishes the version, use a clean project where it is not installed. In Package Manager Version History, expand this version and confirm its notes match \`EXPECTED-UPM-FIELDS.json\`.
+1. If supported Unity tooling exposes the version manifest, compare its field values with \`EXPECTED-UPM-FIELDS.json\`. Do not query undocumented endpoints.`;
   return `${heading}
 
 Package: ${pkg.displayName || pkg.name} (${pkg.name})
@@ -114,7 +158,7 @@ ${payload}
 
 ## Upload
 
-1. ${pathStep}
+${uploadSteps}
 1. Set the listing version to the package version above.
 1. Paste the release notes from the changelog excerpt below.
 1. Submit for Unity review.
@@ -123,7 +167,6 @@ ${payload}
 
 ${changelogSection}`;
 }
-
 function assertSafeOutputDir(repoRoot, outDir) {
   const resolved = path.resolve(repoRoot, outDir);
   const resolvedRepoRoot = path.resolve(repoRoot);
@@ -151,7 +194,6 @@ function assertSafeOutputDir(repoRoot, outDir) {
   }
   return resolved;
 }
-
 function stageAssetStoreSubmission(options = {}) {
   const repoRoot = path.resolve(options.repoRoot || path.join(__dirname, "..", ".."));
   for (const arg of REQUIRED_ARGS) {
@@ -164,31 +206,41 @@ function stageAssetStoreSubmission(options = {}) {
   const packageChecksum = path.resolve(repoRoot, options.packageChecksum);
   const unitypackageFile = path.resolve(repoRoot, options.unitypackageFile);
   const unitypackageChecksum = path.resolve(repoRoot, options.unitypackageChecksum);
-
   validateChecksum(packageFile, packageChecksum);
   validateChecksum(unitypackageFile, unitypackageChecksum);
-
   const pkg = JSON.parse(fs.readFileSync(path.join(repoRoot, "package.json"), "utf8"));
   const tag = options.tag || `v${pkg.version}`;
+  if (tag !== `v${pkg.version}`) {
+    throw new Error(`Release tag ${tag} does not match package version ${pkg.version}.`);
+  }
   const changelogSection = extractSection(
     fs.readFileSync(path.join(repoRoot, "CHANGELOG.md"), "utf8"),
     pkg.version
   );
-  const mediaRoot = path.join(repoRoot, "docs", "images");
-  const missingMedia = STORE_MEDIA.filter((name) => !fs.existsSync(path.join(mediaRoot, name)));
-  if (missingMedia.length > 0) {
-    throw new Error(`Required store media is missing: ${missingMedia.join(", ")}`);
+  if (!pkg._upm || pkg._upm.changelog !== changelogSection) {
+    throw new Error(
+      `package.json _upm.changelog does not match the CHANGELOG.md section for ${pkg.version}.`
+    );
   }
-
+  const mediaRoot = path.join(repoRoot, "docs", "images");
+  for (const [name, width, height, source, sourceHash, pngHash] of STORE_MEDIA) {
+    const file = path.join(mediaRoot, name);
+    const sourceFile = path.join(mediaRoot, source);
+    validatePng(file, Number(width), Number(height));
+    assertFile(sourceFile, "Store media source");
+    if (sha256(sourceFile) !== sourceHash || sha256(file) !== pngHash)
+      throw new Error(
+        `Store media source/output lock is stale for ${name}; re-render and update it.`
+      );
+  }
   fs.rmSync(outDir, { recursive: true, force: true });
   fs.mkdirSync(outDir, { recursive: true });
   for (const source of [packageFile, packageChecksum, unitypackageFile, unitypackageChecksum]) {
     copyFile(source, path.join(outDir, path.basename(source)));
   }
-  for (const name of STORE_MEDIA) {
+  for (const [name] of STORE_MEDIA) {
     copyFile(path.join(mediaRoot, name), path.join(outDir, "media", name));
   }
-
   const checklistInput = {
     pkg,
     tag,
@@ -196,17 +248,15 @@ function stageAssetStoreSubmission(options = {}) {
     unitypackageName: path.basename(unitypackageFile),
     changelogSection
   };
-  fs.writeFileSync(
-    path.join(outDir, "CLASSIC-UPLOAD-CHECKLIST.md"),
-    `${buildChecklist({ ...checklistInput, mode: "classic" })}\n`,
-    "utf8"
+  writeText(
+    outDir,
+    "CLASSIC-UPLOAD-CHECKLIST.md",
+    buildChecklist({ ...checklistInput, mode: "classic" })
   );
-  fs.writeFileSync(
-    path.join(outDir, "UPM-UPLOAD-CHECKLIST.md"),
-    `${buildChecklist({ ...checklistInput, mode: "upm" })}\n`,
-    "utf8"
-  );
-
+  writeText(outDir, "UPM-UPLOAD-CHECKLIST.md", buildChecklist({ ...checklistInput, mode: "upm" }));
+  // prettier-ignore
+  const expectedFields = { name: pkg.name, version: pkg.version, _upm: { changelog: pkg._upm.changelog } };
+  writeText(outDir, "EXPECTED-UPM-FIELDS.json", JSON.stringify(expectedFields, null, 2));
   const manifest = {
     schemaVersion: 1,
     package: {
@@ -225,10 +275,9 @@ function stageAssetStoreSubmission(options = {}) {
     },
     files: collectFiles(outDir).map((file) => relativeEntry(outDir, file))
   };
-  fs.writeFileSync(path.join(outDir, "MANIFEST.json"), `${JSON.stringify(manifest, null, 2)}\n`);
+  writeText(outDir, "MANIFEST.json", JSON.stringify(manifest, null, 2));
   return { outDir, version: pkg.version, files: manifest.files };
 }
-
 function parseArgs(argv) {
   const out = {};
   const values = {
@@ -241,23 +290,16 @@ function parseArgs(argv) {
   };
   for (let index = 0; index < argv.length; index += 1) {
     const key = values[argv[index]];
-    if (!key) {
-      throw new Error(`Unknown argument: ${argv[index]}`);
-    }
+    if (!key) throw new Error(`Unknown argument: ${argv[index]}`);
     const value = argv[index + 1];
-    if (!value || value.startsWith("--")) {
-      throw new Error(`Missing value for ${argv[index]}`);
-    }
+    if (!value || value.startsWith("--")) throw new Error(`Missing value for ${argv[index]}`);
     out[key] = value;
     index += 1;
   }
   const missing = REQUIRED_ARGS.filter((arg) => !out[arg]);
-  if (missing.length > 0) {
-    throw new Error(`Missing required arguments: ${missing.join(", ")}`);
-  }
+  if (missing.length > 0) throw new Error(`Missing required arguments: ${missing.join(", ")}`);
   return out;
 }
-
 function main() {
   try {
     const result = stageAssetStoreSubmission(parseArgs(process.argv.slice(2)));
@@ -269,9 +311,5 @@ function main() {
     process.exit(1);
   }
 }
-
-module.exports = { STORE_MEDIA, parseArgs, stageAssetStoreSubmission };
-
-if (require.main === module) {
-  main();
-}
+module.exports = { parseArgs, stageAssetStoreSubmission };
+if (require.main === module) main();


### PR DESCRIPTION
## Why

Unity documents interactive Editor workflows for classic and UPM Asset Store publishing. It does not document a supported non-interactive upload API or service credential.

The release workflow staged an operator artifact, but uploaded it after npm publication. Its generator did not reject corrupt or stale store media, tag drift, or changelog drift. The UPM procedure also lacked a complete, supported acceptance test for per-version notes.

## What changed

- Upload the verified `asset-store-submission` artifact before npm publication.
- Validate release checksums, tag/version agreement, shipped changelog agreement, PNG structure and dimensions, and SVG/PNG source locks.
- Generate classic and UPM checklists, exact expected UPM field values, and a size/hash manifest.
- Use Unity's official classic Validator and uploader flow.
- Make the two-version Package Manager Version History result the acceptance proof for issue #403.
- Quarantine unsupported-upload research behind a protected manual environment.
- Capture recognized official Unity pages with bounded requests and fail closed when evidence is incomplete.

## How we know

- `npm test`: 524 passed, 0 failed.
- `npm run validate:all`: passed.
- Formatting, spelling, Markdown lint, YAML validation, and diff checks passed.
- A fresh `npm pack` rehearsal generated the ten-file v3.3.0 submission artifact.
- Unity MCP confirmed the connected editor can answer editor-backed calls.
- The final adversarial review reported zero material and zero minor findings.

## Remaining limitation

The authenticated Asset Store upload remains interactive. The workflow does not call undocumented endpoints, harvest Unity ID sessions, or store publisher credentials.

Progresses #399.
Prepares the owner-run experiment for #403.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes reorder the release publish job and add strict pre-npm gates on store collateral; a bad media hash or changelog drift blocks publication, but npm/GitHub release semantics are otherwise unchanged.
> 
> **Overview**
> **Release workflow** now uploads the `asset-store-submission` artifact immediately after assembly and **before** npm publish, so a successful registry step cannot run without the operator payload being available.
> 
> **`asset-store-submission.js`** gains fail-fast checks (release checksums, tag vs `package.json` version, `_upm.changelog` vs `CHANGELOG.md`, PNG structure/dimensions, and pinned SVG/PNG hashes). It emits **`EXPECTED-UPM-FIELDS.json`** and expands classic/UPM checklists to match Unity’s documented Validator/Uploader flows and Package Manager Version History acceptance for per-version notes.
> 
> The **quarantined research workflow** fetches five official Unity publishing URLs into artifacts and fails when any page is missing or unrecognized, instead of printing a static risk brief.
> 
> **Ops/runbook docs** are aligned with the new artifact contents, staging order, media hash lock procedure, and manual UPM verification steps; tests assert workflow ordering and the new validation paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41ed20e07aac7a04a07c7e2bcd930ce84f7f95da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->