### PR TITLE
Record a rejected dispatch optimization

### DIFF
--- a/.llm/skills/benchmark-methodology/references/runtime-performance-campaign-decisions.md
+++ b/.llm/skills/benchmark-methodology/references/runtime-performance-campaign-decisions.md
@@ -142,6 +142,14 @@ separately.
   difference.
 - A 0-4 flat-dispatch `switch` preserved live-active and reset-generation reads
   but regressed representative dispatch by roughly 8-11% versus the compact loop.
+- Do not peel the final entry from the cached untargeted flat-dispatch loop to
+  omit its post-callback reset-generation read. A fresh-assembly local Mono
+  control/candidate/control screen regressed `GlobalToOne` by 4.555% against the
+  geometric mean of both controls. `StructNoBox` moved -2.179%, below the 3%
+  keep threshold, while untouched `Filtered`, `PostProcess`, and
+  `FilteredPostProcess` sentinels moved -3.654%, -4.011%, and -4.976%. The
+  candidate was removed before Standalone IL2CPP CI. Revisit only with a
+  materially different representation or new backend evidence.
 - `[ThreadStatic]` snapshot-holder stacks changed a process-wide 64-holder ceiling
   into 64 holders plus a stack per participating thread. They failed the
   no-retained-memory-increase gate before a timing claim.


### PR DESCRIPTION
## Why

Issue #414 needs durable evidence about dispatch shapes that do not improve MessagePipe parity. Without it, later work can repeat a measured failure.

## What changed

The performance campaign now rejects peeling the final cached untargeted entry. It records the retry boundary. Runtime code remains unchanged.

## How we know

A fresh-assembly Unity control/candidate/control screen passed all 21 paired tests. `GlobalToOne` regressed 4.555%. `StructNoBox` moved -2.179%, below the 3% keep threshold. Three untouched sentinels moved outside the interpretation band.

Local formatting, Markdown, spelling, skill, and repository validation checks pass.

## Follow-up

Issue #414 remains open because this experiment found no improvement worth keeping.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only update to benchmark methodology; no runtime or CI behavior changes.
> 
> **Overview**
> **Documents a rejected runtime experiment** in the performance campaign decisions reference so issue #414 does not get retried without new evidence. **No production or benchmark harness code changes.**
> 
> The new **rejected candidate** entry forbids peeling the last cached untargeted flat-dispatch loop iteration to skip the post-callback reset-generation read. A fresh-assembly local Mono control/candidate/control bracket regressed **`GlobalToOne` by 4.555%** (above the 3% gate). **`StructNoBox`** was -2.179% (below keep threshold), but causal sentinels **`Filtered`**, **`PostProcess`**, and **`FilteredPostProcess`** also shifted roughly -3.7% to -5.0%, so the screen is not interpretable as a win. The optimization was dropped before Standalone IL2CPP CI; revisit only with a materially different shape or new backend proof.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5806a5d4f2672bd9cb3482b5fdcd2b1378a4d8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->