### PR TITLE
Add a stripped shipping-fidelity player

### DIFF
--- a/.github/actions/dump-unity-log-tail/action.yml
+++ b/.github/actions/dump-unity-log-tail/action.yml
@@ -1,10 +1,10 @@
 name: Dump Unity log tail on failure or cancellation
 description: >-
-  Surface the tail of <results-dir>/unity.log and rescan it for catastrophic
-  compile-time failure patterns when an upstream Unity step fails OR is
-  cancelled. Gives operators something concrete to look at when the
-  test-runner step timed out or was cancelled and verify-unity-results
-  (which gates on !cancelled()) would otherwise skip.
+  Surface the tails of Unity diagnostic logs under <results-dir> and rescan
+  them for catastrophic compile-time failure patterns when an upstream Unity
+  step fails OR is cancelled. Gives operators something concrete to look at
+  when the test-runner step timed out or was cancelled and
+  verify-unity-results (which gates on !cancelled()) would otherwise skip.
 inputs:
   results-dir:
     description: "Directory the Unity runner wrote artifacts (and unity.log) into."
@@ -87,11 +87,17 @@ runs:
 
         $logFiles = @(Get-UnityDiagnosticLogFiles -ResultsDir $dir)
         $log = if ($dir) { Join-Path $dir 'unity.log' } else { $null }
+        $primaryLogFullPath = $null
         if (-not $log -or -not (Test-Path -LiteralPath $log -PathType Leaf)) {
           # Cancellation before Unity launched leaves no unity.log; this is
           # NOT an error condition for this diagnostic helper.
           Write-Host "::notice::${label}: no unity.log under '$dir' to dump (Unity may not have started, or the run was cancelled before launch)."
         } else {
+          try {
+            $primaryLogFullPath = (Resolve-Path -LiteralPath $log -ErrorAction Stop).Path
+          } catch {
+            $primaryLogFullPath = $null
+          }
           Write-Host "::group::Unity log tail (last $tailLines lines) -- $label"
           try {
             Get-Content -LiteralPath $log -Tail $tailLines | ForEach-Object {
@@ -106,19 +112,28 @@ runs:
           Write-Host "::endgroup::"
         }
 
-        # STANDALONE: the test player runs as a SEPARATE process and writes its own
-        # log (player.log), not unity.log. On a standalone failure the player log
-        # carries the actual test output and quit diagnostics, so tail it too when
-        # present (no-op for editmode/playmode, which write only unity.log).
-        $playerLog = if ($dir) { Join-Path $dir 'player.log' } else { $null }
-        if ($playerLog -and (Test-Path -LiteralPath $playerLog -PathType Leaf)) {
-          Write-Host "::group::Standalone player log tail (last $tailLines lines) -- $label"
+        # Standalone and shipping players run as separate processes. Tail every
+        # additional diagnostic log so player.log and both shipping process logs
+        # are visible without requiring the operator to download the artifact.
+        foreach ($additionalLog in $logFiles) {
+          if (
+            $primaryLogFullPath -and
+            [string]::Equals(
+              $additionalLog,
+              $primaryLogFullPath,
+              [StringComparison]::OrdinalIgnoreCase
+            )
+          ) {
+            continue
+          }
+          $additionalLogName = Split-Path -Leaf $additionalLog
+          Write-Host "::group::Diagnostic log tail: $additionalLogName (last $tailLines lines) -- $label"
           try {
-            Get-Content -LiteralPath $playerLog -Tail $tailLines | ForEach-Object {
+            Get-Content -LiteralPath $additionalLog -Tail $tailLines | ForEach-Object {
               Write-Host $_
             }
           } catch {
-            Write-Host "::notice::Unable to read tail of '$playerLog': $($_.Exception.Message)"
+            Write-Host "::notice::Unable to read tail of '$additionalLog': $($_.Exception.Message)"
           }
           Write-Host "::endgroup::"
         }

--- a/.github/perf/shipping-fidelity-il2cpp-profile.v1.json
+++ b/.github/perf/shipping-fidelity-il2cpp-profile.v1.json
@@ -1,0 +1,30 @@
+{
+  "schemaVersion": 1,
+  "profileId": "shipping-fidelity-il2cpp-player-v1",
+  "configuration": {
+    "buildTarget": "StandaloneWindows64",
+    "scriptingBackend": "IL2CPP",
+    "apiCompatibilityLevel": "NET_Standard_2_0",
+    "codeOptimization": "Release",
+    "il2cppCompilerConfiguration": "Release",
+    "il2cppCodeGeneration": "OptimizeSpeed",
+    "managedStrippingLevel": "High",
+    "incrementalGc": true,
+    "stripEngineCode": true
+  },
+  "buildOptions": {
+    "developmentBuild": false,
+    "allowDebugging": false,
+    "deepProfiling": false,
+    "enableAssertions": false,
+    "includeTestAssemblies": false,
+    "autoRunPlayer": false,
+    "connectToHost": false,
+    "connectWithProfiler": false,
+    "cleanBuildCache": true,
+    "detailedBuildReport": true
+  },
+  "runtime": {
+    "debugBuild": false
+  }
+}

--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -154,7 +154,7 @@ jobs:
           github.event.pull_request.head.repo.full_name == github.repository))
       }}
     runs-on: [self-hosted, Windows, RAM-64GB]
-    timeout-minutes: 900
+    timeout-minutes: 1050
     strategy:
       fail-fast: false
       max-parallel: 1
@@ -342,7 +342,9 @@ jobs:
           ${{
             steps.compute.outputs.is-empty != 'true' ||
             steps.compute_playmode.outputs.is-empty != 'true' ||
-            steps.compute_standalone.outputs.is-empty != 'true'
+            steps.compute_standalone.outputs.is-empty != 'true' ||
+            matrix.unity-version == '2021.3.45f1' ||
+            matrix.unity-version == '6000.5.2f1'
           }}
         timeout-minutes: 2
         uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-current-pr-head@168b8dea5351f1cc448ed499e354cb31ad64ef10 # post-v1.10.0
@@ -439,9 +441,6 @@ jobs:
             -ReleaseCodeOptimization `
             -ReleasePlayerBuild
 
-      # Keep standalone last. Its IL2CPP build is the longest mode, and the
-      # central cleanup action below returns the final activation before the
-      # editor-scoped organization lock is released.
       - name: Run Unity standalone tests
         id: run_standalone
         if: ${{ !cancelled() && steps.compute_standalone.outputs.is-empty != 'true' && steps.acquire_lock.outputs.acquired == 'true' }}
@@ -470,8 +469,44 @@ jobs:
             -ReleaseCodeOptimization `
             -ReleasePlayerBuild
 
-      # A mode failure is tolerated until all three modes have had a chance to
-      # run. Preserve per-mode diagnostics and result verification, then fail
+      # Run the shipping-fidelity slice on the oldest and newest supported
+      # editors. Keep it last because it builds a second IL2CPP player, and the
+      # central cleanup action below returns the final activation before the
+      # editor-scoped organization lock is released.
+      - name: Run stripped shipping-fidelity player
+        id: run_shipping
+        if: >-
+          ${{
+            !cancelled() &&
+            steps.acquire_lock.outputs.acquired == 'true' &&
+            (matrix.unity-version == '2021.3.45f1' || matrix.unity-version == '6000.5.2f1')
+          }}
+        continue-on-error: true
+        timeout-minutes: 150
+        shell: pwsh
+        env:
+          UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+          UNITY_ACCELERATOR_ENDPOINT: ${{ secrets.UNITY_ACCELERATOR_ENDPOINT }}
+        run: |
+          $projectPath = Join-Path $env:RUNNER_WORKSPACE 'dxm-u\t\${{ matrix.unity-version }}-shipping'
+          $cachePath = Join-Path $env:RUNNER_WORKSPACE 'dxm-c\${{ matrix.unity-version }}'
+          ./scripts/unity/run-ci-tests.ps1 `
+            -UnityVersion '${{ matrix.unity-version }}' `
+            -UnityInstallRoot (Join-Path $env:RUNNER_TOOL_CACHE 'u6-v3') `
+            -TestMode shipping `
+            -AssemblyNames '' `
+            -ArtifactsPath '.artifacts/unity/${{ matrix.unity-version }}-shipping' `
+            -ProjectPath $projectPath `
+            -CachePath $cachePath `
+            -CanonicalProfilePath '.github/perf/shipping-fidelity-il2cpp-profile.v1.json' `
+            -LicenseReturnOwner Central `
+            -ReleaseCodeOptimization `
+            -ReleasePlayerBuild
+
+      # A mode failure is tolerated until the test modes and shipping slice have
+      # had a chance to run. Preserve diagnostics and result verification, then fail
       # the editor-scoped job from one summary gate before central cleanup.
       - name: Dump EditMode log tail on failure or cancellation
         if: ${{ steps.run_editmode.outcome == 'failure' || cancelled() }}
@@ -496,6 +531,14 @@ jobs:
         with:
           results-dir: .artifacts/unity/${{ matrix.unity-version }}-standalone
           label: Unity ${{ matrix.unity-version }} standalone
+
+      - name: Dump shipping-fidelity log tail on failure or cancellation
+        if: ${{ steps.run_shipping.outcome == 'failure' || cancelled() }}
+        timeout-minutes: 5
+        uses: ./.github/actions/dump-unity-log-tail
+        with:
+          results-dir: .artifacts/unity/${{ matrix.unity-version }}-shipping
+          label: Unity ${{ matrix.unity-version }} shipping fidelity
 
       # CLASS GUARD: Unity can fail before NUnit writes results. The shared
       # composite fails unless a results XML exists AND reports total > 0.
@@ -585,6 +628,22 @@ jobs:
           if-no-files-found: warn
           retention-days: 14
 
+      - name: Upload shipping-fidelity artifacts
+        if: >-
+          ${{
+            always() &&
+            !cancelled() &&
+            steps.acquire_lock.outputs.acquired == 'true' &&
+            (matrix.unity-version == '2021.3.45f1' || matrix.unity-version == '6000.5.2f1')
+          }}
+        timeout-minutes: 10
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: unity-${{ matrix.unity-version }}-shipping
+          path: .artifacts/unity/${{ matrix.unity-version }}-shipping
+          if-no-files-found: error
+          retention-days: 14
+
       - name: Require every Unity mode to pass
         if: ${{ !cancelled() && steps.acquire_lock.outputs.acquired == 'true' }}
         timeout-minutes: 2
@@ -602,6 +661,8 @@ jobs:
           STANDALONE_EMPTY: ${{ steps.compute_standalone.outputs.is-empty }}
           STANDALONE_RUN: ${{ steps.run_standalone.outcome }}
           STANDALONE_VERIFY: ${{ steps.verify_standalone.outcome }}
+          SHIPPING_REQUIRED: ${{ matrix.unity-version == '2021.3.45f1' || matrix.unity-version == '6000.5.2f1' }}
+          SHIPPING_RUN: ${{ steps.run_shipping.outcome }}
         run: |
           $failures = @()
           foreach ($mode in @(
@@ -620,10 +681,15 @@ jobs:
               $failures += "$($mode.Name): result verification $($mode.Verify)"
             }
           }
+          if ($env:SHIPPING_REQUIRED -eq 'true' -and $env:SHIPPING_RUN -ne 'success') {
+            $failures += "shipping: fidelity run $env:SHIPPING_RUN"
+          } elseif ($env:SHIPPING_REQUIRED -ne 'true' -and $env:SHIPPING_RUN -ne 'skipped') {
+            $failures += "shipping: non-target editor unexpectedly ran ($env:SHIPPING_RUN)"
+          }
           if ($failures.Count -gt 0) {
             throw "Unity mode failures: $($failures -join '; ')"
           }
-          Write-Host 'All Unity modes completed and produced valid results.'
+          Write-Host 'All required Unity test modes and shipping-fidelity runs completed.'
 
       - name: Return Unity license
         id: return_unity_license

--- a/.llm/skills/il2cpp-build-configuration/SKILL.md
+++ b/.llm/skills/il2cpp-build-configuration/SKILL.md
@@ -47,7 +47,8 @@ spelled out in workflows so YAML drift is visible in review.
 Leg profiles: EditMode and PlayMode take `-ReleaseCodeOptimization`; the
 published Standalone perf leg takes `-StandaloneScriptingBackend IL2CPP`
 plus `-ReleasePlayerBuild` and `-ReleaseCodeOptimization`; Standalone tests take
-`-ReleasePlayerBuild -ReleaseCodeOptimization`.
+`-ReleasePlayerBuild -ReleaseCodeOptimization`. The non-published shipping
+fidelity leg additionally takes `-TestMode shipping` and the shipping profile.
 
 ### Player configuration
 
@@ -61,16 +62,20 @@ plus `-ReleasePlayerBuild` and `-ReleaseCodeOptimization`; Standalone tests take
 - `PlayerSettings.SetApiCompatibilityLevel(..., ApiCompatibilityLevel.NET_Standard)`
   is the non-deprecated profile targeting .NET Standard 2.1.
 - `PlayerSettings.SetManagedStrippingLevel(..., ManagedStrippingLevel.Disabled)`
-  is mandatory. Default stripping deletes the benchmark assemblies and the
-  `[Preserve]` standalone test-run callback, and the player then runs nothing.
+  is mandatory for test players. Default stripping deletes the benchmark
+  assemblies and the `[Preserve]` standalone test-run callback, and the player
+  then runs nothing.
+- `.github/perf/shipping-fidelity-il2cpp-profile.v1.json` pins High stripping
+  and `includeTestAssemblies=false` for the separate shipping consumer. That
+  player builds through `BuildPipeline` and must not use Unity Test Framework.
 - Pin `Il2CppCodeGeneration.OptimizeSpeed`, incremental GC, and engine-code
   stripping from the canonical profile. Do not rely on an ephemeral project's
   defaults.
 
 ### Proving the profile
 
-- The runner archives the exact profile as `canonical-il2cpp-profile.v1.json`
-  and writes its SHA-256 beside it. Generated editor and player code embed that
+- The runner archives the exact selected profile under its source filename and
+  writes its SHA-256 beside it. Generated editor and player code embed that
   profile ID and hash.
 - `configured-profile.json`, `prebuild-profile.json`, and
   `postbuild-profile.json` record settings after configuration and inside the
@@ -88,6 +93,9 @@ plus `-ReleasePlayerBuild` and `-ReleaseCodeOptimization`; Standalone tests take
 - Never publish a Debug number. `perf-numbers.yml` publishes only the Standalone
   IL2CPP Release leg; manually dispatched `unity-benchmarks.yml` supplies
   per-version editor coverage and allocation evidence.
+- The Unity Tests workflow runs the shipping-fidelity player on the oldest and
+  newest supported editors. Its positive and missing-root runs use the same
+  binary and publish correctness evidence only, never throughput rows.
 
 ### Backend split
 

--- a/.llm/skills/il2cpp-build-configuration/references/perf-config-il2cpp-release-netstandard21.md
+++ b/.llm/skills/il2cpp-build-configuration/references/perf-config-il2cpp-release-netstandard21.md
@@ -75,6 +75,7 @@ three knobs:
 | PlayMode tests/benchmarks   | `-ReleaseCodeOptimization`                                                        |
 | Standalone perf (published) | `-StandaloneScriptingBackend IL2CPP -ReleasePlayerBuild -ReleaseCodeOptimization` |
 | Standalone tests            | `-ReleasePlayerBuild -ReleaseCodeOptimization`                                    |
+| Shipping fidelity           | `-TestMode shipping -ReleasePlayerBuild -ReleaseCodeOptimization`                 |
 
 ## .NET Standard 2.1 and stripping
 
@@ -94,13 +95,20 @@ execute and write results. The runner's `StandaloneScriptingBackend` parameter
 defaults to `IL2CPP` and accepts `Mono2x`, so the same script can build either
 backend; the published leg pins IL2CPP.
 
+The separate shipping-fidelity player uses High managed stripping and excludes
+test assemblies. It builds through `BuildPipeline.BuildPlayer` instead of Unity
+Test Framework, then runs positive generated-root coverage and an expected
+missing-root control from the same binary.
+
 ## Canonical profile
 
 `.github/perf/canonical-il2cpp-profile.v1.json` is the reviewed source of truth
-for the published standalone IL2CPP leg. The workflow passes it through
-`-CanonicalProfilePath`. The runner copies the exact bytes and a SHA-256 file to
-the run artifacts, then embeds the profile ID and hash in generated editor and
-player code.
+for the published standalone IL2CPP leg.
+`.github/perf/shipping-fidelity-il2cpp-profile.v1.json` is the reviewed source
+of truth for the stripped correctness player. Each workflow passes its selected
+file through `-CanonicalProfilePath`. The runner copies the exact bytes under
+the source filename and writes a SHA-256 file to the run artifacts, then embeds
+the profile ID and hash in generated editor and player code.
 
 The profile also pins `Il2CppCodeGeneration.OptimizeSpeed`, incremental GC,
 engine-code stripping, and the final `BuildOptions` flags. Keep these values in
@@ -149,6 +157,10 @@ against the committed master baseline. The
 manually dispatched `unity-benchmarks.yml` runs the EditMode and PlayMode
 benchmark tests across Unity versions with `-ReleaseCodeOptimization` for
 coverage only.
+
+The Unity Tests workflow runs the shipping-fidelity profile on the oldest and
+newest supported editors. Its evidence is correctness-only and never enters the
+published benchmark baseline.
 
 ## Common Pitfalls
 

--- a/.llm/skills/unity-editor-ci/SKILL.md
+++ b/.llm/skills/unity-editor-ci/SKILL.md
@@ -11,8 +11,9 @@ metadata:
 The active Unity workflows run `scripts/unity/run-ci-tests.ps1` directly on self-hosted
 Windows runners. `unity-tests.yml` is a four-version matrix. Each editor-scoped
 job runs `editmode`, `playmode`, and `standalone` as separate invocations under
-one lock and cleanup window; `standalone` builds and runs a
-`StandaloneWindows64` IL2CPP player from a runner-local project under
+one lock and cleanup window. The oldest and current endpoint jobs also run the
+stripped shipping-fidelity player. Both player modes build `StandaloneWindows64`
+IL2CPP players from runner-local projects under
 `$RUNNER_WORKSPACE/dxm-u/t/<version>-<mode>/`.
 
 ## When to use
@@ -51,11 +52,12 @@ one lock and cleanup window; `standalone` builds and runs a
   `unity-benchmarks.yml`, and `perf-numbers.yml`). A native
   `concurrency.group: wallstop-organization-builds` is repository-scoped and is FORBIDDEN.
 - Timeout invariant: every step before and including the cleanup gate has an explicit positive
-  timeout. Editor validation is capped at `10`, the acquire step cap (`305`) exceeds its
-  internal wait (`300`). Grouped correctness invocations use `90`/`90`/`150` caps;
-  other licensed work is capped at `120` to `180`. Cleanup uses `5`/`2`/`5`/`2`
-  for return/classify/release/gate. The `900`-minute job cap must retain at least 60 minutes
-  beyond the sum of those enforced step caps.
+  timeout. Editor validation is capped at `10`, and the acquire step cap (`305`) exceeds its
+  internal wait (`300`). Grouped correctness invocations use `90`/`90`/`150` caps, and the
+  endpoint-only shipping invocation uses `150`. Cleanup uses `5`/`2`/`5`/`2` for
+  return/classify/release/gate. `unity-tests.yml` uses a `1050`-minute job cap. Other licensed
+  jobs retain their `900`-minute cap. Each cap must retain at least 60 minutes beyond the sum
+  of its enforced step caps.
 - Editors and modules are installed manually by a runner administrator under
   `RUNNER_TOOL_CACHE/u6-v3`. Workflows MUST NOT install, repair, uninstall, or quarantine
   editors. Validate with `-CiManagedOnly -RequireHealthyExisting` before acquiring the lock.
@@ -75,9 +77,9 @@ one lock and cleanup window; `standalone` builds and runs a
 
 - CI must pass `-CiManagedOnly -RequireHealthyExisting` plus `-ProvisioningProfile`
   explicitly. The grouped correctness job validates `StandaloneWindowsIl2Cpp` once because
-  that superset serves all three invocations. Other jobs use `EditorOnly` for editmode,
-  playmode, benchmarks, and release checks, or `StandaloneWindowsIl2Cpp` for standalone
-  (verifies `windows-il2cpp`); `Android` and `Full`
+  that superset serves all test modes and the endpoint-only shipping invocation. Other jobs use
+  `EditorOnly` for editmode, playmode, benchmarks, and release checks, or
+  `StandaloneWindowsIl2Cpp` for standalone (verifies `windows-il2cpp`); `Android` and `Full`
   remain manual-maintenance profiles.
 - `unity install-path` with NO arguments is a GETTER. The SET form uses a flag (`-s`, then
   `--set` as fallback) and is best-effort only; discovery always relies on the getter.

--- a/.llm/skills/unity-editor-ci/references/unity-ci-matrix.md
+++ b/.llm/skills/unity-editor-ci/references/unity-ci-matrix.md
@@ -2,7 +2,7 @@
 
 # Unity CI Matrix
 
-> **One-line summary**: The active Unity workflows under `.github/workflows/` run `scripts/unity/run-ci-tests.ps1` on self-hosted Windows runners: `unity-tests.yml` has four editor-scoped jobs, and each job invokes editmode, playmode, and standalone separately under one lock and cleanup window.
+> **One-line summary**: The active Unity workflows under `.github/workflows/` run `scripts/unity/run-ci-tests.ps1` on self-hosted Windows runners: `unity-tests.yml` has four editor-scoped jobs, each job invokes editmode, playmode, and standalone, and the oldest and current endpoint jobs also invoke shipping under one lock and cleanup window.
 
 ## When to Use
 
@@ -24,14 +24,16 @@
 | --------------- | --------------------------------------------------------- |
 | `unity-version` | `2021.3.45f1`, `2022.3.45f1`, `6000.3.16f1`, `6000.5.2f1` |
 
-Four jobs each run three independent modes. `editmode`/`playmode` run in-editor
-on Mono; `standalone` builds and runs a `StandaloneWindows64` IL2CPP player.
-Each mode keeps its own result verification, artifact, timeout, and runner-local
-project. The direct runner
+Four jobs each run three independent test modes. `editmode`/`playmode` run in-editor
+on Mono; `standalone` builds and runs a `StandaloneWindows64` IL2CPP test player.
+The oldest and current endpoint jobs also build and run the stripped
+`StandaloneWindows64` IL2CPP shipping-fidelity player. Each invocation keeps its
+own result verification, artifact, timeout, and runner-local project. The direct runner
 generates a package host project under
 `$RUNNER_WORKSPACE/dxm-u/t/<version>-<mode>/`, imports the repo package with a
-`file:` dependency, sets `testables`, and configures IL2CPP before running
-standalone tests. Dispatch runs use the same complete static matrix.
+`file:` dependency, and configures IL2CPP before either player build. Test hosts
+set `testables`; the shipping host omits test packages and `testables`. Dispatch
+runs use the same complete static matrix.
 
 The Unity version list is canonical in `.github/unity-versions.json`;
 `unity-tests.yml` carries a static literal mirror so the organization analyzer
@@ -68,13 +70,13 @@ With both controls, a run consumes at most one seat while another repository can
 job timeout-minutes >= sum(all capped steps through cleanup gate) + 60
 ```
 
-Editor validation is capped at 10 minutes. The acquire input `timeout-minutes: "300"` is the internal lock-poll budget. Its enclosing step has `timeout-minutes: 305`, so the action can finish and report a timeout before GitHub terminates the step. Grouped correctness modes use 90/90/150-minute caps; other licensed work uses 120 to 180 minutes. Return/classify/release/gate use 5/2/5/2 minutes. The licensed jobs use `timeout-minutes: 900`. `scripts/validate-unity-pr-policy.py` sums every enforced step cap through the cleanup gate and requires at least 60 minutes of remaining job time.
+Editor validation is capped at 10 minutes. The acquire input `timeout-minutes: "300"` is the internal lock-poll budget. Its enclosing step has `timeout-minutes: 305`, so the action can finish and report a timeout before GitHub terminates the step. Grouped correctness test modes use 90/90/150-minute caps, and the endpoint-only shipping invocation uses 150 minutes. Return/classify/release/gate use 5/2/5/2 minutes. `unity-tests.yml` uses `timeout-minutes: 1050`; other licensed jobs retain `timeout-minutes: 900`. `scripts/validate-unity-pr-policy.py` sums every enforced step cap through the cleanup gate and requires at least 60 minutes of remaining job time.
 
 The step-level caps protect the in-use seat from a hung editor or ancillary action. They must remain strictly below the job timeout so the step fails first and the cleanup chain still runs. This matters because `stuck-job-watchdog.yml` ignores any `in_progress` job; without step caps, a wedged action can squat the seat until the whole job is cancelled.
 
 Runner administrators manually install every exact editor and required module under `RUNNER_TOOL_CACHE/u6-v3`. Workflows validate that root with `-CiManagedOnly -RequireHealthyExisting` before acquiring the organization lock; they never install or repair editors. Release the lock only after the always-run return and cleanup-classification steps.
 
-**Operator note (standalone IL2CPP):** the grouped correctness jobs require the Windows IL2CPP Unity module and the host build toolchain needed by Unity for Windows players. They validate the `StandaloneWindowsIl2Cpp` profile once before the lock, then reuse that editor for all three modes. Other workflows still select `EditorOnly` or `StandaloneWindowsIl2Cpp` according to their one mode. See [unity-editor-cli-bootstrap](./unity-editor-cli-bootstrap.md) for manual maintenance details.
+**Operator note (standalone IL2CPP):** the grouped correctness jobs require the Windows IL2CPP Unity module and the host build toolchain needed by Unity for Windows players. They validate the `StandaloneWindowsIl2Cpp` profile once before the lock, then reuse that editor for all test modes and the endpoint-only shipping invocation. Other workflows still select `EditorOnly` or `StandaloneWindowsIl2Cpp` according to their one mode. See [unity-editor-cli-bootstrap](./unity-editor-cli-bootstrap.md) for manual maintenance details.
 
 `unity-benchmarks.yml` (active; manual-only, NEVER on PRs):
 
@@ -87,7 +89,7 @@ The active `unity-benchmarks.yml` explicitly omits `pull_request` and `push` per
 
 ## compute-unity-assemblies is-empty Gate
 
-Every workflow that consumes `./.github/actions/compute-unity-assemblies` gives each Unity invocation a stable compute id. Grouped correctness uses `compute`, `compute_playmode`, and `compute_standalone`; each run receives only its matching assembly output through an environment variable. Unity work skips when its selection is empty. Lock acquisition remains unconditional because the static matrix is structurally non-empty and the organization analyzer must prove each acquisition. When asmdef discovery resolves no owned assemblies, verification treats the empty selection as an intentional skip while the terminal return/classify/release/gate chain still proves cleanup.
+Every workflow that consumes `./.github/actions/compute-unity-assemblies` gives each Unity test invocation a stable compute id. Grouped correctness uses `compute`, `compute_playmode`, and `compute_standalone`; each test run receives only its matching assembly output through an environment variable. Test work skips when its selection is empty. The endpoint-only shipping invocation is not test-assembly-discovery gated. Lock acquisition remains unconditional because the static matrix is structurally non-empty and the organization analyzer must prove each acquisition. When asmdef discovery resolves no owned assemblies, verification treats the empty selection as an intentional skip while the terminal return/classify/release/gate chain still proves cleanup.
 
 The `Verify tests actually ran` step keeps a cancellation-safe gate and must also require `steps.compute.outcome == 'success'` plus either `steps.compute.outputs.is-empty == 'true'` or a non-skipped Unity run step (never an is-empty gate alone). It receives `expected-empty: ${{ steps.compute.outputs.is-empty }}`, so an intentional skip reads as success rather than a "tests did not run" failure, while checkout/cache/setup/editor-validation/lock failures that prevent Unity from launching are not obscured by a generic missing-results annotation. The skip path does not fire for the current asmdef set; it is the robustness path for a target whose assemblies are all filtered out, such as a runtime-only standalone run when every DxMessaging test asmdef is editor-only.
 
@@ -164,4 +166,4 @@ For `standalone` runs, the direct runner first configures the generated project 
 - Unity CLI docs: https://docs.unity.com/en-us/hub/unity-cli
 - Unity LTS roadmap: https://unity.com/releases/lts
 - Unity managed code stripping: https://docs.unity3d.com/Manual/ManagedCodeStripping.html
-- Active workflows: `.github/workflows/unity-tests.yml` (direct Unity on self-hosted Windows; editmode/playmode/standalone), `.github/workflows/unity-benchmarks.yml`, `.github/workflows/perf-numbers.yml`, and `.github/workflows/release.yml`; ubuntu reference mirrors: `.github/workflows-disabled/`
+- Active workflows: `.github/workflows/unity-tests.yml` (direct Unity on self-hosted Windows; editmode/playmode/standalone on all versions and shipping on the oldest/current endpoints), `.github/workflows/unity-benchmarks.yml`, `.github/workflows/perf-numbers.yml`, and `.github/workflows/release.yml`; ubuntu reference mirrors: `.github/workflows-disabled/`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix stripped IL2CPP projects on Unity 2021.3 failing to compile because the runtime assembly
+  referenced the optional IMGUI module ([#515](https://github.com/Ambiguous-Interactive/DxMessaging/pull/515)).
 - Fix combined `ReflexiveSendMode` flags so active filtering is opt-in, inactive descendants are
   included without it, and missing zero- or one-argument receivers remain silent
   ([#489](https://github.com/Ambiguous-Interactive/DxMessaging/issues/489),

--- a/Editor/Settings/DxMessagingRuntimeSettingsCreator.cs
+++ b/Editor/Settings/DxMessagingRuntimeSettingsCreator.cs
@@ -1,0 +1,30 @@
+namespace DxMessaging.Editor.Settings
+{
+#if UNITY_EDITOR
+    using DxMessaging.Core.Configuration;
+    using UnityEditor;
+    using UnityEngine;
+
+    internal static class DxMessagingRuntimeSettingsCreator
+    {
+        private const string ResourceFolder = "Assets/Resources";
+        private const string ResourceAssetPath =
+            ResourceFolder + "/" + DxMessagingRuntimeSettings.ResourceName + ".asset";
+
+        [MenuItem("Assets/Create/Wallstop Studios/DxMessaging/Runtime Settings (in Resources)")]
+        private static void CreateAssetInResources()
+        {
+            if (!AssetDatabase.IsValidFolder(ResourceFolder))
+            {
+                AssetDatabase.CreateFolder("Assets", "Resources");
+            }
+            string targetPath = AssetDatabase.GenerateUniqueAssetPath(ResourceAssetPath);
+            DxMessagingRuntimeSettings asset =
+                ScriptableObject.CreateInstance<DxMessagingRuntimeSettings>();
+            AssetDatabase.CreateAsset(asset, targetPath);
+            AssetDatabase.SaveAssets();
+            EditorGUIUtility.PingObject(asset);
+        }
+    }
+#endif
+}

--- a/Editor/Settings/DxMessagingRuntimeSettingsCreator.cs.meta
+++ b/Editor/Settings/DxMessagingRuntimeSettingsCreator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a426dfaca00a1f5fcc983402ec70c2e0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Runtime/Core/Configuration/DxMessagingRuntimeSettings.cs
+++ b/Runtime/Core/Configuration/DxMessagingRuntimeSettings.cs
@@ -136,28 +136,6 @@ namespace DxMessaging.Core.Configuration
         }
 
 #if UNITY_EDITOR
-        private const string ResourceFolder = "Assets/Resources";
-        private const string ResourceAssetPath = ResourceFolder + "/" + ResourceName + ".asset";
-
-        [UnityEditor.MenuItem(
-            "Assets/Create/Wallstop Studios/DxMessaging/Runtime Settings (in Resources)"
-        )]
-        private static void CreateAssetInResources()
-        {
-            if (!UnityEditor.AssetDatabase.IsValidFolder(ResourceFolder))
-            {
-                UnityEditor.AssetDatabase.CreateFolder("Assets", "Resources");
-            }
-            string targetPath = UnityEditor.AssetDatabase.GenerateUniqueAssetPath(
-                ResourceAssetPath
-            );
-            DxMessagingRuntimeSettings asset =
-                ScriptableObject.CreateInstance<DxMessagingRuntimeSettings>();
-            UnityEditor.AssetDatabase.CreateAsset(asset, targetPath);
-            UnityEditor.AssetDatabase.SaveAssets();
-            UnityEditor.EditorGUIUtility.PingObject(asset);
-        }
-
         private void OnValidate()
         {
             if (_idleEvictionSeconds < 0f)

--- a/Tests/Editor/Contract/RuntimeAssemblyDependencyTests.cs
+++ b/Tests/Editor/Contract/RuntimeAssemblyDependencyTests.cs
@@ -1,0 +1,58 @@
+#if UNITY_EDITOR && UNITY_2021_3_OR_NEWER
+namespace DxMessaging.Tests.Editor.Contract
+{
+    using System.Linq;
+    using System.Reflection;
+    using DxMessaging.Core.Configuration;
+    using DxMessaging.Editor.Settings;
+    using NUnit.Framework;
+    using UnityEditor;
+
+    [TestFixture]
+    public sealed class RuntimeAssemblyDependencyTests
+    {
+        [Test]
+        public void RuntimeAssemblyDoesNotReferenceOptionalImguiModule()
+        {
+            string[] referencedAssemblies = typeof(DxMessagingRuntimeSettings)
+                .Assembly.GetReferencedAssemblies()
+                .Select(reference => reference.Name)
+                .ToArray();
+
+            CollectionAssert.DoesNotContain(
+                referencedAssemblies,
+                "UnityEngine.IMGUIModule",
+                "The runtime assembly must compile in stripped projects that omit the optional IMGUI module."
+            );
+        }
+
+        [Test]
+        public void RuntimeSettingsResourceMenuRemainsInEditorAssembly()
+        {
+            Assert.AreNotSame(
+                typeof(DxMessagingRuntimeSettings).Assembly,
+                typeof(DxMessagingRuntimeSettingsCreator).Assembly
+            );
+            MethodInfo createMethod = typeof(DxMessagingRuntimeSettingsCreator).GetMethod(
+                "CreateAssetInResources",
+                BindingFlags.NonPublic | BindingFlags.Static
+            );
+            Assert.IsNotNull(
+                createMethod,
+                "The Resources-folder creation command must remain available."
+            );
+            CustomAttributeData menuItem = createMethod
+                .GetCustomAttributesData()
+                .SingleOrDefault(attribute => attribute.AttributeType == typeof(MenuItem));
+            Assert.IsNotNull(
+                menuItem,
+                "The Resources-folder creation command must remain a Unity menu item."
+            );
+            Assert.AreEqual(
+                "Assets/Create/Wallstop Studios/DxMessaging/Runtime Settings (in Resources)",
+                menuItem.ConstructorArguments[0].Value
+            );
+        }
+    }
+}
+#endif

--- a/Tests/Editor/Contract/RuntimeAssemblyDependencyTests.cs.meta
+++ b/Tests/Editor/Contract/RuntimeAssemblyDependencyTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0f36e0d5224a8d52404d89ec7870fee3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/docs/runbooks/perf-benchmark-methodology.md
+++ b/docs/runbooks/perf-benchmark-methodology.md
@@ -285,6 +285,23 @@ metrics because the Release player strips the required profiler recorder (see
   renderer omits the all-unmeasured memory columns from the Standalone table and
   the all-unmeasured memory matrices entirely.
 
+- **Shipping-fidelity leg (not published)** builds a separate IL2CPP Release
+  player with High managed stripping and no test assemblies. It uses
+  `.github/perf/shipping-fidelity-il2cpp-profile.v1.json` and calls
+  `BuildPipeline.BuildPlayer` directly, without Unity Test Framework or a
+  PlayerConnection. The oldest and newest supported Unity editors each run the
+  same built binary twice: the positive run checks generated AOT roots across
+  every public top-level, public nested, and private nested class and readonly
+  struct message shape across all three message kinds, while the
+  missing-root run checks the expected failure for a private manual message.
+  Evidence records the exact ordered shape inventory for the first untyped,
+  typed, and registered untyped phases. The runner clears and hashes every
+  generated project input before reuse. It also archives a privacy-safe hash
+  and semantic summary of the resolved package lock, the exact two-assembly
+  player inventory, loaded assembly inventory, profile evidence, and
+  before/after binary manifests. This correctness slice does not contribute
+  benchmark rows or change the published performance profile.
+
 - **EditMode leg (not published)** also runs in-editor under Mono with
   `-releaseCodeOptimization`. It remains a fast scope for local iteration, and
   manually dispatched `unity-benchmarks.yml` runs the editmode + playmode

--- a/scripts/__tests__/ci-aggregate-workflow.test.js
+++ b/scripts/__tests__/ci-aggregate-workflow.test.js
@@ -553,7 +553,9 @@ test("every Unity lock window releases with explicit cleanup proof", () => {
     const label = `${file}:${jobId}`;
     const licensedCondition = `${file === "perf-numbers.yml" ? "success\\(\\) && " : ""}${file === "unity-tests.yml" ? "!cancelled\\(\\) && " : ""}${emptyAware ? "steps\\.compute\\.outputs\\.is-empty != 'true' && " : ""}steps\\.acquire_lock\\.outputs\\.acquired == 'true'`;
     const job = getJobBlock(readWorkflow(file), jobId, file);
-    assert.match(job, /\n    timeout-minutes: 900\n/, `${label}: lifecycle budget`);
+    const expectedJobTimeout = file === "unity-tests.yml" ? 1050 : 900;
+    // prettier-ignore
+    assert.match(job, new RegExp(`\\n    timeout-minutes: ${expectedJobTimeout}\\n`), `${label}: lifecycle budget`);
     if (["perf-numbers.yml", "unity-benchmarks.yml", "unity-tests.yml"].includes(file)) {
       assert.match(job, /\n      fail-fast: false\n      max-parallel: 1\n/, `${label} fairness`);
     }
@@ -693,7 +695,8 @@ test("licensed PR workflows fail closed and skip only documented non-code paths"
     aggregate,
     /DEPENDABOT_PR: \$\{\{ github\.event_name == 'pull_request' && github\.event\.pull_request\.user\.login == 'dependabot\[bot\]' \}\}/
   );
-  assert.doesNotMatch(aggregate, /github\.actor == 'dependabot\[bot\]'/);
+  // prettier-ignore
+  assert.doesNotMatch(aggregate, /github\.actor == 'dependabot\[bot\]'/); assert.match(getStepBlock(getJobBlock(unity, "unity-tests", "unity-tests.yml"), "Upload shipping-fidelity artifacts"), /always\(\) &&[\s\S]*!cancelled\(\) &&[\s\S]*steps\.acquire_lock\.outputs\.acquired == 'true'[\s\S]*if-no-files-found: error/);
 });
 // prettier-ignore
 test("active workflows pin external actions and scope licensed credentials", () => {

--- a/scripts/__tests__/unity-perf.test.js
+++ b/scripts/__tests__/unity-perf.test.js
@@ -213,11 +213,8 @@ test("scenario filters keep only dispatch and DxMessaging comparison rows", () =
 });
 
 test("PowerShell performance harness regression tests pass", () => {
-  for (const script of [
-    "il2cpp-profile.test.ps1",
-    "require-comparison-rows.test.ps1",
-    "same-player-repeat-evidence.test.ps1"
-  ]) {
+  // prettier-ignore
+  for (const script of ["il2cpp-profile.test.ps1", "require-comparison-rows.test.ps1", "same-player-repeat-evidence.test.ps1", "shipping-fidelity.test.ps1"]) {
     const testScript = path.join(REPO_ROOT, "scripts", "unity", "__tests__", script);
     const result = spawnSync("pwsh", ["-NoLogo", "-NoProfile", "-File", testScript], {
       encoding: "utf8"

--- a/scripts/__tests__/verify-unity-results-action.test.js
+++ b/scripts/__tests__/verify-unity-results-action.test.js
@@ -178,9 +178,9 @@ test("Unity result actions scan retry logs alongside or instead of unity.log", (
       name: "dump final plus retry",
       run: runDumpUnityLogTailAction,
       finalLog: "Final attempt failed later.\n",
-      retryLog: "CompilationFailedException: first attempt stopped before retry\n",
+      retryLog: "additional diagnostic tail sentinel\nCompilationFailedException: retry stopped\n",
       status: 0,
-      patterns: [/Pattern detected -- CompilationFailedException/, /unity\.first-attempt\.log/]
+      patterns: [/additional diagnostic tail sentinel/, /unity\.first-attempt\.log/]
     },
     {
       name: "dump retry only",

--- a/scripts/unity/__tests__/il2cpp-profile.test.ps1
+++ b/scripts/unity/__tests__/il2cpp-profile.test.ps1
@@ -94,29 +94,29 @@ try {
 
     $generatedSources = @(
         New-ConfiguratorSource -CanonicalProfileId $profile.profileId -CanonicalProfileSha256 $profileSha256
-        New-StandaloneBuildModifierSource -CanonicalProfileId $profile.profileId -CanonicalProfileSha256 $profileSha256
         New-StandaloneTestCallbackSource -CanonicalProfileId $profile.profileId -CanonicalProfileSha256 $profileSha256
     )
     foreach ($source in $generatedSources) {
         Assert-That 'generated C# embeds the profile ID' ($source.Contains($profile.profileId))
         Assert-That 'generated C# embeds the profile SHA-256' ($source.Contains($profileSha256))
     }
+    $buildModifierSource = New-StandaloneBuildModifierSource -CanonicalProfileId $profile.profileId
     Assert-That 'the configurator pins OptimizeSpeed' (
         $generatedSources[0].Contains('Il2CppCodeGeneration.OptimizeSpeed')
     )
     Assert-That 'the build evidence reads final BuildReport options' (
-        $generatedSources[1].Contains('report.summary.options')
+        $buildModifierSource.Contains('report.summary.options')
     )
     Assert-That 'the build process records prebuild and postbuild configuration' (
-        $generatedSources[1].Contains('DXM_PREBUILD_CONFIG_PROFILE_PATH') -and
-        $generatedSources[1].Contains('DXM_POSTBUILD_CONFIG_PROFILE_PATH')
+        $buildModifierSource.Contains('DXM_PREBUILD_CONFIG_PROFILE_PATH') -and
+        $buildModifierSource.Contains('DXM_POSTBUILD_CONFIG_PROFILE_PATH')
     )
     Assert-That 'the build evidence uses Unity ForceEnableAssertions flag' (
-        $generatedSources[1].Contains('BuildOptions.ForceEnableAssertions') -and
-        -not $generatedSources[1].Contains('BuildOptions.EnableAssertions')
+        $generatedSources[0].Contains('BuildOptions.ForceEnableAssertions') -and
+        -not $generatedSources[0].Contains('BuildOptions.EnableAssertions')
     )
     Assert-That 'the player records Debug.isDebugBuild' (
-        $generatedSources[2].Contains('Debug.isDebugBuild')
+        $generatedSources[1].Contains('Debug.isDebugBuild')
     )
 
     $runnerText = Get-Content -LiteralPath $runnerPath -Raw
@@ -140,6 +140,19 @@ try {
     & $validatorPath -ProfilePath $profilePath -ProfileOnly -ExpectedSha256 $profileSha256
 
     $badProfilePath = Join-Path $fixtureRoot 'bad-profile.json'
+    foreach ($semanticMutation in @(
+        @{ Group = 'configuration'; Property = 'buildTarget'; Value = 'StandaloneLinux64' },
+        @{ Group = 'configuration'; Property = 'il2cppCodeGeneration'; Value = 'OptimizeSize' },
+        @{ Group = 'buildOptions'; Property = 'developmentBuild'; Value = $true },
+        @{ Group = 'runtime'; Property = 'debugBuild'; Value = $true }
+    )) {
+        $mutatedProfile = Copy-JsonValue -Value $profile
+        $mutatedProfile.($semanticMutation.Group).($semanticMutation.Property) = $semanticMutation.Value
+        Write-TestJson -Path $badProfilePath -Value $mutatedProfile
+        Assert-Fails "$($semanticMutation.Group).$($semanticMutation.Property) fixed profile value" {
+            & $validatorPath -ProfilePath $badProfilePath -ProfileOnly
+        }
+    }
     foreach ($kind in @('configuration', 'buildOptions', 'runtime')) {
         foreach ($property in $profile.$kind.PSObject.Properties) {
             $wrongTypeProfile = Copy-JsonValue -Value $profile
@@ -282,6 +295,16 @@ try {
     }
 
     $badProfile = Copy-JsonValue -Value $profile
+    $badProfile.profileId = 'unsupported-il2cpp-profile-v1'
+    Write-TestJson -Path $badProfilePath -Value $badProfile
+    Assert-Fails 'unsupported profile ID lists both accepted profiles' -ExpectedMessage (
+        "Supported profileIds: 'canonical-il2cpp-verdict-player-v1', " +
+        "'shipping-fidelity-il2cpp-player-v1'."
+    ) {
+        & $validatorPath -ProfilePath $badProfilePath -ProfileOnly
+    }
+
+    $badProfile = Copy-JsonValue -Value $profile
     $badProfile.schemaVersion = '1'
     Write-TestJson -Path $badProfilePath -Value $badProfile
     Assert-Fails 'string canonical profile schema version' {
@@ -293,7 +316,7 @@ try {
         & $validatorPath -ProfilePath $badProfilePath -ProfileOnly
     }
 
-    Write-Host 'Canonical IL2CPP profile contract tests passed.'
+    Write-Host 'IL2CPP profile contract tests passed.'
 } finally {
     if (Test-Path -LiteralPath $fixtureRoot -PathType Container) {
         Remove-Item -LiteralPath $fixtureRoot -Recurse -Force

--- a/scripts/unity/__tests__/shipping-fidelity.test.ps1
+++ b/scripts/unity/__tests__/shipping-fidelity.test.ps1
@@ -1,0 +1,731 @@
+#!/usr/bin/env pwsh
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSScriptRoot))
+$unityScriptsRoot = Split-Path -Parent $PSScriptRoot
+$runnerPath = Join-Path $unityScriptsRoot 'run-ci-tests.ps1'
+$validatorPath = Join-Path $unityScriptsRoot 'validate-il2cpp-profile.ps1'
+$profilePath = Join-Path $repoRoot '.github/perf/shipping-fidelity-il2cpp-profile.v1.json'
+$fixtureRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("dxm-shipping-fidelity-{0}" -f [guid]::NewGuid().ToString('N'))
+
+function Assert-That {
+    param(
+        [Parameter(Mandatory = $true)][string]$Description,
+        [Parameter(Mandatory = $true)][bool]$Condition
+    )
+
+    if (-not $Condition) {
+        throw "Assertion failed: $Description"
+    }
+}
+
+function Assert-Fails {
+    param(
+        [Parameter(Mandatory = $true)][string]$Description,
+        [Parameter(Mandatory = $true)][scriptblock]$Action,
+        [Parameter(Mandatory = $true)][string]$ExpectedMessage
+    )
+
+    try {
+        & $Action
+    } catch {
+        if ($_.Exception.Message.Contains($ExpectedMessage)) {
+            return
+        }
+        throw "Expected '$Description' to contain '$ExpectedMessage', observed '$($_.Exception.Message)'."
+    }
+    throw "Expected failure: $Description"
+}
+
+function Copy-JsonValue {
+    param([Parameter(Mandatory = $true)]$Value)
+    return $Value | ConvertTo-Json -Depth 10 | ConvertFrom-Json
+}
+
+try {
+    New-Item -ItemType Directory -Force -Path $fixtureRoot | Out-Null
+    $tokens = $null
+    $parseErrors = $null
+    $runnerAst = [System.Management.Automation.Language.Parser]::ParseFile(
+        $runnerPath,
+        [ref]$tokens,
+        [ref]$parseErrors
+    )
+    if (@($parseErrors).Count -gt 0) {
+        throw "run-ci-tests.ps1 has parse errors: $($parseErrors.Message -join '; ')"
+    }
+    foreach ($functionName in @(
+        'Resolve-FullPath',
+        'ConvertTo-UnityFileUriPath',
+        'Test-IsReparsePoint',
+        'Write-JsonArtifact',
+        'Assert-ExactJsonPropertyNames',
+        'Assert-JsonValueType',
+        'Get-ExpectedShippingShapeNames',
+        'Assert-ExactJsonStringArray',
+        'Assert-NoShippingTestAssemblies',
+        'Test-ShippingAssemblyEvidence',
+        'Write-ShippingPackageResolutionEvidence',
+        'Test-ShippingFidelityResult'
+    )) {
+        $definition = $runnerAst.FindAll(
+            {
+                param($node)
+                $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+                    $node.Name -eq $functionName
+            },
+            $true
+        ) | Select-Object -First 1
+        if (-not $definition) {
+            throw "Function '$functionName' was not found in run-ci-tests.ps1."
+        }
+        Invoke-Expression $definition.Extent.Text
+    }
+
+    $projectPath = Join-Path $fixtureRoot 'project'
+    $artifactsPath = Join-Path $fixtureRoot 'artifacts'
+    $cachePath = Join-Path $fixtureRoot 'cache'
+    & $runnerPath `
+        -UnityVersion '6000.3.16f1' `
+        -TestMode shipping `
+        -AssemblyNames '' `
+        -ArtifactsPath $artifactsPath `
+        -RepoRoot $repoRoot `
+        -ProjectPath $projectPath `
+        -CachePath $cachePath `
+        -CanonicalProfilePath $profilePath `
+        -GenerateOnly
+
+    $manifest = Get-Content -LiteralPath (Join-Path $projectPath 'Packages/manifest.json') -Raw | ConvertFrom-Json
+    $manifestPropertyNames = @($manifest.PSObject.Properties.Name)
+    Assert-That 'shipping manifest contains only dependencies' (
+        $manifestPropertyNames.Count -eq 1 -and $manifestPropertyNames[0] -ceq 'dependencies'
+    )
+    $dependencyNames = @($manifest.dependencies.PSObject.Properties.Name)
+    Assert-That 'shipping manifest contains only the package under test' (
+        $dependencyNames.Count -eq 1 -and $dependencyNames[0] -ceq 'com.wallstop-studios.dxmessaging'
+    )
+    Assert-That 'shipping manifest omits Unity Test Framework' (
+        $manifest.dependencies.PSObject.Properties.Name -cnotcontains 'com.unity.test-framework'
+    )
+
+    $assetFiles = @(
+        Get-ChildItem -LiteralPath (Join-Path $projectPath 'Assets') -File -Recurse |
+            Select-Object -ExpandProperty Name
+    )
+    Assert-That 'shipping project emits only compiler options, the configurator, builder, and player sources' (
+        $assetFiles.Count -eq 4 -and
+        $assetFiles -ccontains 'csc.rsp' -and
+        $assetFiles -ccontains 'DxmCiTestConfigurator.cs' -and
+        $assetFiles -ccontains 'DxmShippingFidelityBuilder.cs' -and
+        $assetFiles -ccontains 'DxmShippingFidelityPlayer.cs'
+    )
+    Assert-That 'shipping project omits test callbacks and build modifiers' (
+        $assetFiles -cnotcontains 'DxmCiStandaloneTestCallback.cs' -and
+        $assetFiles -cnotcontains 'DxmCiStandaloneBuildModifier.cs'
+    )
+    $projectInputManifestPath = Join-Path $artifactsPath 'shipping-project-inputs.json'
+    $projectInputManifest = Get-Content -LiteralPath $projectInputManifestPath -Raw | ConvertFrom-Json
+    $projectInputPaths = @($projectInputManifest.files.path)
+    Assert-That 'shipping project-input evidence contains the exact seven generated inputs' (
+        $projectInputPaths.Count -eq 7 -and
+        $projectInputPaths -ccontains 'Assets/csc.rsp' -and
+        $projectInputPaths -ccontains 'Assets/DxmShippingFidelityPlayer.cs' -and
+        $projectInputPaths -ccontains 'Assets/Editor/DxmCiTestConfigurator.cs' -and
+        $projectInputPaths -ccontains 'Assets/Editor/DxmShippingFidelityBuilder.cs' -and
+        $projectInputPaths -ccontains 'Packages/manifest.json' -and
+        $projectInputPaths -ccontains 'ProjectSettings/EditorSettings.asset' -and
+        $projectInputPaths -ccontains 'ProjectSettings/ProjectVersion.txt'
+    )
+    $staleInputPaths = @(
+        'Assets/StaleShippingProbe.cs',
+        'Assets/StaleShippingPlugin.dll',
+        'Assets/link.xml',
+        'Packages/packages-lock.json',
+        'Packages/com.example.stale/package.json',
+        'Packages/com.example.stale/Runtime/StalePackageProbe.cs',
+        'ProjectSettings/StaleShippingSettings.asset',
+        'UserSettings/StaleShippingPreferences.asset'
+    )
+    foreach ($staleInputRelativePath in $staleInputPaths) {
+        $staleInputPath = Join-Path $projectPath $staleInputRelativePath
+        New-Item -ItemType Directory -Force -Path (Split-Path -Parent $staleInputPath) | Out-Null
+        [System.IO.File]::WriteAllText($staleInputPath, 'stale shipping input')
+    }
+    & $runnerPath `
+        -UnityVersion '6000.3.16f1' `
+        -TestMode shipping `
+        -AssemblyNames '' `
+        -ArtifactsPath $artifactsPath `
+        -RepoRoot $repoRoot `
+        -ProjectPath $projectPath `
+        -CachePath $cachePath `
+        -CanonicalProfilePath $profilePath `
+        -GenerateOnly
+    foreach ($staleInputRelativePath in $staleInputPaths) {
+        Assert-That "shipping project reuse removes $staleInputRelativePath" (
+            -not (Test-Path -LiteralPath (Join-Path $projectPath $staleInputRelativePath))
+        )
+    }
+    $packagesAfterReuse = @(Get-ChildItem -LiteralPath (Join-Path $projectPath 'Packages') -Force)
+    Assert-That 'GenerateOnly leaves only the reviewed manifest under Packages' (
+        $packagesAfterReuse.Count -eq 1 -and $packagesAfterReuse[0].Name -ceq 'manifest.json'
+    )
+    $directoryLinkType = if ([System.IO.Path]::DirectorySeparatorChar -eq '\') {
+        'Junction'
+    } else {
+        'SymbolicLink'
+    }
+    $externalRootTarget = Join-Path $fixtureRoot 'external-root-target'
+    New-Item -ItemType Directory -Force -Path $externalRootTarget | Out-Null
+    $externalRootSentinel = Join-Path $externalRootTarget 'root-sentinel.txt'
+    [System.IO.File]::WriteAllText($externalRootSentinel, 'must survive root reparse cleanup')
+    $assetsRoot = Join-Path $projectPath 'Assets'
+    Remove-Item -LiteralPath $assetsRoot -Recurse -Force
+    New-Item -ItemType $directoryLinkType -Path $assetsRoot -Target $externalRootTarget | Out-Null
+    & $runnerPath `
+        -UnityVersion '6000.3.16f1' `
+        -TestMode shipping `
+        -AssemblyNames '' `
+        -ArtifactsPath $artifactsPath `
+        -RepoRoot $repoRoot `
+        -ProjectPath $projectPath `
+        -CachePath $cachePath `
+        -CanonicalProfilePath $profilePath `
+        -GenerateOnly
+    Assert-That 'shipping reuse unlinks an input-root reparse point without traversal' (
+        (Test-Path -LiteralPath $externalRootSentinel -PathType Leaf) -and
+        -not (Test-IsReparsePoint -Path $assetsRoot) -and
+        (Test-Path -LiteralPath (Join-Path $assetsRoot 'DxmShippingFidelityPlayer.cs') -PathType Leaf)
+    )
+
+    $externalChildTarget = Join-Path $fixtureRoot 'external-child-target'
+    New-Item -ItemType Directory -Force -Path $externalChildTarget | Out-Null
+    $externalChildSentinel = Join-Path $externalChildTarget 'child-sentinel.txt'
+    [System.IO.File]::WriteAllText($externalChildSentinel, 'must survive child reparse cleanup')
+    $linkedChildPath = Join-Path $assetsRoot 'StaleLinkedInput'
+    New-Item -ItemType $directoryLinkType -Path $linkedChildPath -Target $externalChildTarget | Out-Null
+    & $runnerPath `
+        -UnityVersion '6000.3.16f1' `
+        -TestMode shipping `
+        -AssemblyNames '' `
+        -ArtifactsPath $artifactsPath `
+        -RepoRoot $repoRoot `
+        -ProjectPath $projectPath `
+        -CachePath $cachePath `
+        -CanonicalProfilePath $profilePath `
+        -GenerateOnly
+    Assert-That 'shipping reuse unlinks a child reparse point without traversal' (
+        (Test-Path -LiteralPath $externalChildSentinel -PathType Leaf) -and
+        -not (Test-Path -LiteralPath $linkedChildPath) -and
+        (Test-Path -LiteralPath (Join-Path $assetsRoot 'DxmShippingFidelityPlayer.cs') -PathType Leaf)
+    )
+
+    $danglingRootTarget = Join-Path $fixtureRoot 'dangling-root-target'
+    New-Item -ItemType Directory -Force -Path $danglingRootTarget | Out-Null
+    Remove-Item -LiteralPath $assetsRoot -Recurse -Force
+    New-Item -ItemType $directoryLinkType -Path $assetsRoot -Target $danglingRootTarget | Out-Null
+    [System.IO.Directory]::Delete($danglingRootTarget, $true)
+    & $runnerPath `
+        -UnityVersion '6000.3.16f1' `
+        -TestMode shipping `
+        -AssemblyNames '' `
+        -ArtifactsPath $artifactsPath `
+        -RepoRoot $repoRoot `
+        -ProjectPath $projectPath `
+        -CachePath $cachePath `
+        -CanonicalProfilePath $profilePath `
+        -GenerateOnly
+    Assert-That 'shipping reuse replaces a dangling input-root directory link' (
+        -not (Test-IsReparsePoint -Path $assetsRoot) -and
+        (Test-Path -LiteralPath (Join-Path $assetsRoot 'DxmShippingFidelityPlayer.cs') -PathType Leaf)
+    )
+
+    $danglingChildTarget = Join-Path $fixtureRoot 'dangling-child-target'
+    New-Item -ItemType Directory -Force -Path $danglingChildTarget | Out-Null
+    $danglingChildPath = Join-Path $assetsRoot 'DanglingLinkedInput'
+    New-Item -ItemType $directoryLinkType -Path $danglingChildPath -Target $danglingChildTarget | Out-Null
+    [System.IO.Directory]::Delete($danglingChildTarget, $true)
+    & $runnerPath `
+        -UnityVersion '6000.3.16f1' `
+        -TestMode shipping `
+        -AssemblyNames '' `
+        -ArtifactsPath $artifactsPath `
+        -RepoRoot $repoRoot `
+        -ProjectPath $projectPath `
+        -CachePath $cachePath `
+        -CanonicalProfilePath $profilePath `
+        -GenerateOnly
+    Assert-That 'shipping reuse removes a dangling child directory link' (
+        -not (Test-Path -LiteralPath $danglingChildPath) -and
+        (Test-Path -LiteralPath (Join-Path $assetsRoot 'DxmShippingFidelityPlayer.cs') -PathType Leaf)
+    )
+
+    $manifest = Get-Content -LiteralPath (Join-Path $projectPath 'Packages/manifest.json') -Raw | ConvertFrom-Json
+    $packageLockPath = Join-Path $projectPath 'Packages/packages-lock.json'
+    $generatedManifestPath = Join-Path $projectPath 'Packages/manifest.json'
+    $generatedManifestSha256 = (
+        Get-FileHash -LiteralPath $generatedManifestPath -Algorithm SHA256
+    ).Hash.ToLowerInvariant()
+    $manifestDependencyValue = [string]$manifest.dependencies.'com.wallstop-studios.dxmessaging'
+    $packageLock = [ordered]@{
+        dependencies = [ordered]@{
+            'com.wallstop-studios.dxmessaging' = [ordered]@{
+                version = $manifestDependencyValue
+                depth = 0
+                source = 'local'
+                dependencies = [ordered]@{}
+            }
+        }
+    }
+    $packageEvidenceArguments = @{
+        ProjectPath = $projectPath
+        ArtifactsPath = $artifactsPath
+        ExpectedRepoRoot = $repoRoot
+        ExpectedManifestSha256 = $generatedManifestSha256
+    }
+    [System.IO.File]::WriteAllText($packageLockPath, ($packageLock | ConvertTo-Json -Depth 10))
+    Write-ShippingPackageResolutionEvidence @packageEvidenceArguments
+    $resolvedPackageEvidence = Get-Content `
+        -LiteralPath (Join-Path $artifactsPath 'shipping-resolved-package-inputs.json') `
+        -Raw |
+        ConvertFrom-Json
+    Assert-That 'shipping resolution evidence hashes the exact manifest and generated lock' (
+        @($resolvedPackageEvidence.files).Count -eq 2 -and
+        @($resolvedPackageEvidence.files.path)[0] -ceq 'Packages/manifest.json' -and
+        @($resolvedPackageEvidence.files.path)[1] -ceq 'Packages/packages-lock.json' -and
+        $resolvedPackageEvidence.resolvedPackage.packageId -ceq 'com.wallstop-studios.dxmessaging' -and
+        $resolvedPackageEvidence.resolvedPackage.source -ceq 'local' -and
+        [int]$resolvedPackageEvidence.resolvedPackage.depth -eq 0 -and
+        $resolvedPackageEvidence.resolvedPackage.versionScheme -ceq 'file'
+    )
+    $badPackageLock = Copy-JsonValue -Value $packageLock
+    $badPackageLock.dependencies.'com.wallstop-studios.dxmessaging'.source = 'registry'
+    [System.IO.File]::WriteAllText($packageLockPath, ($badPackageLock | ConvertTo-Json -Depth 10))
+    Assert-Fails 'shipping package resolution rejects a non-local lock' {
+        Write-ShippingPackageResolutionEvidence @packageEvidenceArguments
+    } 'reviewed checkout'
+    $badPackageLock = Copy-JsonValue -Value $packageLock
+    $badPackageLock.dependencies.'com.wallstop-studios.dxmessaging'.version = 'file:/another/checkout'
+    [System.IO.File]::WriteAllText($packageLockPath, ($badPackageLock | ConvertTo-Json -Depth 10))
+    Assert-Fails 'shipping package resolution rejects another local checkout' {
+        Write-ShippingPackageResolutionEvidence @packageEvidenceArguments
+    } 'reviewed checkout'
+    $badPackageLock = Copy-JsonValue -Value $packageLock
+    $badPackageLock.dependencies.'com.wallstop-studios.dxmessaging'.depth = '0'
+    [System.IO.File]::WriteAllText($packageLockPath, ($badPackageLock | ConvertTo-Json -Depth 10))
+    Assert-Fails 'shipping package resolution rejects a mistyped lock depth' {
+        Write-ShippingPackageResolutionEvidence @packageEvidenceArguments
+    } 'must be a JSON integer'
+    $badPackageLock = Copy-JsonValue -Value $packageLock
+    $badPackageLock.dependencies | Add-Member `
+        -NotePropertyName 'com.example.stale' `
+        -NotePropertyValue ([pscustomobject]@{})
+    [System.IO.File]::WriteAllText($packageLockPath, ($badPackageLock | ConvertTo-Json -Depth 10))
+    Assert-Fails 'shipping package resolution rejects an extra lock dependency' {
+        Write-ShippingPackageResolutionEvidence @packageEvidenceArguments
+    } 'exact one-package graph'
+    [System.IO.File]::WriteAllText($packageLockPath, ($packageLock | ConvertTo-Json -Depth 10))
+    $staleEmbeddedPackagePath = Join-Path $projectPath 'Packages/com.example.stale/package.json'
+    New-Item -ItemType Directory -Force -Path (Split-Path -Parent $staleEmbeddedPackagePath) | Out-Null
+    [System.IO.File]::WriteAllText($staleEmbeddedPackagePath, '{}')
+    Assert-Fails 'shipping package resolution rejects an embedded package' {
+        Write-ShippingPackageResolutionEvidence @packageEvidenceArguments
+    } 'unexpected entry'
+    Remove-Item -LiteralPath (Join-Path $projectPath 'Packages/com.example.stale') -Recurse -Force
+    $mutatedManifest = Copy-JsonValue -Value $manifest
+    $mutatedManifest.dependencies.'com.wallstop-studios.dxmessaging' = 'file:/another/checkout'
+    [System.IO.File]::WriteAllText($generatedManifestPath, ($mutatedManifest | ConvertTo-Json -Depth 10))
+    Assert-Fails 'shipping package resolution rejects post-resolution manifest drift' {
+        Write-ShippingPackageResolutionEvidence @packageEvidenceArguments
+    } 'manifest hash changed'
+    [System.IO.File]::WriteAllText($generatedManifestPath, ($manifest | ConvertTo-Json -Depth 10))
+
+    $configuratorText = Get-Content -LiteralPath (Join-Path $projectPath 'Assets/Editor/DxmCiTestConfigurator.cs') -Raw
+    $builderText = Get-Content -LiteralPath (Join-Path $projectPath 'Assets/Editor/DxmShippingFidelityBuilder.cs') -Raw
+    $playerText = Get-Content -LiteralPath (Join-Path $projectPath 'Assets/DxmShippingFidelityPlayer.cs') -Raw
+    $runtimeSettingsText = Get-Content -LiteralPath (
+        Join-Path $repoRoot 'Runtime/Core/Configuration/DxMessagingRuntimeSettings.cs'
+    ) -Raw
+    $runtimeSettingsCreatorText = Get-Content -LiteralPath (
+        Join-Path $repoRoot 'Editor/Settings/DxMessagingRuntimeSettingsCreator.cs'
+    ) -Raw
+    Assert-That 'runtime settings keep optional IMGUI calls in the editor assembly' (
+        -not $runtimeSettingsText.Contains('EditorGUIUtility') -and
+        $runtimeSettingsCreatorText.Contains('EditorGUIUtility.PingObject(asset);') -and
+        $runtimeSettingsCreatorText.Contains(
+            'Assets/Create/Wallstop Studios/DxMessaging/Runtime Settings (in Resources)'
+        )
+    )
+    Assert-That 'shipping configuration defers engine stripping until the builder assembly has loaded' (
+        $configuratorText.Contains('PlayerSettings.stripEngineCode = !string.Equals(') -and
+        $configuratorText.Contains('"shipping-fidelity-il2cpp-player-v1"')
+    )
+    Assert-That 'shipping builder invokes BuildPipeline directly' (
+        $builderText.Contains('BuildPipeline.BuildPlayer(options)')
+    )
+    $applyProfileIndex = $builderText.IndexOf('ApplyShippingProfile();', [StringComparison]::Ordinal)
+    $prebuildEvidenceIndex = $builderText.IndexOf(
+        'Environment.GetEnvironmentVariable("DXM_PREBUILD_CONFIG_PROFILE_PATH")',
+        [StringComparison]::Ordinal
+    )
+    $buildPlayerIndex = $builderText.IndexOf(
+        'BuildPipeline.BuildPlayer(options)',
+        [StringComparison]::Ordinal
+    )
+    Assert-That 'shipping builder applies the complete reviewed profile before evidence and build' (
+        $applyProfileIndex -ge 0 -and
+        $prebuildEvidenceIndex -gt $applyProfileIndex -and
+        $buildPlayerIndex -gt $prebuildEvidenceIndex -and
+        $builderText.Contains('PlayerSettings.SetScriptingBackend(standalone, ScriptingImplementation.IL2CPP);') -and
+        $builderText.Contains('PlayerSettings.SetApiCompatibilityLevel(standalone, ApiCompatibilityLevel.NET_Standard);') -and
+        $builderText.Contains('PlayerSettings.SetManagedStrippingLevel(standalone, ManagedStrippingLevel.High);') -and
+        $builderText.Contains('Il2CppCompilerConfiguration.Release);') -and
+        $builderText.Contains('PlayerSettings.gcIncremental = true;') -and
+        $builderText.Contains('PlayerSettings.stripEngineCode = true;') -and
+        $builderText.Contains('Il2CppCodeGeneration.OptimizeSpeed);')
+    )
+    Assert-That 'shipping builder excludes test assemblies and player connections' (
+        $builderText.Contains('~BuildOptions.IncludeTestAssemblies') -and
+        $builderText.Contains('~BuildOptions.AutoRunPlayer') -and
+        $builderText.Contains('~BuildOptions.ConnectToHost') -and
+        $builderText.Contains('~BuildOptions.ConnectWithProfiler')
+    )
+    $shapeCases = @(
+        @{ Type = 'DxmShippingPublicUntargetedClass'; Variable = 'publicUntargetedClass'; Kind = 'Untargeted'; Handler = 'HandlePublicUntargetedClass' },
+        @{ Type = 'DxmShippingPublicUntargetedStruct'; Variable = 'publicUntargetedStruct'; Kind = 'Untargeted'; Handler = 'HandlePublicUntargetedStruct' },
+        @{ Type = 'DxmShippingPublicTargetedClass'; Variable = 'publicTargetedClass'; Kind = 'Targeted'; Handler = 'HandlePublicTargetedClass' },
+        @{ Type = 'DxmShippingPublicTargetedStruct'; Variable = 'publicTargetedStruct'; Kind = 'Targeted'; Handler = 'HandlePublicTargetedStruct' },
+        @{ Type = 'DxmShippingPublicBroadcastClass'; Variable = 'publicBroadcastClass'; Kind = 'Broadcast'; Handler = 'HandlePublicBroadcastClass' },
+        @{ Type = 'DxmShippingPublicBroadcastStruct'; Variable = 'publicBroadcastStruct'; Kind = 'Broadcast'; Handler = 'HandlePublicBroadcastStruct' },
+        @{ Type = 'NestedUntargetedClass'; Variable = 'nestedUntargetedClass'; Kind = 'Untargeted'; Handler = 'HandleNestedUntargetedClass' },
+        @{ Type = 'NestedUntargetedStruct'; Variable = 'nestedUntargetedStruct'; Kind = 'Untargeted'; Handler = 'HandleNestedUntargetedStruct' },
+        @{ Type = 'NestedTargetedClass'; Variable = 'nestedTargetedClass'; Kind = 'Targeted'; Handler = 'HandleNestedTargetedClass' },
+        @{ Type = 'NestedTargetedStruct'; Variable = 'nestedTargetedStruct'; Kind = 'Targeted'; Handler = 'HandleNestedTargetedStruct' },
+        @{ Type = 'NestedBroadcastClass'; Variable = 'nestedBroadcastClass'; Kind = 'Broadcast'; Handler = 'HandleNestedBroadcastClass' },
+        @{ Type = 'NestedBroadcastStruct'; Variable = 'nestedBroadcastStruct'; Kind = 'Broadcast'; Handler = 'HandleNestedBroadcastStruct' },
+        @{ Type = 'PublicNestedUntargetedClass'; Variable = 'publicNestedUntargetedClass'; Kind = 'Untargeted'; Handler = 'HandlePublicNestedUntargetedClass' },
+        @{ Type = 'PublicNestedUntargetedStruct'; Variable = 'publicNestedUntargetedStruct'; Kind = 'Untargeted'; Handler = 'HandlePublicNestedUntargetedStruct' },
+        @{ Type = 'PublicNestedTargetedClass'; Variable = 'publicNestedTargetedClass'; Kind = 'Targeted'; Handler = 'HandlePublicNestedTargetedClass' },
+        @{ Type = 'PublicNestedTargetedStruct'; Variable = 'publicNestedTargetedStruct'; Kind = 'Targeted'; Handler = 'HandlePublicNestedTargetedStruct' },
+        @{ Type = 'PublicNestedBroadcastClass'; Variable = 'publicNestedBroadcastClass'; Kind = 'Broadcast'; Handler = 'HandlePublicNestedBroadcastClass' },
+        @{ Type = 'PublicNestedBroadcastStruct'; Variable = 'publicNestedBroadcastStruct'; Kind = 'Broadcast'; Handler = 'HandlePublicNestedBroadcastStruct' }
+    )
+    $rootStart = $playerText.IndexOf('List<string> rootedUntypedShapes', [StringComparison]::Ordinal)
+    $rootEnd = $playerText.IndexOf('long rootedUntypedProbeCount', $rootStart, [StringComparison]::Ordinal)
+    $typedStart = $playerText.IndexOf('s_UntypedPhase = false;', $rootEnd, [StringComparison]::Ordinal)
+    $typedEnd = $playerText.IndexOf('s_UntypedPhase = true;', $typedStart, [StringComparison]::Ordinal)
+    $untypedEnd = $playerText.IndexOf('result.typedDispatchCount', $typedEnd, [StringComparison]::Ordinal)
+    Assert-That 'shipping player exposes ordered source segments for every dispatch phase' (
+        $rootStart -ge 0 -and $rootEnd -gt $rootStart -and
+        $typedStart -gt $rootEnd -and $typedEnd -gt $typedStart -and $untypedEnd -gt $typedEnd
+    )
+    $rootSegment = $playerText.Substring($rootStart, $rootEnd - $rootStart)
+    $typedSegment = $playerText.Substring($typedStart, $typedEnd - $typedStart)
+    $untypedSegment = $playerText.Substring($typedEnd, $untypedEnd - $typedEnd)
+    foreach ($shapeCase in $shapeCases) {
+        $type = $shapeCase.Type
+        $variable = $shapeCase.Variable
+        $kind = $shapeCase.Kind
+        $handler = $shapeCase.Handler
+        $rootArguments = if ($kind -ceq 'Untargeted') {
+            "bus, $variable, rootedUntypedShapes"
+        } else {
+            "bus, route, $variable, rootedUntypedShapes"
+        }
+        $typedInvocation = if ($kind -ceq 'Untargeted') {
+            "bus.UntargetedBroadcast(ref $variable);"
+        } elseif ($kind -ceq 'Targeted') {
+            "bus.TargetedBroadcast(ref route, ref $variable);"
+        } else {
+            "bus.SourcedBroadcast(ref route, ref $variable);"
+        }
+        $untypedInvocation = if ($kind -ceq 'Untargeted') {
+            "bus.UntypedUntargetedBroadcast($variable);"
+        } elseif ($kind -ceq 'Targeted') {
+            "bus.UntypedTargetedBroadcast(route, $variable);"
+        } else {
+            "bus.UntypedSourcedBroadcast(route, $variable);"
+        }
+        $registrationInvocation = if ($kind -ceq 'Untargeted') {
+            "token.RegisterUntargeted<$type>($handler)"
+        } else {
+            "token.Register$kind<$type>(route, $handler)"
+        }
+        Assert-That "$type has the expected source-generator attribute" (
+            [regex]::Matches(
+                $playerText,
+                "\[Dx$($kind)Message\]\s+(?:public|private)\s+(?:sealed\s+partial\s+class|readonly\s+partial\s+struct)\s+$type"
+            ).Count -eq 1
+        )
+        Assert-That "$type is probed once before registration with its observed interface type" (
+            [regex]::Matches(
+                $rootSegment,
+                [regex]::Escape("Probe$($kind)Root($rootArguments);")
+            ).Count -eq 1
+        )
+        Assert-That "$type is registered with its distinct handler" (
+            $playerText.Contains($registrationInvocation)
+        )
+        Assert-That "$type is dispatched once through its typed path" (
+            [regex]::Matches($typedSegment, [regex]::Escape($typedInvocation)).Count -eq 1
+        )
+        Assert-That "$type is dispatched once through its post-registration untyped path" (
+            [regex]::Matches($untypedSegment, [regex]::Escape($untypedInvocation)).Count -eq 1
+        )
+        Assert-That "$type handler records the observed concrete shape" (
+            $playerText.Contains("$handler(in $type message) => Count(`"$type`");")
+        )
+    }
+    $messageAttributeCount = [regex]::Matches(
+        $playerText,
+        '\[Dx(?:Untargeted|Targeted|Broadcast)Message\]'
+    ).Count
+    Assert-That 'shipping player covers all 18 visibility, nesting, kind, and representation shapes' (
+        $messageAttributeCount -eq 18
+    )
+    Assert-That 'shipping player contains the private missing-root mutant' (
+        $playerText.Contains('private sealed class MissingRootUntargetedMessage') -and
+        $playerText.Contains('no rooted dispatch bridge was registered')
+    )
+    Assert-That 'shipping player checks the forbidden test define' (
+        $playerText.Contains('#if UNITY_INCLUDE_TESTS') -and
+        $playerText.Contains('result.unityIncludeTests = true;') -and
+        $playerText.Contains('if (result.unityIncludeTests)') -and
+        -not [regex]::IsMatch($playerText, 'result\.unityIncludeTests = true;\s*throw')
+    )
+    Assert-That 'shipping player serializes evidence without an optional Unity engine module' (
+        -not $playerText.Contains('JsonUtility') -and
+        $playerText.Contains('private static string QuoteJson(string value)') -and
+        $playerText.Contains('private static string SerializeStringArray(string[] values)') -and
+        $playerText.Contains('File.WriteAllText(path, json);')
+    )
+
+    $profile = Get-Content -LiteralPath $profilePath -Raw | ConvertFrom-Json
+    $profileSha256 = (Get-FileHash -LiteralPath $profilePath -Algorithm SHA256).Hash.ToLowerInvariant()
+    $assemblyEvidencePath = Join-Path $fixtureRoot 'shipping-assemblies.json'
+    $assemblyEvidence = [ordered]@{
+        schemaVersion = 1
+        profileId = $profile.profileId
+        profileSha256 = $profileSha256
+        unityVersion = '6000.3.16f1'
+        includeTestAssemblies = $false
+        playerAssemblies = @('Assembly-CSharp', 'WallstopStudios.DxMessaging')
+    }
+    [System.IO.File]::WriteAllText($assemblyEvidencePath, ($assemblyEvidence | ConvertTo-Json -Depth 10))
+    Test-ShippingAssemblyEvidence `
+        -Path $assemblyEvidencePath `
+        -ExpectedProfileId $profile.profileId `
+        -ExpectedProfileSha256 $profileSha256 `
+        -ExpectedUnityVersion '6000.3.16f1'
+    foreach ($property in $assemblyEvidence.GetEnumerator()) {
+        $mistypedEvidence = Copy-JsonValue -Value $assemblyEvidence
+        $mistypedEvidence.($property.Key) = if ($property.Value -is [bool]) {
+            $property.Value.ToString().ToLowerInvariant()
+        } elseif ($property.Value -is [int] -or $property.Value -is [long]) {
+            $property.Value.ToString()
+        } elseif ($property.Value -is [string]) {
+            $false
+        } else {
+            [string]$property.Value[0]
+        }
+        [System.IO.File]::WriteAllText($assemblyEvidencePath, ($mistypedEvidence | ConvertTo-Json -Depth 10))
+        Assert-Fails "shipping assembly evidence $($property.Key) type" {
+            Test-ShippingAssemblyEvidence `
+                -Path $assemblyEvidencePath `
+                -ExpectedProfileId $profile.profileId `
+                -ExpectedProfileSha256 $profileSha256 `
+                -ExpectedUnityVersion '6000.3.16f1'
+        } 'must be a JSON'
+    }
+    foreach ($badAssemblyMutation in @(
+        'include-tests',
+        'loaded-test-assembly',
+        'unexpected-player-assembly',
+        'mistyped-assembly-name',
+        'extra-property'
+    )) {
+        $mutatedEvidence = Copy-JsonValue -Value $assemblyEvidence
+        if ($badAssemblyMutation -ceq 'include-tests') {
+            $mutatedEvidence.includeTestAssemblies = $true
+        } elseif ($badAssemblyMutation -ceq 'loaded-test-assembly') {
+            $mutatedEvidence.playerAssemblies += 'nunit.framework'
+        } elseif ($badAssemblyMutation -ceq 'unexpected-player-assembly') {
+            $mutatedEvidence.playerAssemblies += 'StaleShippingPlugin'
+        } elseif ($badAssemblyMutation -ceq 'mistyped-assembly-name') {
+            $mutatedEvidence.playerAssemblies = @('Assembly-CSharp', 42)
+        } else {
+            $mutatedEvidence | Add-Member -NotePropertyName unexpected -NotePropertyValue $true
+        }
+        [System.IO.File]::WriteAllText($assemblyEvidencePath, ($mutatedEvidence | ConvertTo-Json -Depth 10))
+        $expectedAssemblyFailure = if ($badAssemblyMutation -ceq 'mistyped-assembly-name') {
+            'must be a JSON'
+        } else {
+            'Shipping'
+        }
+        Assert-Fails "shipping assembly evidence $badAssemblyMutation" {
+            Test-ShippingAssemblyEvidence `
+                -Path $assemblyEvidencePath `
+                -ExpectedProfileId $profile.profileId `
+                -ExpectedProfileSha256 $profileSha256 `
+                -ExpectedUnityVersion '6000.3.16f1'
+        } $expectedAssemblyFailure
+    }
+
+    $resultPath = Join-Path $fixtureRoot 'shipping-result.json'
+    $expectedShapeNames = @(Get-ExpectedShippingShapeNames)
+    $positiveResult = [ordered]@{
+        schemaVersion = 1
+        profileId = $profile.profileId
+        profileSha256 = $profileSha256
+        unityVersion = '6000.3.16f1'
+        mode = 'positive'
+        success = $true
+        unityIncludeTests = $false
+        rootedUntypedProbeCount = 18
+        typedDispatchCount = 18
+        untypedDispatchCount = 18
+        rootedUntypedShapes = @($expectedShapeNames)
+        typedDispatchShapes = @($expectedShapeNames)
+        untypedDispatchShapes = @($expectedShapeNames)
+        missingRootFailureObserved = $false
+        failureType = ''
+        failureMessage = ''
+        loadedAssemblies = @('Assembly-CSharp', 'WallstopStudios.DxMessaging')
+    }
+    [System.IO.File]::WriteAllText($resultPath, ($positiveResult | ConvertTo-Json -Depth 10))
+    Test-ShippingFidelityResult `
+        -Path $resultPath `
+        -ExpectedMode positive `
+        -ExpectedProfileId $profile.profileId `
+        -ExpectedProfileSha256 $profileSha256 `
+        -ExpectedUnityVersion '6000.3.16f1'
+    foreach ($property in $positiveResult.GetEnumerator()) {
+        $mistypedResult = Copy-JsonValue -Value $positiveResult
+        $mistypedResult.($property.Key) = if ($property.Value -is [bool]) {
+            $property.Value.ToString().ToLowerInvariant()
+        } elseif ($property.Value -is [int] -or $property.Value -is [long]) {
+            $property.Value.ToString()
+        } elseif ($property.Value -is [string]) {
+            $false
+        } else {
+            [string]$property.Value[0]
+        }
+        [System.IO.File]::WriteAllText($resultPath, ($mistypedResult | ConvertTo-Json -Depth 10))
+        Assert-Fails "shipping result $($property.Key) type" {
+            Test-ShippingFidelityResult `
+                -Path $resultPath `
+                -ExpectedMode positive `
+                -ExpectedProfileId $profile.profileId `
+                -ExpectedProfileSha256 $profileSha256 `
+                -ExpectedUnityVersion '6000.3.16f1'
+        } 'must be a JSON'
+    }
+    foreach ($badResultMutation in @(
+        'failed',
+        'missing-root-probe-count',
+        'wrong-count',
+        'duplicate-rooted-shape',
+        'duplicate-typed-shape',
+        'missing-untyped-shape',
+        'loaded-test-assembly',
+        'mistyped-assembly-name',
+        'extra-property'
+    )) {
+        $mutatedResult = Copy-JsonValue -Value $positiveResult
+        if ($badResultMutation -ceq 'failed') {
+            $mutatedResult.success = $false
+            $mutatedResult.failureType = 'System.InvalidOperationException'
+        } elseif ($badResultMutation -ceq 'missing-root-probe-count') {
+            $mutatedResult.rootedUntypedProbeCount = 0
+        } elseif ($badResultMutation -ceq 'wrong-count') {
+            $mutatedResult.untypedDispatchCount = 5
+        } elseif ($badResultMutation -ceq 'duplicate-rooted-shape') {
+            $mutatedResult.rootedUntypedShapes[1] = $mutatedResult.rootedUntypedShapes[0]
+        } elseif ($badResultMutation -ceq 'duplicate-typed-shape') {
+            $mutatedResult.typedDispatchShapes[1] = $mutatedResult.typedDispatchShapes[0]
+        } elseif ($badResultMutation -ceq 'missing-untyped-shape') {
+            $mutatedResult.untypedDispatchShapes = @($mutatedResult.untypedDispatchShapes)[0..16]
+        } elseif ($badResultMutation -ceq 'loaded-test-assembly') {
+            $mutatedResult.loadedAssemblies += 'UnityEngine.TestRunner'
+        } elseif ($badResultMutation -ceq 'mistyped-assembly-name') {
+            $mutatedResult.loadedAssemblies = @('Assembly-CSharp', 42)
+        } else {
+            $mutatedResult | Add-Member -NotePropertyName unexpected -NotePropertyValue $true
+        }
+        [System.IO.File]::WriteAllText($resultPath, ($mutatedResult | ConvertTo-Json -Depth 10))
+        $expectedResultFailure = if ($badResultMutation -ceq 'mistyped-assembly-name') {
+            'must be a JSON'
+        } elseif ($badResultMutation -clike '*shape') {
+            'shape inventory'
+        } else {
+            'Shipping'
+        }
+        Assert-Fails "shipping result $badResultMutation" {
+            Test-ShippingFidelityResult `
+                -Path $resultPath `
+                -ExpectedMode positive `
+                -ExpectedProfileId $profile.profileId `
+                -ExpectedProfileSha256 $profileSha256 `
+                -ExpectedUnityVersion '6000.3.16f1'
+        } $expectedResultFailure
+    }
+    $mutantResult = Copy-JsonValue -Value $positiveResult
+    $mutantResult.mode = 'missing-root-mutant'
+    $mutantResult.rootedUntypedProbeCount = 0
+    $mutantResult.typedDispatchCount = 0
+    $mutantResult.untypedDispatchCount = 0
+    $mutantResult.rootedUntypedShapes = @()
+    $mutantResult.typedDispatchShapes = @()
+    $mutantResult.untypedDispatchShapes = @()
+    $mutantResult.missingRootFailureObserved = $true
+    [System.IO.File]::WriteAllText($resultPath, ($mutantResult | ConvertTo-Json -Depth 10))
+    Test-ShippingFidelityResult `
+        -Path $resultPath `
+        -ExpectedMode missing-root-mutant `
+        -ExpectedProfileId $profile.profileId `
+        -ExpectedProfileSha256 $profileSha256 `
+        -ExpectedUnityVersion '6000.3.16f1'
+
+    & $validatorPath -ProfilePath $profilePath -ProfileOnly
+    foreach ($mutation in @(
+        @{ Path = 'managedStrippingLevel'; Value = 'Disabled' },
+        @{ Path = 'managedStrippingLevel'; Value = 'Medium' },
+        @{ Path = 'includeTestAssemblies'; Value = $true }
+    )) {
+        $mutatedProfile = Copy-JsonValue -Value $profile
+        if ($mutation.Path -ceq 'managedStrippingLevel') {
+            $mutatedProfile.configuration.managedStrippingLevel = $mutation.Value
+        } else {
+            $mutatedProfile.buildOptions.includeTestAssemblies = $mutation.Value
+        }
+        $mutatedPath = Join-Path $fixtureRoot "bad-$($mutation.Path).json"
+        [System.IO.File]::WriteAllText($mutatedPath, ($mutatedProfile | ConvertTo-Json -Depth 10))
+        Assert-Fails "shipping profile $($mutation.Path) mutation" {
+            & $validatorPath -ProfilePath $mutatedPath -ProfileOnly
+        } 'differs'
+    }
+
+    Assert-Fails 'shipping assembly names must be empty' {
+        & $runnerPath `
+            -UnityVersion '6000.3.16f1' `
+            -TestMode shipping `
+            -AssemblyNames 'WallstopStudios.DxMessaging.Tests' `
+            -ArtifactsPath (Join-Path $fixtureRoot 'bad-artifacts') `
+            -RepoRoot $repoRoot `
+            -ProjectPath (Join-Path $fixtureRoot 'bad-project') `
+            -CachePath (Join-Path $fixtureRoot 'bad-cache') `
+            -CanonicalProfilePath $profilePath `
+            -GenerateOnly
+    } 'AssemblyNames must be empty'
+
+    Write-Host 'Shipping-fidelity harness contract tests passed.'
+} finally {
+    if (Test-Path -LiteralPath $fixtureRoot -PathType Container) {
+        Remove-Item -LiteralPath $fixtureRoot -Recurse -Force
+    }
+}

--- a/scripts/unity/__tests__/shipping-fidelity.test.ps1.meta
+++ b/scripts/unity/__tests__/shipping-fidelity.test.ps1.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: eccb4d5e6e5954f1ea9b052495154293
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/scripts/unity/run-ci-tests.ps1
+++ b/scripts/unity/run-ci-tests.ps1
@@ -6,10 +6,11 @@ param(
     [string]$UnityVersion,
 
     [Parameter(Mandatory = $true)]
-    [ValidateSet('editmode', 'playmode', 'standalone')]
+    [ValidateSet('editmode', 'playmode', 'standalone', 'shipping')]
     [string]$TestMode,
 
     [Parameter(Mandatory = $true)]
+    [AllowEmptyString()]
     [string]$AssemblyNames,
 
     [Parameter(Mandatory = $true)]
@@ -790,6 +791,45 @@ function Test-IsReparsePoint {
     return (($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0)
 }
 
+function Remove-OwnedUnityInputEntry {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    $item = Get-Item -LiteralPath $Path -Force -ErrorAction SilentlyContinue
+    if ($null -eq $item) {
+        return
+    }
+    if (($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) {
+        $isDirectoryReparsePoint = (
+            $item.PSIsContainer -or
+            (($item.Attributes -band [System.IO.FileAttributes]::Directory) -ne 0)
+        )
+        if ($isDirectoryReparsePoint) {
+            [System.IO.Directory]::Delete($item.FullName, $false)
+        } else {
+            [System.IO.File]::Delete($item.FullName)
+        }
+        return
+    }
+    if ($item.PSIsContainer) {
+        foreach ($child in @(Get-ChildItem -LiteralPath $item.FullName -Force)) {
+            Remove-OwnedUnityInputEntry -Path $child.FullName
+        }
+        [System.IO.Directory]::Delete($item.FullName, $false)
+        return
+    }
+    [System.IO.File]::Delete($item.FullName)
+}
+
+function Reset-OwnedUnityInputRoot {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    Remove-OwnedUnityInputEntry -Path $Path
+    New-Item -ItemType Directory -Path $Path -Force | Out-Null
+    if (Test-IsReparsePoint -Path $Path) {
+        throw "Owned Unity input root remained a reparse point after reset: '$Path'."
+    }
+}
+
 function Test-PathContainsReparsePointBeforeBoundary {
     param(
         [Parameter(Mandatory = $true)][string]$Path,
@@ -1185,19 +1225,31 @@ function New-ManifestJson {
         [Parameter(Mandatory = $true)][string]$Root,
         [switch]$IncludeComparisons,
         [switch]$IncludeIntegrations,
+        [switch]$ShippingFidelity,
         [string]$RepoRoot
     )
 
     $packagePath = ConvertTo-UnityFileUriPath -Path $Root
-    $dependencies = [ordered]@{
-        'com.unity.test-framework' = $TestFrameworkVersion
-        'com.unity.test-framework.performance' = $PerformanceFrameworkVersion
-        $PackageName = "file:$packagePath"
-    }
-
-    $manifest = [ordered]@{
-        dependencies = $dependencies
-        testables = @($PackageName)
+    if ($ShippingFidelity) {
+        if ($IncludeComparisons -or $IncludeIntegrations) {
+            throw 'A shipping-fidelity project cannot include comparison or integration test packages.'
+        }
+        $dependencies = [ordered]@{
+            $PackageName = "file:$packagePath"
+        }
+        $manifest = [ordered]@{
+            dependencies = $dependencies
+        }
+    } else {
+        $dependencies = [ordered]@{
+            'com.unity.test-framework' = $TestFrameworkVersion
+            'com.unity.test-framework.performance' = $PerformanceFrameworkVersion
+            $PackageName = "file:$packagePath"
+        }
+        $manifest = [ordered]@{
+            dependencies = $dependencies
+            testables = @($PackageName)
+        }
     }
 
     # Comparison legs install the benchmark dependencies and their required Unity
@@ -1365,6 +1417,8 @@ PluginImporter:
 function New-ConfiguratorSource {
     param(
         [string]$Backend = 'IL2CPP',
+        [ValidateSet('Disabled', 'Minimal', 'Low', 'Medium', 'High')]
+        [string]$ManagedStrippingLevel = 'Disabled',
         [string]$CanonicalProfileId = '',
         [string]$CanonicalProfileSha256 = ''
     )
@@ -1374,10 +1428,9 @@ function New-ConfiguratorSource {
     # string) is therefore backtick-escaped (`$). The LIVE code uses the
     # parameterized scripting backend (ScriptingImplementation.<Backend>), the
     # non-deprecated ApiCompatibilityLevel.NET_Standard (which targets .NET Standard
-    # 2.1), CompilationPipeline.codeOptimization = Release, disables managed
-    # stripping so the test assemblies + [Preserve] callback survive a Release Mono
-    # player build, and pins the IL2CPP C++ compiler configuration to Release. This
-    # is an invariant of the generated configurator.
+    # 2.1), CompilationPipeline.codeOptimization = Release, applies the selected
+    # managed stripping level, and pins the IL2CPP C++ compiler configuration to
+    # Release. This is an invariant of the generated configurator.
     @"
 using System;
 using System.IO;
@@ -1412,6 +1465,32 @@ public static class DxmCiTestConfigurator
         public bool stripEngineCode;
     }
 
+    [Serializable]
+    private sealed class BuildOptionsEvidence
+    {
+        public int schemaVersion = 1;
+        public string profileId = "$CanonicalProfileId";
+        public string profileSha256 = "$CanonicalProfileSha256";
+        public string evidenceKind = "buildOptions";
+        public string unityVersion = Application.unityVersion;
+        public BuildOptionsValues values = new BuildOptionsValues();
+    }
+
+    [Serializable]
+    private sealed class BuildOptionsValues
+    {
+        public bool developmentBuild;
+        public bool allowDebugging;
+        public bool deepProfiling;
+        public bool enableAssertions;
+        public bool includeTestAssemblies;
+        public bool autoRunPlayer;
+        public bool connectToHost;
+        public bool connectWithProfiler;
+        public bool cleanBuildCache;
+        public bool detailedBuildReport;
+    }
+
     public static void Apply()
     {
         // Prove Release editor code optimization for every Unity CI leg. Set FIRST
@@ -1427,10 +1506,9 @@ public static class DxmCiTestConfigurator
         // Standard 2.1). The deprecated 2.0 form and the non-existent 2.1 enum
         // member are intentionally NOT used.
         PlayerSettings.SetApiCompatibilityLevel(standalone, ApiCompatibilityLevel.NET_Standard);
-        // Disable managed code stripping so IncludeTestAssemblies + the [Preserve]
-        // standalone TestRunCallback survive a NON-development (Release) Mono player
-        // build; otherwise the stripper can drop the test code from the player.
-        PlayerSettings.SetManagedStrippingLevel(standalone, ManagedStrippingLevel.Disabled);
+        // Apply the reviewed profile's stripping level. Test players select
+        // Disabled so their callbacks survive; shipping fidelity selects High.
+        PlayerSettings.SetManagedStrippingLevel(standalone, ManagedStrippingLevel.$ManagedStrippingLevel);
         // Pin the IL2CPP C++ compiler configuration to Release explicitly. An
         // ephemeral CI project has no committed default for this setting, and
         // measured CI runs showed Debug's faster native compile is outweighed by a
@@ -1442,7 +1520,14 @@ public static class DxmCiTestConfigurator
         if (!string.IsNullOrEmpty("$CanonicalProfileId"))
         {
             PlayerSettings.gcIncremental = true;
-            PlayerSettings.stripEngineCode = true;
+            // Unity 2021.3 can omit UnityEngine.IMGUIModule while recompiling
+            // editor-only package code when engine stripping is already enabled.
+            // Keep it disabled while the shipping builder assembly loads; that
+            // builder applies the reviewed value immediately before BuildPlayer.
+            PlayerSettings.stripEngineCode = !string.Equals(
+                "$CanonicalProfileId",
+                "shipping-fidelity-il2cpp-player-v1",
+                StringComparison.Ordinal);
 #if UNITY_2022_1_OR_NEWER
             PlayerSettings.SetIl2CppCodeGeneration(standalone, Il2CppCodeGeneration.OptimizeSpeed);
 #else
@@ -1509,6 +1594,31 @@ public static class DxmCiTestConfigurator
         WriteJson(profilePath, evidence);
     }
 
+    internal static void WriteBuildOptionsEvidence(string profilePath, BuildOptions options)
+    {
+        if (string.IsNullOrEmpty(profilePath))
+        {
+            return;
+        }
+        BuildOptionsEvidence evidence = new BuildOptionsEvidence();
+        evidence.values.developmentBuild = Has(options, BuildOptions.Development);
+        evidence.values.allowDebugging = Has(options, BuildOptions.AllowDebugging);
+        evidence.values.deepProfiling = Has(options, BuildOptions.EnableDeepProfilingSupport);
+        evidence.values.enableAssertions = Has(options, BuildOptions.ForceEnableAssertions);
+        evidence.values.includeTestAssemblies = Has(options, BuildOptions.IncludeTestAssemblies);
+        evidence.values.autoRunPlayer = Has(options, BuildOptions.AutoRunPlayer);
+        evidence.values.connectToHost = Has(options, BuildOptions.ConnectToHost);
+        evidence.values.connectWithProfiler = Has(options, BuildOptions.ConnectWithProfiler);
+        evidence.values.cleanBuildCache = Has(options, BuildOptions.CleanBuildCache);
+        evidence.values.detailedBuildReport = Has(options, BuildOptions.DetailedBuildReport);
+        WriteJson(profilePath, evidence);
+    }
+
+    private static bool Has(BuildOptions options, BuildOptions flag)
+    {
+        return (options & flag) == flag;
+    }
+
     private static void WriteJson(string path, object value)
     {
         string dir = Path.GetDirectoryName(path);
@@ -1540,8 +1650,7 @@ public static class DxmCiTestConfigurator
 function New-StandaloneBuildModifierSource {
     param(
         [bool]$DevelopmentBuild = $false,
-        [string]$CanonicalProfileId = '',
-        [string]$CanonicalProfileSha256 = ''
+        [string]$CanonicalProfileId = ''
     )
 
     # The Development BuildOptions flag is opt-in only. Unity CI defaults to a true
@@ -1581,32 +1690,6 @@ using UnityEngine.TestTools;
 // the build) to exit the editor cleanly.
 public sealed class DxmCiStandaloneBuildModifier : ITestPlayerBuildModifier, IPostBuildCleanup, IPostprocessBuildWithReport
 {
-    [Serializable]
-    private sealed class BuildOptionsEvidence
-    {
-        public int schemaVersion = 1;
-        public string profileId = "$CanonicalProfileId";
-        public string profileSha256 = "$CanonicalProfileSha256";
-        public string evidenceKind = "buildOptions";
-        public string unityVersion = Application.unityVersion;
-        public BuildOptionsValues values = new BuildOptionsValues();
-    }
-
-    [Serializable]
-    private sealed class BuildOptionsValues
-    {
-        public bool developmentBuild;
-        public bool allowDebugging;
-        public bool deepProfiling;
-        public bool enableAssertions;
-        public bool includeTestAssemblies;
-        public bool autoRunPlayer;
-        public bool connectToHost;
-        public bool connectWithProfiler;
-        public bool cleanBuildCache;
-        public bool detailedBuildReport;
-    }
-
     private static bool s_Armed;
     private static readonly EditorApplication.CallbackFunction s_Exit = () => EditorApplication.Exit(0);
     public int callbackOrder => 0;
@@ -1645,38 +1728,9 @@ $developmentOption
     {
         DxmCiTestConfigurator.WriteConfigurationEvidence(
             Environment.GetEnvironmentVariable("DXM_POSTBUILD_CONFIG_PROFILE_PATH"));
-        WriteProfileEvidence(report.summary.options);
-    }
-
-    private static void WriteProfileEvidence(BuildOptions options)
-    {
-        string path = Environment.GetEnvironmentVariable("DXM_BUILD_OPTIONS_PROFILE_PATH");
-        if (string.IsNullOrEmpty(path))
-        {
-            return;
-        }
-        BuildOptionsEvidence evidence = new BuildOptionsEvidence();
-        evidence.values.developmentBuild = Has(options, BuildOptions.Development);
-        evidence.values.allowDebugging = Has(options, BuildOptions.AllowDebugging);
-        evidence.values.deepProfiling = Has(options, BuildOptions.EnableDeepProfilingSupport);
-        evidence.values.enableAssertions = Has(options, BuildOptions.ForceEnableAssertions);
-        evidence.values.includeTestAssemblies = Has(options, BuildOptions.IncludeTestAssemblies);
-        evidence.values.autoRunPlayer = Has(options, BuildOptions.AutoRunPlayer);
-        evidence.values.connectToHost = Has(options, BuildOptions.ConnectToHost);
-        evidence.values.connectWithProfiler = Has(options, BuildOptions.ConnectWithProfiler);
-        evidence.values.cleanBuildCache = Has(options, BuildOptions.CleanBuildCache);
-        evidence.values.detailedBuildReport = Has(options, BuildOptions.DetailedBuildReport);
-        string dir = Path.GetDirectoryName(path);
-        if (!string.IsNullOrEmpty(dir))
-        {
-            Directory.CreateDirectory(dir);
-        }
-        File.WriteAllText(path, JsonUtility.ToJson(evidence, true));
-    }
-
-    private static bool Has(BuildOptions options, BuildOptions flag)
-    {
-        return (options & flag) == flag;
+        DxmCiTestConfigurator.WriteBuildOptionsEvidence(
+            Environment.GetEnvironmentVariable("DXM_BUILD_OPTIONS_PROFILE_PATH"),
+            report.summary.options);
     }
 
     public void Cleanup()
@@ -1892,6 +1946,848 @@ function New-StandaloneTestCallbackAsmdef {
 '@
 }
 
+# SHIPPING ONLY. This is a real Assembly-CSharp consumer with no NUnit or Unity
+# Test Framework references. It proves the package survives High managed
+# stripping and that generated AOT roots support typed and untyped dispatch for
+# public, private nested, class, and readonly-struct message shapes. A private
+# manual message intentionally has no generated bridge and supplies the RED
+# missing-root control from the same built binary.
+function New-ShippingFidelityPlayerSource {
+    param(
+        [Parameter(Mandatory = $true)][string]$CanonicalProfileId,
+        [Parameter(Mandatory = $true)][string]$CanonicalProfileSha256
+    )
+
+    @"
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using DxMessaging.Core;
+using DxMessaging.Core.Attributes;
+using DxMessaging.Core.MessageBus;
+using DxMessaging.Core.Messages;
+using UnityEngine;
+
+[DxUntargetedMessage]
+public sealed partial class DxmShippingPublicUntargetedClass
+{
+}
+
+[DxUntargetedMessage]
+public readonly partial struct DxmShippingPublicUntargetedStruct
+{
+}
+
+[DxTargetedMessage]
+public sealed partial class DxmShippingPublicTargetedClass
+{
+}
+
+[DxTargetedMessage]
+public readonly partial struct DxmShippingPublicTargetedStruct
+{
+}
+
+[DxBroadcastMessage]
+public sealed partial class DxmShippingPublicBroadcastClass
+{
+}
+
+[DxBroadcastMessage]
+public readonly partial struct DxmShippingPublicBroadcastStruct
+{
+}
+
+public sealed partial class DxmShippingFidelityPlayer
+{
+    private const string PositiveMode = "positive";
+    private const string MissingRootMode = "missing-root-mutant";
+    private const string MissingRootMessageFragment = "no rooted dispatch bridge was registered";
+
+    [DxUntargetedMessage]
+    private readonly partial struct NestedUntargetedStruct
+    {
+    }
+
+    [DxUntargetedMessage]
+    private sealed partial class NestedUntargetedClass
+    {
+    }
+
+    [DxTargetedMessage]
+    private sealed partial class NestedTargetedClass
+    {
+    }
+
+    [DxTargetedMessage]
+    private readonly partial struct NestedTargetedStruct
+    {
+    }
+
+    [DxBroadcastMessage]
+    private readonly partial struct NestedBroadcastStruct
+    {
+    }
+
+    [DxBroadcastMessage]
+    private sealed partial class NestedBroadcastClass
+    {
+    }
+
+    [DxUntargetedMessage]
+    public sealed partial class PublicNestedUntargetedClass
+    {
+    }
+
+    [DxUntargetedMessage]
+    public readonly partial struct PublicNestedUntargetedStruct
+    {
+    }
+
+    [DxTargetedMessage]
+    public sealed partial class PublicNestedTargetedClass
+    {
+    }
+
+    [DxTargetedMessage]
+    public readonly partial struct PublicNestedTargetedStruct
+    {
+    }
+
+    [DxBroadcastMessage]
+    public sealed partial class PublicNestedBroadcastClass
+    {
+    }
+
+    [DxBroadcastMessage]
+    public readonly partial struct PublicNestedBroadcastStruct
+    {
+    }
+
+    private sealed class MissingRootUntargetedMessage : IUntargetedMessage
+    {
+        public Type MessageType => typeof(MissingRootUntargetedMessage);
+    }
+
+    [Serializable]
+    private sealed class ShippingResult
+    {
+        public int schemaVersion = 1;
+        public string profileId = "$CanonicalProfileId";
+        public string profileSha256 = "$CanonicalProfileSha256";
+        public string unityVersion = Application.unityVersion;
+        public string mode = string.Empty;
+        public bool success;
+        public bool unityIncludeTests;
+        public int rootedUntypedProbeCount;
+        public int typedDispatchCount;
+        public int untypedDispatchCount;
+        public string[] rootedUntypedShapes = new string[0];
+        public string[] typedDispatchShapes = new string[0];
+        public string[] untypedDispatchShapes = new string[0];
+        public bool missingRootFailureObserved;
+        public string failureType = string.Empty;
+        public string failureMessage = string.Empty;
+        public string[] loadedAssemblies = new string[0];
+    }
+
+    [Serializable]
+    private sealed class RuntimeEvidence
+    {
+        public int schemaVersion = 1;
+        public string profileId = "$CanonicalProfileId";
+        public string profileSha256 = "$CanonicalProfileSha256";
+        public string evidenceKind = "runtime";
+        public string unityVersion = Application.unityVersion;
+        public RuntimeValues values = new RuntimeValues();
+    }
+
+    [Serializable]
+    private sealed class RuntimeValues
+    {
+        public bool debugBuild;
+    }
+
+    private static int s_TypedDispatchCount;
+    private static int s_UntypedDispatchCount;
+    private static bool s_UntypedPhase;
+    private static readonly List<string> TypedDispatchShapes = new List<string>(18);
+    private static readonly List<string> UntypedDispatchShapes = new List<string>(18);
+
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
+    private static void Run()
+    {
+        string resultPath = ResolveArgument("-dxmShippingResult");
+        string runtimeProfilePath = ResolveArgument("-dxmRuntimeProfile");
+        string mode = ResolveArgument("-dxmShippingMode") ?? PositiveMode;
+        if (string.IsNullOrEmpty(resultPath) || string.IsNullOrEmpty(runtimeProfilePath))
+        {
+            Debug.LogError("DXM shipping player requires result and runtime-profile paths.");
+            Application.Quit(2);
+            return;
+        }
+
+        ShippingResult result = new ShippingResult { mode = mode };
+        try
+        {
+#if UNITY_INCLUDE_TESTS
+            result.unityIncludeTests = true;
+#endif
+            if (result.unityIncludeTests)
+            {
+                throw new InvalidOperationException(
+                    "Shipping player compiled with the forbidden UNITY_INCLUDE_TESTS define.");
+            }
+            result.loadedAssemblies = GetLoadedAssemblyNames();
+            AssertNoTestAssemblies(result.loadedAssemblies);
+            if (string.Equals(mode, PositiveMode, StringComparison.Ordinal))
+            {
+                RunPositiveSmoke(result);
+            }
+            else if (string.Equals(mode, MissingRootMode, StringComparison.Ordinal))
+            {
+                RunMissingRootMutant(result);
+            }
+            else
+            {
+                throw new InvalidOperationException("Unknown shipping-fidelity mode: " + mode);
+            }
+            result.success = true;
+        }
+        catch (Exception ex)
+        {
+            result.success = false;
+            result.failureType = ex.GetType().FullName;
+            result.failureMessage = ex.Message;
+            Debug.LogException(ex);
+        }
+
+        try
+        {
+            WriteRuntimeEvidence(runtimeProfilePath);
+            WriteJson(resultPath, result);
+        }
+        catch (Exception ex)
+        {
+            Debug.LogException(ex);
+            Application.Quit(3);
+            return;
+        }
+
+        Application.Quit(result.success ? 0 : 1);
+    }
+
+    private static void RunPositiveSmoke(ShippingResult result)
+    {
+        MessageBus bus = new MessageBus();
+        InstanceId route = new InstanceId(0x5348_4950);
+
+        DxmShippingPublicUntargetedClass publicUntargetedClass = new DxmShippingPublicUntargetedClass();
+        DxmShippingPublicUntargetedStruct publicUntargetedStruct = default;
+        DxmShippingPublicTargetedClass publicTargetedClass = new DxmShippingPublicTargetedClass();
+        DxmShippingPublicTargetedStruct publicTargetedStruct = default;
+        DxmShippingPublicBroadcastClass publicBroadcastClass = new DxmShippingPublicBroadcastClass();
+        DxmShippingPublicBroadcastStruct publicBroadcastStruct = default;
+        NestedUntargetedClass nestedUntargetedClass = new NestedUntargetedClass();
+        NestedUntargetedStruct nestedUntargetedStruct = default;
+        NestedTargetedClass nestedTargetedClass = new NestedTargetedClass();
+        NestedTargetedStruct nestedTargetedStruct = default;
+        NestedBroadcastClass nestedBroadcastClass = new NestedBroadcastClass();
+        NestedBroadcastStruct nestedBroadcastStruct = default;
+        PublicNestedUntargetedClass publicNestedUntargetedClass = new PublicNestedUntargetedClass();
+        PublicNestedUntargetedStruct publicNestedUntargetedStruct = default;
+        PublicNestedTargetedClass publicNestedTargetedClass = new PublicNestedTargetedClass();
+        PublicNestedTargetedStruct publicNestedTargetedStruct = default;
+        PublicNestedBroadcastClass publicNestedBroadcastClass = new PublicNestedBroadcastClass();
+        PublicNestedBroadcastStruct publicNestedBroadcastStruct = default;
+
+        // First dispatch each shape only through its interface. No typed register
+        // or emit has had a chance to seed a bridge, so success proves the
+        // generated RuntimeInitializeOnLoadMethod root survived stripping.
+        long emissionIdBeforeRootProbe = bus.EmissionId;
+        List<string> rootedUntypedShapes = new List<string>(18);
+        ProbeUntargetedRoot(bus, publicUntargetedClass, rootedUntypedShapes);
+        ProbeUntargetedRoot(bus, publicUntargetedStruct, rootedUntypedShapes);
+        ProbeTargetedRoot(bus, route, publicTargetedClass, rootedUntypedShapes);
+        ProbeTargetedRoot(bus, route, publicTargetedStruct, rootedUntypedShapes);
+        ProbeBroadcastRoot(bus, route, publicBroadcastClass, rootedUntypedShapes);
+        ProbeBroadcastRoot(bus, route, publicBroadcastStruct, rootedUntypedShapes);
+        ProbeUntargetedRoot(bus, nestedUntargetedClass, rootedUntypedShapes);
+        ProbeUntargetedRoot(bus, nestedUntargetedStruct, rootedUntypedShapes);
+        ProbeTargetedRoot(bus, route, nestedTargetedClass, rootedUntypedShapes);
+        ProbeTargetedRoot(bus, route, nestedTargetedStruct, rootedUntypedShapes);
+        ProbeBroadcastRoot(bus, route, nestedBroadcastClass, rootedUntypedShapes);
+        ProbeBroadcastRoot(bus, route, nestedBroadcastStruct, rootedUntypedShapes);
+        ProbeUntargetedRoot(bus, publicNestedUntargetedClass, rootedUntypedShapes);
+        ProbeUntargetedRoot(bus, publicNestedUntargetedStruct, rootedUntypedShapes);
+        ProbeTargetedRoot(bus, route, publicNestedTargetedClass, rootedUntypedShapes);
+        ProbeTargetedRoot(bus, route, publicNestedTargetedStruct, rootedUntypedShapes);
+        ProbeBroadcastRoot(bus, route, publicNestedBroadcastClass, rootedUntypedShapes);
+        ProbeBroadcastRoot(bus, route, publicNestedBroadcastStruct, rootedUntypedShapes);
+        long rootedUntypedProbeCount = bus.EmissionId - emissionIdBeforeRootProbe;
+        if (rootedUntypedProbeCount != 18 || rootedUntypedShapes.Count != 18)
+        {
+            throw new InvalidOperationException(
+                "Shipping root probe did not execute all 18 first-untyped dispatches.");
+        }
+        result.rootedUntypedProbeCount = (int)rootedUntypedProbeCount;
+        result.rootedUntypedShapes = rootedUntypedShapes.ToArray();
+
+        MessageHandler handler = new MessageHandler(route, bus) { active = true };
+        MessageRegistrationToken token = MessageRegistrationToken.Create(handler, bus);
+        try
+        {
+            _ = token.RegisterUntargeted<DxmShippingPublicUntargetedClass>(HandlePublicUntargetedClass);
+            _ = token.RegisterUntargeted<DxmShippingPublicUntargetedStruct>(HandlePublicUntargetedStruct);
+            _ = token.RegisterTargeted<DxmShippingPublicTargetedClass>(route, HandlePublicTargetedClass);
+            _ = token.RegisterTargeted<DxmShippingPublicTargetedStruct>(route, HandlePublicTargetedStruct);
+            _ = token.RegisterBroadcast<DxmShippingPublicBroadcastClass>(route, HandlePublicBroadcastClass);
+            _ = token.RegisterBroadcast<DxmShippingPublicBroadcastStruct>(route, HandlePublicBroadcastStruct);
+            _ = token.RegisterUntargeted<NestedUntargetedClass>(HandleNestedUntargetedClass);
+            _ = token.RegisterUntargeted<NestedUntargetedStruct>(HandleNestedUntargetedStruct);
+            _ = token.RegisterTargeted<NestedTargetedClass>(route, HandleNestedTargetedClass);
+            _ = token.RegisterTargeted<NestedTargetedStruct>(route, HandleNestedTargetedStruct);
+            _ = token.RegisterBroadcast<NestedBroadcastClass>(route, HandleNestedBroadcastClass);
+            _ = token.RegisterBroadcast<NestedBroadcastStruct>(route, HandleNestedBroadcastStruct);
+            _ = token.RegisterUntargeted<PublicNestedUntargetedClass>(HandlePublicNestedUntargetedClass);
+            _ = token.RegisterUntargeted<PublicNestedUntargetedStruct>(HandlePublicNestedUntargetedStruct);
+            _ = token.RegisterTargeted<PublicNestedTargetedClass>(route, HandlePublicNestedTargetedClass);
+            _ = token.RegisterTargeted<PublicNestedTargetedStruct>(route, HandlePublicNestedTargetedStruct);
+            _ = token.RegisterBroadcast<PublicNestedBroadcastClass>(route, HandlePublicNestedBroadcastClass);
+            _ = token.RegisterBroadcast<PublicNestedBroadcastStruct>(route, HandlePublicNestedBroadcastStruct);
+            token.Enable();
+
+            s_TypedDispatchCount = 0;
+            s_UntypedDispatchCount = 0;
+            TypedDispatchShapes.Clear();
+            UntypedDispatchShapes.Clear();
+            s_UntypedPhase = false;
+            bus.UntargetedBroadcast(ref publicUntargetedClass);
+            bus.UntargetedBroadcast(ref publicUntargetedStruct);
+            bus.TargetedBroadcast(ref route, ref publicTargetedClass);
+            bus.TargetedBroadcast(ref route, ref publicTargetedStruct);
+            bus.SourcedBroadcast(ref route, ref publicBroadcastClass);
+            bus.SourcedBroadcast(ref route, ref publicBroadcastStruct);
+            bus.UntargetedBroadcast(ref nestedUntargetedClass);
+            bus.UntargetedBroadcast(ref nestedUntargetedStruct);
+            bus.TargetedBroadcast(ref route, ref nestedTargetedClass);
+            bus.TargetedBroadcast(ref route, ref nestedTargetedStruct);
+            bus.SourcedBroadcast(ref route, ref nestedBroadcastClass);
+            bus.SourcedBroadcast(ref route, ref nestedBroadcastStruct);
+            bus.UntargetedBroadcast(ref publicNestedUntargetedClass);
+            bus.UntargetedBroadcast(ref publicNestedUntargetedStruct);
+            bus.TargetedBroadcast(ref route, ref publicNestedTargetedClass);
+            bus.TargetedBroadcast(ref route, ref publicNestedTargetedStruct);
+            bus.SourcedBroadcast(ref route, ref publicNestedBroadcastClass);
+            bus.SourcedBroadcast(ref route, ref publicNestedBroadcastStruct);
+
+            s_UntypedPhase = true;
+            bus.UntypedUntargetedBroadcast(publicUntargetedClass);
+            bus.UntypedUntargetedBroadcast(publicUntargetedStruct);
+            bus.UntypedTargetedBroadcast(route, publicTargetedClass);
+            bus.UntypedTargetedBroadcast(route, publicTargetedStruct);
+            bus.UntypedSourcedBroadcast(route, publicBroadcastClass);
+            bus.UntypedSourcedBroadcast(route, publicBroadcastStruct);
+            bus.UntypedUntargetedBroadcast(nestedUntargetedClass);
+            bus.UntypedUntargetedBroadcast(nestedUntargetedStruct);
+            bus.UntypedTargetedBroadcast(route, nestedTargetedClass);
+            bus.UntypedTargetedBroadcast(route, nestedTargetedStruct);
+            bus.UntypedSourcedBroadcast(route, nestedBroadcastClass);
+            bus.UntypedSourcedBroadcast(route, nestedBroadcastStruct);
+            bus.UntypedUntargetedBroadcast(publicNestedUntargetedClass);
+            bus.UntypedUntargetedBroadcast(publicNestedUntargetedStruct);
+            bus.UntypedTargetedBroadcast(route, publicNestedTargetedClass);
+            bus.UntypedTargetedBroadcast(route, publicNestedTargetedStruct);
+            bus.UntypedSourcedBroadcast(route, publicNestedBroadcastClass);
+            bus.UntypedSourcedBroadcast(route, publicNestedBroadcastStruct);
+
+            result.typedDispatchCount = s_TypedDispatchCount;
+            result.untypedDispatchCount = s_UntypedDispatchCount;
+            result.typedDispatchShapes = TypedDispatchShapes.ToArray();
+            result.untypedDispatchShapes = UntypedDispatchShapes.ToArray();
+            if (s_TypedDispatchCount != 18 || s_UntypedDispatchCount != 18)
+            {
+                throw new InvalidOperationException(
+                    string.Format(
+                        "Shipping dispatch counts differ (typed={0}, untyped={1}).",
+                        s_TypedDispatchCount,
+                        s_UntypedDispatchCount));
+            }
+        }
+        finally
+        {
+            token.UnregisterAll();
+            token.Dispose();
+            handler.active = false;
+        }
+    }
+
+    private static void ProbeUntargetedRoot(
+        MessageBus bus,
+        IUntargetedMessage message,
+        List<string> observedShapes)
+    {
+        bus.UntypedUntargetedBroadcast(message);
+        observedShapes.Add(message.MessageType.Name);
+    }
+
+    private static void ProbeTargetedRoot(
+        MessageBus bus,
+        InstanceId target,
+        ITargetedMessage message,
+        List<string> observedShapes)
+    {
+        bus.UntypedTargetedBroadcast(target, message);
+        observedShapes.Add(message.MessageType.Name);
+    }
+
+    private static void ProbeBroadcastRoot(
+        MessageBus bus,
+        InstanceId source,
+        IBroadcastMessage message,
+        List<string> observedShapes)
+    {
+        bus.UntypedSourcedBroadcast(source, message);
+        observedShapes.Add(message.MessageType.Name);
+    }
+
+    private static void RunMissingRootMutant(ShippingResult result)
+    {
+        MessageBus bus = new MessageBus();
+        try
+        {
+            bus.UntypedUntargetedBroadcast(new MissingRootUntargetedMessage());
+        }
+        catch (InvalidOperationException ex)
+        {
+            if (ex.Message.IndexOf(MissingRootMessageFragment, StringComparison.Ordinal) < 0)
+            {
+                throw new InvalidOperationException(
+                    "The missing-root mutant threw the wrong InvalidOperationException.",
+                    ex);
+            }
+            result.missingRootFailureObserved = true;
+            return;
+        }
+        throw new InvalidOperationException(
+            "The missing-root mutant dispatched without the required AOT bridge failure.");
+    }
+
+    private static void HandlePublicUntargetedClass(in DxmShippingPublicUntargetedClass message) => Count("DxmShippingPublicUntargetedClass");
+    private static void HandlePublicUntargetedStruct(in DxmShippingPublicUntargetedStruct message) => Count("DxmShippingPublicUntargetedStruct");
+    private static void HandlePublicTargetedClass(in DxmShippingPublicTargetedClass message) => Count("DxmShippingPublicTargetedClass");
+    private static void HandlePublicTargetedStruct(in DxmShippingPublicTargetedStruct message) => Count("DxmShippingPublicTargetedStruct");
+    private static void HandlePublicBroadcastClass(in DxmShippingPublicBroadcastClass message) => Count("DxmShippingPublicBroadcastClass");
+    private static void HandlePublicBroadcastStruct(in DxmShippingPublicBroadcastStruct message) => Count("DxmShippingPublicBroadcastStruct");
+    private static void HandleNestedUntargetedClass(in NestedUntargetedClass message) => Count("NestedUntargetedClass");
+    private static void HandleNestedUntargetedStruct(in NestedUntargetedStruct message) => Count("NestedUntargetedStruct");
+    private static void HandleNestedTargetedClass(in NestedTargetedClass message) => Count("NestedTargetedClass");
+    private static void HandleNestedTargetedStruct(in NestedTargetedStruct message) => Count("NestedTargetedStruct");
+    private static void HandleNestedBroadcastClass(in NestedBroadcastClass message) => Count("NestedBroadcastClass");
+    private static void HandleNestedBroadcastStruct(in NestedBroadcastStruct message) => Count("NestedBroadcastStruct");
+    private static void HandlePublicNestedUntargetedClass(in PublicNestedUntargetedClass message) => Count("PublicNestedUntargetedClass");
+    private static void HandlePublicNestedUntargetedStruct(in PublicNestedUntargetedStruct message) => Count("PublicNestedUntargetedStruct");
+    private static void HandlePublicNestedTargetedClass(in PublicNestedTargetedClass message) => Count("PublicNestedTargetedClass");
+    private static void HandlePublicNestedTargetedStruct(in PublicNestedTargetedStruct message) => Count("PublicNestedTargetedStruct");
+    private static void HandlePublicNestedBroadcastClass(in PublicNestedBroadcastClass message) => Count("PublicNestedBroadcastClass");
+    private static void HandlePublicNestedBroadcastStruct(in PublicNestedBroadcastStruct message) => Count("PublicNestedBroadcastStruct");
+
+    private static void Count(string shape)
+    {
+        if (s_UntypedPhase)
+        {
+            s_UntypedDispatchCount++;
+            UntypedDispatchShapes.Add(shape);
+        }
+        else
+        {
+            s_TypedDispatchCount++;
+            TypedDispatchShapes.Add(shape);
+        }
+    }
+
+    private static string[] GetLoadedAssemblyNames()
+    {
+        System.Reflection.Assembly[] assemblies = AppDomain.CurrentDomain.GetAssemblies();
+        List<string> names = new List<string>(assemblies.Length);
+        for (int i = 0; i < assemblies.Length; i++)
+        {
+            names.Add(assemblies[i].GetName().Name);
+        }
+        string[] result = names.ToArray();
+        Array.Sort(result, StringComparer.Ordinal);
+        return result;
+    }
+
+    private static void AssertNoTestAssemblies(string[] assemblyNames)
+    {
+        for (int i = 0; i < assemblyNames.Length; i++)
+        {
+            string name = assemblyNames[i];
+            if (
+                string.Equals(name, "nunit.framework", StringComparison.OrdinalIgnoreCase)
+                || name.IndexOf("TestRunner", StringComparison.OrdinalIgnoreCase) >= 0
+                || name.IndexOf("PerformanceTesting", StringComparison.OrdinalIgnoreCase) >= 0
+                || name.EndsWith(".Tests", StringComparison.OrdinalIgnoreCase)
+                || name.IndexOf(".Tests.", StringComparison.OrdinalIgnoreCase) >= 0
+                || name.StartsWith("DxmCiStandalone", StringComparison.Ordinal)
+            )
+            {
+                throw new InvalidOperationException(
+                    "Shipping player loaded forbidden test assembly: " + name);
+            }
+        }
+    }
+
+    private static string ResolveArgument(string name)
+    {
+        string[] args = Environment.GetCommandLineArgs();
+        for (int i = 0; i < args.Length - 1; i++)
+        {
+            if (string.Equals(args[i], name, StringComparison.Ordinal))
+            {
+                return args[i + 1];
+            }
+        }
+        return null;
+    }
+
+    private static void WriteRuntimeEvidence(string path)
+    {
+        RuntimeEvidence evidence = new RuntimeEvidence();
+        evidence.values.debugBuild = Debug.isDebugBuild;
+        WriteJson(path, evidence);
+    }
+
+    private static void WriteJson(string path, ShippingResult value)
+    {
+        StringBuilder json = new StringBuilder(2048);
+        json.Append('{');
+        AppendProperty(json, "schemaVersion", value.schemaVersion.ToString(CultureInfo.InvariantCulture), false);
+        AppendProperty(json, "profileId", QuoteJson(value.profileId), true);
+        AppendProperty(json, "profileSha256", QuoteJson(value.profileSha256), true);
+        AppendProperty(json, "unityVersion", QuoteJson(value.unityVersion), true);
+        AppendProperty(json, "mode", QuoteJson(value.mode), true);
+        AppendProperty(json, "success", JsonBoolean(value.success), true);
+        AppendProperty(json, "unityIncludeTests", JsonBoolean(value.unityIncludeTests), true);
+        AppendProperty(json, "rootedUntypedProbeCount", value.rootedUntypedProbeCount.ToString(CultureInfo.InvariantCulture), true);
+        AppendProperty(json, "typedDispatchCount", value.typedDispatchCount.ToString(CultureInfo.InvariantCulture), true);
+        AppendProperty(json, "untypedDispatchCount", value.untypedDispatchCount.ToString(CultureInfo.InvariantCulture), true);
+        AppendProperty(json, "rootedUntypedShapes", SerializeStringArray(value.rootedUntypedShapes), true);
+        AppendProperty(json, "typedDispatchShapes", SerializeStringArray(value.typedDispatchShapes), true);
+        AppendProperty(json, "untypedDispatchShapes", SerializeStringArray(value.untypedDispatchShapes), true);
+        AppendProperty(json, "missingRootFailureObserved", JsonBoolean(value.missingRootFailureObserved), true);
+        AppendProperty(json, "failureType", QuoteJson(value.failureType), true);
+        AppendProperty(json, "failureMessage", QuoteJson(value.failureMessage), true);
+        AppendProperty(json, "loadedAssemblies", SerializeStringArray(value.loadedAssemblies), true);
+        json.Append('}');
+        WriteJsonText(path, json.ToString());
+    }
+
+    private static void WriteJson(string path, RuntimeEvidence value)
+    {
+        StringBuilder json = new StringBuilder(384);
+        json.Append('{');
+        AppendProperty(json, "schemaVersion", value.schemaVersion.ToString(CultureInfo.InvariantCulture), false);
+        AppendProperty(json, "profileId", QuoteJson(value.profileId), true);
+        AppendProperty(json, "profileSha256", QuoteJson(value.profileSha256), true);
+        AppendProperty(json, "evidenceKind", QuoteJson(value.evidenceKind), true);
+        AppendProperty(json, "unityVersion", QuoteJson(value.unityVersion), true);
+        json.Append(',').Append(QuoteJson("values")).Append(':').Append('{');
+        AppendProperty(json, "debugBuild", JsonBoolean(value.values.debugBuild), false);
+        json.Append('}').Append('}');
+        WriteJsonText(path, json.ToString());
+    }
+
+    private static void AppendProperty(
+        StringBuilder json,
+        string name,
+        string encodedValue,
+        bool prependComma)
+    {
+        if (prependComma)
+        {
+            json.Append(',');
+        }
+        json.Append(QuoteJson(name)).Append(':').Append(encodedValue);
+    }
+
+    private static string SerializeStringArray(string[] values)
+    {
+        StringBuilder json = new StringBuilder();
+        json.Append('[');
+        for (int i = 0; i < values.Length; i++)
+        {
+            if (i > 0)
+            {
+                json.Append(',');
+            }
+            json.Append(QuoteJson(values[i]));
+        }
+        json.Append(']');
+        return json.ToString();
+    }
+
+    private static string QuoteJson(string value)
+    {
+        if (value == null)
+        {
+            return "null";
+        }
+        StringBuilder json = new StringBuilder(value.Length + 2);
+        json.Append('"');
+        for (int i = 0; i < value.Length; i++)
+        {
+            char character = value[i];
+            switch (character)
+            {
+                case '"': json.Append("\\\""); break;
+                case '\\': json.Append("\\\\"); break;
+                case '\b': json.Append("\\b"); break;
+                case '\f': json.Append("\\f"); break;
+                case '\n': json.Append("\\n"); break;
+                case '\r': json.Append("\\r"); break;
+                case '\t': json.Append("\\t"); break;
+                default:
+                    if (character < 0x20)
+                    {
+                        json.Append("\\u").Append(
+                            ((int)character).ToString("x4", CultureInfo.InvariantCulture));
+                    }
+                    else
+                    {
+                        json.Append(character);
+                    }
+                    break;
+            }
+        }
+        return json.Append('"').ToString();
+    }
+
+    private static string JsonBoolean(bool value)
+    {
+        return value ? "true" : "false";
+    }
+
+    private static void WriteJsonText(string path, string json)
+    {
+        string directory = Path.GetDirectoryName(path);
+        if (!string.IsNullOrEmpty(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+        File.WriteAllText(path, json);
+    }
+}
+"@
+}
+
+# SHIPPING ONLY. Builds the Assembly-CSharp smoke consumer directly through
+# BuildPipeline, without -runTests, IncludeTestAssemblies, TestRunCallback, or
+# PlayerConnection. It records the exact final BuildOptions and the player
+# assembly inventory used by Unity before writing a fresh completion marker.
+function New-ShippingFidelityBuilderSource {
+    param(
+        [Parameter(Mandatory = $true)][string]$CanonicalProfileId,
+        [Parameter(Mandatory = $true)][string]$CanonicalProfileSha256
+    )
+
+    @"
+using System;
+using System.Collections.Generic;
+using System.IO;
+using UnityEditor;
+using UnityEditor.Build;
+using UnityEditor.Build.Reporting;
+using UnityEditor.Compilation;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+public static class DxmShippingFidelityBuilder
+{
+    [Serializable]
+    private sealed class AssemblyEvidence
+    {
+        public int schemaVersion = 1;
+        public string profileId = "$CanonicalProfileId";
+        public string profileSha256 = "$CanonicalProfileSha256";
+        public string unityVersion = Application.unityVersion;
+        public bool includeTestAssemblies;
+        public string[] playerAssemblies = new string[0];
+    }
+
+    public static void Build()
+    {
+        string outputPath = RequireEnvironmentVariable("DXM_PLAYER_BUILD_PATH");
+        string markerPath = RequireEnvironmentVariable("DXM_SHIPPING_BUILD_MARKER_PATH");
+        string scenePath = "Assets/DxmShippingFidelity.unity";
+        string outputDirectory = Path.GetDirectoryName(outputPath);
+        if (!string.IsNullOrEmpty(outputDirectory))
+        {
+            Directory.CreateDirectory(outputDirectory);
+        }
+
+        Scene scene = EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+        if (!EditorSceneManager.SaveScene(scene, scenePath))
+        {
+            throw new InvalidOperationException("Could not save the shipping-fidelity scene.");
+        }
+
+        UnityEditor.Compilation.Assembly[] playerAssemblies =
+            CompilationPipeline.GetAssemblies(AssembliesType.Player);
+        string[] assemblyNames = GetAssemblyNames(playerAssemblies);
+        AssertNoTestAssemblies(assemblyNames);
+
+        ApplyShippingProfile();
+
+        BuildPlayerOptions options = new BuildPlayerOptions
+        {
+            scenes = new[] { scenePath },
+            locationPathName = outputPath,
+            target = BuildTarget.StandaloneWindows64,
+            options = BuildOptions.CleanBuildCache | BuildOptions.DetailedBuildReport
+        };
+        options.options &= ~BuildOptions.Development;
+        options.options &= ~BuildOptions.AllowDebugging;
+        options.options &= ~BuildOptions.EnableDeepProfilingSupport;
+        options.options &= ~BuildOptions.ForceEnableAssertions;
+        options.options &= ~BuildOptions.IncludeTestAssemblies;
+        options.options &= ~BuildOptions.AutoRunPlayer;
+        options.options &= ~BuildOptions.ConnectToHost;
+        options.options &= ~BuildOptions.ConnectWithProfiler;
+
+        DxmCiTestConfigurator.WriteConfigurationEvidence(
+            Environment.GetEnvironmentVariable("DXM_PREBUILD_CONFIG_PROFILE_PATH"));
+        BuildReport report = BuildPipeline.BuildPlayer(options);
+        DxmCiTestConfigurator.WriteConfigurationEvidence(
+            Environment.GetEnvironmentVariable("DXM_POSTBUILD_CONFIG_PROFILE_PATH"));
+        DxmCiTestConfigurator.WriteBuildOptionsEvidence(
+            Environment.GetEnvironmentVariable("DXM_BUILD_OPTIONS_PROFILE_PATH"),
+            report.summary.options);
+        if (report.summary.result != BuildResult.Succeeded)
+        {
+            throw new InvalidOperationException(
+                "Shipping-fidelity build failed: " + report.summary.result);
+        }
+
+        WriteAssemblyEvidence(
+            RequireEnvironmentVariable("DXM_SHIPPING_ASSEMBLY_EVIDENCE_PATH"),
+            assemblyNames,
+            (report.summary.options & BuildOptions.IncludeTestAssemblies)
+                == BuildOptions.IncludeTestAssemblies);
+        WriteMarker(markerPath);
+    }
+
+    private static void ApplyShippingProfile()
+    {
+        NamedBuildTarget standalone = NamedBuildTarget.Standalone;
+        UnityEditor.Compilation.CompilationPipeline.codeOptimization =
+            UnityEditor.Compilation.CodeOptimization.Release;
+        PlayerSettings.SetScriptingBackend(standalone, ScriptingImplementation.IL2CPP);
+        PlayerSettings.SetApiCompatibilityLevel(standalone, ApiCompatibilityLevel.NET_Standard);
+        PlayerSettings.SetManagedStrippingLevel(standalone, ManagedStrippingLevel.High);
+        PlayerSettings.SetIl2CppCompilerConfiguration(
+            standalone,
+            Il2CppCompilerConfiguration.Release);
+        PlayerSettings.gcIncremental = true;
+        PlayerSettings.stripEngineCode = true;
+#if UNITY_2022_1_OR_NEWER
+        PlayerSettings.SetIl2CppCodeGeneration(
+            standalone,
+            Il2CppCodeGeneration.OptimizeSpeed);
+#else
+        EditorUserBuildSettings.il2CppCodeGeneration = Il2CppCodeGeneration.OptimizeSpeed;
+#endif
+    }
+
+    private static string[] GetAssemblyNames(UnityEditor.Compilation.Assembly[] assemblies)
+    {
+        List<string> names = new List<string>(assemblies.Length);
+        for (int i = 0; i < assemblies.Length; i++)
+        {
+            names.Add(assemblies[i].name);
+        }
+        string[] result = names.ToArray();
+        Array.Sort(result, StringComparer.Ordinal);
+        return result;
+    }
+
+    private static void AssertNoTestAssemblies(string[] assemblyNames)
+    {
+        for (int i = 0; i < assemblyNames.Length; i++)
+        {
+            string name = assemblyNames[i];
+            if (
+                string.Equals(name, "nunit.framework", StringComparison.OrdinalIgnoreCase)
+                || name.IndexOf("TestRunner", StringComparison.OrdinalIgnoreCase) >= 0
+                || name.IndexOf("PerformanceTesting", StringComparison.OrdinalIgnoreCase) >= 0
+                || name.EndsWith(".Tests", StringComparison.OrdinalIgnoreCase)
+                || name.IndexOf(".Tests.", StringComparison.OrdinalIgnoreCase) >= 0
+                || name.StartsWith("DxmCiStandalone", StringComparison.Ordinal)
+            )
+            {
+                throw new InvalidOperationException(
+                    "Shipping build selected forbidden test assembly: " + name);
+            }
+        }
+        if (
+            assemblyNames.Length != 2
+            || !string.Equals(assemblyNames[0], "Assembly-CSharp", StringComparison.Ordinal)
+            || !string.Equals(
+                assemblyNames[1],
+                "WallstopStudios.DxMessaging",
+                StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                "Shipping build selected an unexpected player assembly inventory: "
+                + string.Join(",", assemblyNames));
+        }
+    }
+
+    private static void WriteAssemblyEvidence(
+        string path,
+        string[] assemblyNames,
+        bool includeTestAssemblies)
+    {
+        AssemblyEvidence evidence = new AssemblyEvidence
+        {
+            includeTestAssemblies = includeTestAssemblies,
+            playerAssemblies = assemblyNames
+        };
+        string directory = Path.GetDirectoryName(path);
+        if (!string.IsNullOrEmpty(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+        File.WriteAllText(path, JsonUtility.ToJson(evidence, true));
+    }
+
+    private static void WriteMarker(string path)
+    {
+        string directory = Path.GetDirectoryName(path);
+        if (!string.IsNullOrEmpty(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+        File.WriteAllText(path, "DxmShippingFidelityBuilder.Build completed");
+    }
+
+    private static string RequireEnvironmentVariable(string name)
+    {
+        string value = Environment.GetEnvironmentVariable(name);
+        if (string.IsNullOrEmpty(value))
+        {
+            throw new InvalidOperationException("Missing required environment variable: " + name);
+        }
+        return value;
+    }
+}
+"@
+}
+
 function Assert-DxMessagingAnalyzerDllsPresent {
     param([Parameter(Mandatory = $true)][string]$Root)
 
@@ -2043,6 +2939,8 @@ function Initialize-EphemeralProject {
         [string]$Path,
         [switch]$IncludeComparisons,
         [string]$Backend = 'IL2CPP',
+        [ValidateSet('Disabled', 'Minimal', 'Low', 'Medium', 'High')]
+        [string]$ManagedStrippingLevel = 'Disabled',
         [bool]$DevelopmentBuild = $false,
         [string]$CanonicalProfileId = '',
         [string]$CanonicalProfileSha256 = '',
@@ -2116,13 +3014,38 @@ function Initialize-EphemeralProject {
             "with a DirectoryNotFoundException before any test ran. Shorten the project path (see issue #357).")
     }
 
-    New-Item -ItemType Directory -Force -Path (Join-Path $project 'Packages') | Out-Null
-    New-Item -ItemType Directory -Force -Path (Join-Path $project 'ProjectSettings') | Out-Null
-    New-Item -ItemType Directory -Force -Path ([System.IO.Path]::Combine($project, 'Assets', 'Editor')) | Out-Null
-    Write-ProjectOwnershipMarker -ProjectPath $project
-
     $includeIntegrations = $Mode -eq 'editmode'
-    New-ManifestJson -Root $Root -IncludeComparisons:$IncludeComparisons -IncludeIntegrations:$includeIntegrations -RepoRoot $RepoRoot |
+    $isShippingFidelity = $Mode -eq 'shipping'
+    New-Item -ItemType Directory -Force -Path $project | Out-Null
+    Write-ProjectOwnershipMarker -ProjectPath $project
+    if ($isShippingFidelity) {
+        # Reset every authored root before creating any child path. The helper
+        # unlinks reparse points without traversal and recursively checks real
+        # directories, so a cached junction or symlink cannot redirect cleanup
+        # outside the owned generated project.
+        foreach ($shippingInputRootName in @('Assets', 'Packages', 'ProjectSettings', 'UserSettings')) {
+            Reset-OwnedUnityInputRoot -Path (Join-Path $project $shippingInputRootName)
+        }
+        New-Item -ItemType Directory -Force -Path ([System.IO.Path]::Combine($project, 'Assets', 'Editor')) | Out-Null
+    } else {
+        New-Item -ItemType Directory -Force -Path (Join-Path $project 'Packages') | Out-Null
+        New-Item -ItemType Directory -Force -Path (Join-Path $project 'ProjectSettings') | Out-Null
+        New-Item -ItemType Directory -Force -Path ([System.IO.Path]::Combine($project, 'Assets', 'Editor')) | Out-Null
+    }
+
+    $shippingProjectInputRelativePaths = @()
+    if ($isShippingFidelity) {
+        $shippingProjectInputRelativePaths = @(
+            'Assets/csc.rsp',
+            'Assets/DxmShippingFidelityPlayer.cs',
+            'Assets/Editor/DxmCiTestConfigurator.cs',
+            'Assets/Editor/DxmShippingFidelityBuilder.cs',
+            'Packages/manifest.json',
+            'ProjectSettings/EditorSettings.asset',
+            'ProjectSettings/ProjectVersion.txt'
+        )
+    }
+    New-ManifestJson -Root $Root -IncludeComparisons:$IncludeComparisons -IncludeIntegrations:$includeIntegrations -ShippingFidelity:$isShippingFidelity -RepoRoot $RepoRoot |
         Set-Content -LiteralPath ([System.IO.Path]::Combine($project, 'Packages', 'manifest.json')) -Encoding UTF8
     "m_EditorVersion: $Version`n" |
         Set-Content -LiteralPath ([System.IO.Path]::Combine($project, 'ProjectSettings', 'ProjectVersion.txt')) -Encoding UTF8
@@ -2158,9 +3081,11 @@ EditorSettings:
         }
     }
     $cscOptions | Set-Content -LiteralPath ([System.IO.Path]::Combine($project, 'Assets', 'csc.rsp')) -Encoding UTF8
-    New-ConfiguratorSource -Backend $Backend -CanonicalProfileId $CanonicalProfileId -CanonicalProfileSha256 $CanonicalProfileSha256 |
+    New-ConfiguratorSource -Backend $Backend -ManagedStrippingLevel $ManagedStrippingLevel -CanonicalProfileId $CanonicalProfileId -CanonicalProfileSha256 $CanonicalProfileSha256 |
         Set-Content -LiteralPath ([System.IO.Path]::Combine($project, 'Assets', 'Editor', 'DxmCiTestConfigurator.cs')) -Encoding UTF8
-    Copy-SamplesForCompilation -Root $Root -Project $project -IncludeIntegrations:$includeIntegrations
+    if (-not $isShippingFidelity) {
+        Copy-SamplesForCompilation -Root $Root -Project $project -IncludeIntegrations:$includeIntegrations
+    }
 
     # The generator + analyzer ship under the package's Runtime/Analyzers/
     # (RoslynAnalyzer-labeled, every platform disabled), so Unity scopes them to the
@@ -2181,7 +3106,7 @@ EditorSettings:
     # untouched).
     if ($Mode -eq 'standalone') {
         $standaloneFiles = @(
-            @{ Path = ([System.IO.Path]::Combine($project, 'Assets', 'Editor', 'DxmCiStandaloneBuildModifier.cs')); Content = (New-StandaloneBuildModifierSource -DevelopmentBuild $DevelopmentBuild -CanonicalProfileId $CanonicalProfileId -CanonicalProfileSha256 $CanonicalProfileSha256) },
+            @{ Path = ([System.IO.Path]::Combine($project, 'Assets', 'Editor', 'DxmCiStandaloneBuildModifier.cs')); Content = (New-StandaloneBuildModifierSource -DevelopmentBuild $DevelopmentBuild -CanonicalProfileId $CanonicalProfileId) },
             @{ Path = ([System.IO.Path]::Combine($project, 'Assets', 'DxmCiStandaloneTestCallback', 'DxmCiStandaloneTestCallback.cs')); Content = (New-StandaloneTestCallbackSource -CanonicalProfileId $CanonicalProfileId -CanonicalProfileSha256 $CanonicalProfileSha256) },
             @{ Path = ([System.IO.Path]::Combine($project, 'Assets', 'DxmCiStandaloneTestCallback', 'DxmCiStandaloneTestCallback.asmdef')); Content = (New-StandaloneTestCallbackAsmdef) }
         )
@@ -2208,6 +3133,80 @@ EditorSettings:
             Write-Host "  $($file.Path)"
         }
         Write-Host "::endgroup::"
+    } elseif ($isShippingFidelity) {
+        if (
+            [string]::IsNullOrWhiteSpace($CanonicalProfileId) -or
+            [string]::IsNullOrWhiteSpace($CanonicalProfileSha256)
+        ) {
+            throw 'Shipping-fidelity generation requires a validated IL2CPP profile identity.'
+        }
+        $shippingFiles = @(
+            @{ Path = ([System.IO.Path]::Combine($project, 'Assets', 'Editor', 'DxmShippingFidelityBuilder.cs')); Content = (New-ShippingFidelityBuilderSource -CanonicalProfileId $CanonicalProfileId -CanonicalProfileSha256 $CanonicalProfileSha256) },
+            @{ Path = ([System.IO.Path]::Combine($project, 'Assets', 'DxmShippingFidelityPlayer.cs')); Content = (New-ShippingFidelityPlayerSource -CanonicalProfileId $CanonicalProfileId -CanonicalProfileSha256 $CanonicalProfileSha256) }
+        )
+        foreach ($file in $shippingFiles) {
+            $dir = Split-Path -Parent $file.Path
+            if ($dir -and -not (Test-Path -LiteralPath $dir -PathType Container)) {
+                New-Item -ItemType Directory -Force -Path $dir | Out-Null
+            }
+            $needsWrite = -not (Test-Path -LiteralPath $file.Path -PathType Leaf)
+            if (-not $needsWrite) {
+                $existing = Get-Content -LiteralPath $file.Path -Raw
+                $needsWrite = ($existing.TrimEnd("`r", "`n") -ne $file.Content.TrimEnd("`r", "`n"))
+            }
+            if ($needsWrite) {
+                Set-Content -LiteralPath $file.Path -Value $file.Content -Encoding UTF8
+            }
+        }
+        Write-Host "::group::DxMessaging shipping-fidelity player"
+        Write-Host "Generated the stripped Assembly-CSharp consumer and direct player builder under $project."
+        foreach ($file in $shippingFiles) {
+            Write-Host "  $($file.Path)"
+        }
+        Write-Host "::endgroup::"
+
+        $observedProjectInputs = @(
+            foreach ($shippingInputRootName in @('Assets', 'Packages', 'ProjectSettings', 'UserSettings')) {
+                $shippingInputRoot = Join-Path $project $shippingInputRootName
+                if (-not (Test-Path -LiteralPath $shippingInputRoot -PathType Container)) {
+                    continue
+                }
+                Get-ChildItem -LiteralPath $shippingInputRoot -File -Recurse -Force |
+                    Where-Object { -not $_.Name.EndsWith('.meta', [StringComparison]::Ordinal) } |
+                    ForEach-Object {
+                        $_.FullName.Substring($project.Length).TrimStart(
+                            [System.IO.Path]::DirectorySeparatorChar,
+                            [System.IO.Path]::AltDirectorySeparatorChar
+                        ).Replace('\', '/')
+                    }
+            }
+        )
+        $unexpectedProjectInputs = @(
+            $observedProjectInputs |
+                Where-Object { $shippingProjectInputRelativePaths -cnotcontains $_ }
+        )
+        $missingProjectInputs = @(
+            $shippingProjectInputRelativePaths |
+                Where-Object { $observedProjectInputs -cnotcontains $_ }
+        )
+        if ($unexpectedProjectInputs.Count -gt 0 -or $missingProjectInputs.Count -gt 0) {
+            throw "Shipping project inputs differ (missing=$($missingProjectInputs -join ','), unexpected=$($unexpectedProjectInputs -join ','))."
+        }
+        $projectInputEntries = New-Object System.Collections.Generic.List[object]
+        foreach ($relativeInputPath in $shippingProjectInputRelativePaths) {
+            $fullInputPath = Join-Path $project $relativeInputPath
+            $projectInputEntries.Add([ordered]@{
+                    path = $relativeInputPath
+                    length = [long](Get-Item -LiteralPath $fullInputPath).Length
+                    sha256 = (Get-FileHash -LiteralPath $fullInputPath -Algorithm SHA256).Hash.ToLowerInvariant()
+                })
+        }
+        Write-JsonArtifact `
+            -Path (Join-Path $ArtifactsPath 'shipping-project-inputs.json') `
+            -Value ([ordered]@{
+                schemaVersion = 1
+                files = @($projectInputEntries.ToArray())
+            })
     }
 
     return $project
@@ -3872,6 +4871,438 @@ function Test-StandalonePlayerBuildOutput {
     return ''
 }
 
+function Assert-ExactJsonPropertyNames {
+    param(
+        [Parameter(Mandatory = $true)][object]$Value,
+        [Parameter(Mandatory = $true)][string[]]$Expected,
+        [Parameter(Mandatory = $true)][string]$Label
+    )
+
+    $actualNames = [string[]]@($Value.PSObject.Properties.Name)
+    [Array]::Sort($actualNames, [System.StringComparer]::Ordinal)
+    $expectedNames = [string[]]@($Expected)
+    [Array]::Sort($expectedNames, [System.StringComparer]::Ordinal)
+    if (($actualNames -join "`n") -cne ($expectedNames -join "`n")) {
+        throw "$Label has unexpected JSON properties. Expected [$($expectedNames -join ', ')], observed [$($actualNames -join ', ')]."
+    }
+}
+
+function Assert-JsonValueType {
+    param(
+        [Parameter(Mandatory = $true)][AllowNull()][AllowEmptyString()][object]$Value,
+        [Parameter(Mandatory = $true)][ValidateSet('string', 'bool', 'integer', 'array')][string]$ExpectedKind,
+        [Parameter(Mandatory = $true)][string]$Path
+    )
+
+    $matches = switch ($ExpectedKind) {
+        'string' { $Value -is [string] }
+        'bool' { $Value -is [bool] }
+        'integer' { $Value -is [int] -or $Value -is [long] }
+        'array' { $Value -is [System.Array] }
+    }
+    if (-not $matches) {
+        $actualType = if ($null -eq $Value) { 'null' } else { $Value.GetType().FullName }
+        throw "$Path must be a JSON $ExpectedKind value; observed $actualType."
+    }
+}
+
+function Get-ExpectedShippingShapeNames {
+    return [string[]]@(
+        'DxmShippingPublicUntargetedClass',
+        'DxmShippingPublicUntargetedStruct',
+        'DxmShippingPublicTargetedClass',
+        'DxmShippingPublicTargetedStruct',
+        'DxmShippingPublicBroadcastClass',
+        'DxmShippingPublicBroadcastStruct',
+        'NestedUntargetedClass',
+        'NestedUntargetedStruct',
+        'NestedTargetedClass',
+        'NestedTargetedStruct',
+        'NestedBroadcastClass',
+        'NestedBroadcastStruct',
+        'PublicNestedUntargetedClass',
+        'PublicNestedUntargetedStruct',
+        'PublicNestedTargetedClass',
+        'PublicNestedTargetedStruct',
+        'PublicNestedBroadcastClass',
+        'PublicNestedBroadcastStruct'
+    )
+}
+
+function Assert-ExactJsonStringArray {
+    param(
+        [Parameter(Mandatory = $true)][AllowEmptyCollection()][object[]]$Value,
+        [Parameter(Mandatory = $true)][AllowEmptyCollection()][string[]]$Expected,
+        [Parameter(Mandatory = $true)][string]$Path
+    )
+
+    foreach ($element in @($Value)) {
+        Assert-JsonValueType -Value $element -ExpectedKind string -Path "$Path[]"
+    }
+    $actual = [string[]]@($Value)
+    if (
+        $actual.Count -ne $Expected.Count -or
+        ($actual -join "`n") -cne ($Expected -join "`n")
+    ) {
+        throw "$Path does not contain the exact expected ordered shape inventory."
+    }
+}
+
+function Assert-NoShippingTestAssemblies {
+    param(
+        [Parameter(Mandatory = $true)][string[]]$AssemblyNames,
+        [Parameter(Mandatory = $true)][string]$Label
+    )
+
+    foreach ($assemblyName in $AssemblyNames) {
+        if (
+            [string]::IsNullOrWhiteSpace($assemblyName) -or
+            $assemblyName -ieq 'nunit.framework' -or
+            $assemblyName -imatch 'TestRunner' -or
+            $assemblyName -imatch 'PerformanceTesting' -or
+            $assemblyName -imatch '(?:^|\.)Tests(?:\.|$)' -or
+            $assemblyName -clike 'DxmCiStandalone*'
+        ) {
+            throw "$Label contains a forbidden or empty assembly name: '$assemblyName'."
+        }
+    }
+    $uniqueNames = @($AssemblyNames | Sort-Object -Unique)
+    if ($uniqueNames.Count -ne $AssemblyNames.Count) {
+        throw "$Label contains duplicate assembly names."
+    }
+}
+
+function Test-ShippingAssemblyEvidence {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][string]$ExpectedProfileId,
+        [Parameter(Mandatory = $true)][string]$ExpectedProfileSha256,
+        [Parameter(Mandatory = $true)][string]$ExpectedUnityVersion
+    )
+
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        throw "Shipping build did not write assembly evidence at $Path."
+    }
+    $evidence = Get-Content -LiteralPath $Path -Raw | ConvertFrom-Json
+    Assert-ExactJsonPropertyNames -Value $evidence -Expected @(
+        'schemaVersion',
+        'profileId',
+        'profileSha256',
+        'unityVersion',
+        'includeTestAssemblies',
+        'playerAssemblies'
+    ) -Label 'Shipping assembly evidence'
+    Assert-JsonValueType -Value $evidence.schemaVersion -ExpectedKind integer -Path 'shippingAssemblyEvidence.schemaVersion'
+    Assert-JsonValueType -Value $evidence.profileId -ExpectedKind string -Path 'shippingAssemblyEvidence.profileId'
+    Assert-JsonValueType -Value $evidence.profileSha256 -ExpectedKind string -Path 'shippingAssemblyEvidence.profileSha256'
+    Assert-JsonValueType -Value $evidence.unityVersion -ExpectedKind string -Path 'shippingAssemblyEvidence.unityVersion'
+    Assert-JsonValueType -Value $evidence.includeTestAssemblies -ExpectedKind bool -Path 'shippingAssemblyEvidence.includeTestAssemblies'
+    Assert-JsonValueType -Value $evidence.playerAssemblies -ExpectedKind array -Path 'shippingAssemblyEvidence.playerAssemblies'
+    if (
+        [int]$evidence.schemaVersion -ne 1 -or
+        [string]$evidence.profileId -cne $ExpectedProfileId -or
+        [string]$evidence.profileSha256 -cne $ExpectedProfileSha256 -or
+        [string]$evidence.unityVersion -cne $ExpectedUnityVersion -or
+        [bool]$evidence.includeTestAssemblies
+    ) {
+        throw 'Shipping assembly evidence does not match the selected profile or Unity version.'
+    }
+    foreach ($rawAssemblyName in @($evidence.playerAssemblies)) {
+        Assert-JsonValueType `
+            -Value $rawAssemblyName `
+            -ExpectedKind string `
+            -Path 'shippingAssemblyEvidence.playerAssemblies[]'
+    }
+    $assemblyNames = [string[]]@($evidence.playerAssemblies)
+    Assert-NoShippingTestAssemblies -AssemblyNames $assemblyNames -Label 'Shipping build assembly inventory'
+    $expectedAssemblyNames = @('Assembly-CSharp', 'WallstopStudios.DxMessaging')
+    if (($assemblyNames -join "`n") -cne ($expectedAssemblyNames -join "`n")) {
+        throw 'Shipping build assembly inventory differs from the exact two expected consumer assemblies.'
+    }
+}
+
+function Write-ShippingPackageResolutionEvidence {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProjectPath,
+        [Parameter(Mandatory = $true)][string]$ArtifactsPath,
+        [Parameter(Mandatory = $true)][string]$ExpectedRepoRoot,
+        [Parameter(Mandatory = $true)][string]$ExpectedManifestSha256
+    )
+
+    $packagesPath = Join-Path $ProjectPath 'Packages'
+    $packageEntries = @(Get-ChildItem -LiteralPath $packagesPath -Force)
+    $actualEntryNames = [string[]]@($packageEntries | ForEach-Object { $_.Name })
+    [Array]::Sort($actualEntryNames, [System.StringComparer]::Ordinal)
+    $expectedEntryNames = [string[]]@('manifest.json', 'packages-lock.json')
+    if (($actualEntryNames -join "`n") -cne ($expectedEntryNames -join "`n")) {
+        throw 'Shipping Packages contains an unexpected entry after package resolution.'
+    }
+    foreach ($packageEntry in $packageEntries) {
+        if ($packageEntry.PSIsContainer -or (Test-IsReparsePoint -Path $packageEntry.FullName)) {
+            throw "Shipping Packages entry '$($packageEntry.Name)' must be a regular file."
+        }
+    }
+
+    $manifestPath = Join-Path $packagesPath 'manifest.json'
+    $lockPath = Join-Path $packagesPath 'packages-lock.json'
+    $resolvedManifestSha256 = (Get-FileHash -LiteralPath $manifestPath -Algorithm SHA256).Hash.ToLowerInvariant()
+    if ($resolvedManifestSha256 -cne $ExpectedManifestSha256) {
+        throw 'Shipping package manifest hash changed during package resolution.'
+    }
+    $manifest = Get-Content -LiteralPath $manifestPath -Raw | ConvertFrom-Json
+    if ($manifest -isnot [pscustomobject] -or $manifest.dependencies -isnot [pscustomobject]) {
+        throw 'Shipping package manifest and dependencies must be JSON objects.'
+    }
+    Assert-ExactJsonPropertyNames `
+        -Value $manifest `
+        -Expected @('dependencies') `
+        -Label 'Shipping package manifest'
+    $manifestDependencyNames = @($manifest.dependencies.PSObject.Properties.Name)
+    if (
+        $manifestDependencyNames.Count -ne 1 -or
+        $manifestDependencyNames[0] -cne 'com.wallstop-studios.dxmessaging'
+    ) {
+        throw 'Shipping package manifest differs from the single reviewed file dependency.'
+    }
+    $manifestDependency = $manifest.dependencies.'com.wallstop-studios.dxmessaging'
+    Assert-JsonValueType `
+        -Value $manifestDependency `
+        -ExpectedKind string `
+        -Path 'shippingPackageManifest.dependencies.com.wallstop-studios.dxmessaging'
+    $expectedManifestDependency = "file:$(ConvertTo-UnityFileUriPath -Path (Resolve-FullPath -Path $ExpectedRepoRoot))"
+    if ([string]$manifestDependency -cne $expectedManifestDependency) {
+        throw 'Shipping package manifest does not reference the reviewed repository root.'
+    }
+
+    $packageLock = Get-Content -LiteralPath $lockPath -Raw | ConvertFrom-Json
+    if ($packageLock -isnot [pscustomobject] -or $packageLock.dependencies -isnot [pscustomobject]) {
+        throw 'Shipping packages-lock and dependencies must be JSON objects.'
+    }
+    Assert-ExactJsonPropertyNames `
+        -Value $packageLock `
+        -Expected @('dependencies') `
+        -Label 'Shipping packages-lock'
+    $lockDependencyNames = @($packageLock.dependencies.PSObject.Properties.Name)
+    if (
+        $lockDependencyNames.Count -ne 1 -or
+        $lockDependencyNames[0] -cne 'com.wallstop-studios.dxmessaging'
+    ) {
+        throw 'Shipping packages-lock differs from the exact one-package graph.'
+    }
+    $lockDependencyProperty = $packageLock.dependencies.PSObject.Properties[
+        'com.wallstop-studios.dxmessaging'
+    ]
+    $lockDependency = if ($null -eq $lockDependencyProperty) {
+        $null
+    } else {
+        $lockDependencyProperty.Value
+    }
+    if ($null -ne $lockDependency) {
+        Assert-ExactJsonPropertyNames `
+            -Value $lockDependency `
+            -Expected @('version', 'depth', 'source', 'dependencies') `
+            -Label 'Shipping packages-lock dependency'
+        Assert-JsonValueType -Value $lockDependency.version -ExpectedKind string -Path 'shippingPackagesLock.version'
+        Assert-JsonValueType -Value $lockDependency.depth -ExpectedKind integer -Path 'shippingPackagesLock.depth'
+        Assert-JsonValueType -Value $lockDependency.source -ExpectedKind string -Path 'shippingPackagesLock.source'
+        if ($lockDependency.dependencies -isnot [pscustomobject]) {
+            throw 'Shipping packages-lock transitive dependencies must be a JSON object.'
+        }
+    }
+    $transitiveDependencyNames = @()
+    if ($null -ne $lockDependency) {
+        $transitiveDependencyNames = @(
+            $lockDependency.dependencies.PSObject.Properties |
+                ForEach-Object { $_.Name }
+        )
+    }
+    if (
+        $null -eq $lockDependency -or
+        [string]$lockDependency.source -cne 'local' -or
+        [int]$lockDependency.depth -ne 0 -or
+        [string]$lockDependency.version -cne $expectedManifestDependency -or
+        $transitiveDependencyNames.Count -ne 0
+    ) {
+        throw 'Shipping packages-lock does not exactly resolve the reviewed checkout as one direct local dependency.'
+    }
+
+    $resolvedInputEntries = New-Object System.Collections.Generic.List[object]
+    foreach ($resolvedInputPath in @($manifestPath, $lockPath)) {
+        $resolvedInputEntries.Add([ordered]@{
+                path = "Packages/$([System.IO.Path]::GetFileName($resolvedInputPath))"
+                length = [long](Get-Item -LiteralPath $resolvedInputPath).Length
+                sha256 = (Get-FileHash -LiteralPath $resolvedInputPath -Algorithm SHA256).Hash.ToLowerInvariant()
+            })
+    }
+    Write-JsonArtifact `
+        -Path (Join-Path $ArtifactsPath 'shipping-resolved-package-inputs.json') `
+        -Value ([ordered]@{
+            schemaVersion = 1
+            resolvedPackage = [ordered]@{
+                packageId = 'com.wallstop-studios.dxmessaging'
+                source = 'local'
+                depth = 0
+                versionScheme = 'file'
+            }
+            files = @($resolvedInputEntries.ToArray())
+        })
+}
+
+function Test-ShippingFidelityResult {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][ValidateSet('positive', 'missing-root-mutant')][string]$ExpectedMode,
+        [Parameter(Mandatory = $true)][string]$ExpectedProfileId,
+        [Parameter(Mandatory = $true)][string]$ExpectedProfileSha256,
+        [Parameter(Mandatory = $true)][string]$ExpectedUnityVersion
+    )
+
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        throw "Shipping player did not write $ExpectedMode evidence at $Path."
+    }
+    $result = Get-Content -LiteralPath $Path -Raw | ConvertFrom-Json
+    Assert-ExactJsonPropertyNames -Value $result -Expected @(
+        'schemaVersion',
+        'profileId',
+        'profileSha256',
+        'unityVersion',
+        'mode',
+        'success',
+        'unityIncludeTests',
+        'rootedUntypedProbeCount',
+        'typedDispatchCount',
+        'untypedDispatchCount',
+        'rootedUntypedShapes',
+        'typedDispatchShapes',
+        'untypedDispatchShapes',
+        'missingRootFailureObserved',
+        'failureType',
+        'failureMessage',
+        'loadedAssemblies'
+    ) -Label "Shipping $ExpectedMode result"
+    foreach ($stringProperty in @(
+        'profileId',
+        'profileSha256',
+        'unityVersion',
+        'mode',
+        'failureType',
+        'failureMessage'
+    )) {
+        Assert-JsonValueType `
+            -Value $result.$stringProperty `
+            -ExpectedKind string `
+            -Path "shippingResult.$stringProperty"
+    }
+    foreach ($booleanProperty in @('success', 'unityIncludeTests', 'missingRootFailureObserved')) {
+        Assert-JsonValueType `
+            -Value $result.$booleanProperty `
+            -ExpectedKind bool `
+            -Path "shippingResult.$booleanProperty"
+    }
+    foreach ($integerProperty in @(
+        'schemaVersion',
+        'rootedUntypedProbeCount',
+        'typedDispatchCount',
+        'untypedDispatchCount'
+    )) {
+        Assert-JsonValueType `
+            -Value $result.$integerProperty `
+            -ExpectedKind integer `
+            -Path "shippingResult.$integerProperty"
+    }
+    foreach ($arrayProperty in @(
+        'rootedUntypedShapes',
+        'typedDispatchShapes',
+        'untypedDispatchShapes',
+        'loadedAssemblies'
+    )) {
+        Assert-JsonValueType -Value $result.$arrayProperty -ExpectedKind array -Path "shippingResult.$arrayProperty"
+    }
+    if (
+        [int]$result.schemaVersion -ne 1 -or
+        [string]$result.profileId -cne $ExpectedProfileId -or
+        [string]$result.profileSha256 -cne $ExpectedProfileSha256 -or
+        [string]$result.unityVersion -cne $ExpectedUnityVersion -or
+        [string]$result.mode -cne $ExpectedMode -or
+        -not [bool]$result.success -or
+        [bool]$result.unityIncludeTests -or
+        -not [string]::IsNullOrEmpty([string]$result.failureType) -or
+        -not [string]::IsNullOrEmpty([string]$result.failureMessage)
+    ) {
+        throw "Shipping $ExpectedMode result does not satisfy the success contract."
+    }
+    [string[]]$expectedShapes = @()
+    if ($ExpectedMode -ceq 'positive') {
+        $expectedShapes = @(Get-ExpectedShippingShapeNames)
+    }
+    foreach ($shapeProperty in @(
+        'rootedUntypedShapes',
+        'typedDispatchShapes',
+        'untypedDispatchShapes'
+    )) {
+        Assert-ExactJsonStringArray `
+            -Value @($result.$shapeProperty) `
+            -Expected $expectedShapes `
+            -Path "shippingResult.$shapeProperty"
+    }
+    if ($ExpectedMode -ceq 'positive') {
+        if (
+            [int]$result.rootedUntypedProbeCount -ne 18 -or
+            [int]$result.typedDispatchCount -ne 18 -or
+            [int]$result.untypedDispatchCount -ne 18 -or
+            [bool]$result.missingRootFailureObserved
+        ) {
+            throw 'Shipping positive result does not contain the required 18 typed and 18 untyped dispatches.'
+        }
+    } elseif (
+        [int]$result.rootedUntypedProbeCount -ne 0 -or
+        [int]$result.typedDispatchCount -ne 0 -or
+        [int]$result.untypedDispatchCount -ne 0 -or
+        -not [bool]$result.missingRootFailureObserved
+    ) {
+        throw 'Shipping missing-root mutant did not observe the required rooted-bridge failure.'
+    }
+    foreach ($rawAssemblyName in @($result.loadedAssemblies)) {
+        Assert-JsonValueType `
+            -Value $rawAssemblyName `
+            -ExpectedKind string `
+            -Path 'shippingResult.loadedAssemblies[]'
+    }
+    $loadedAssemblies = [string[]]@($result.loadedAssemblies)
+    Assert-NoShippingTestAssemblies -AssemblyNames $loadedAssemblies -Label "Shipping $ExpectedMode loaded assembly inventory"
+    foreach ($requiredAssembly in @('Assembly-CSharp', 'WallstopStudios.DxMessaging')) {
+        if ($loadedAssemblies -cnotcontains $requiredAssembly) {
+            throw "Shipping $ExpectedMode loaded assembly inventory is missing '$requiredAssembly'."
+        }
+    }
+}
+
+function Invoke-ShippingFidelityPlayer {
+    param(
+        [Parameter(Mandatory = $true)][string]$ExecutablePath,
+        [Parameter(Mandatory = $true)][ValidateSet('positive', 'missing-root-mutant')][string]$Mode,
+        [Parameter(Mandatory = $true)][string]$ResultPath,
+        [Parameter(Mandatory = $true)][string]$RuntimeProfilePath,
+        [Parameter(Mandatory = $true)][string]$LogPath,
+        [int]$TimeoutSeconds = 1800
+    )
+
+    $arguments = @(
+        '-batchmode',
+        '-nographics',
+        '-logFile', '-',
+        '-dxmShippingResult', $ResultPath,
+        '-dxmRuntimeProfile', $RuntimeProfilePath,
+        '-dxmShippingMode', $Mode
+    )
+    return Invoke-ProcessWithTreeKillTimeout `
+        -FilePath $ExecutablePath `
+        -Arguments $arguments `
+        -TimeoutSeconds $TimeoutSeconds `
+        -LogPath $LogPath `
+        -Label "Run shipping-fidelity player ($Mode)"
+}
+
 function Test-NUnitResults {
     # The NUnit results.xml is the SOLE source of truth for editmode/playmode and
     # the standalone player run. $UnityExitCode is the process exit code of the
@@ -3946,12 +5377,38 @@ Assert-RepoRoot -Path $RepoRoot
 $ArtifactsPath = Resolve-FullPath -Path $ArtifactsPath
 New-Item -ItemType Directory -Force -Path $ArtifactsPath | Out-Null
 
+$isShippingFidelity = $TestMode -eq 'shipping'
+if ($isShippingFidelity) {
+    if (-not [string]::IsNullOrWhiteSpace($AssemblyNames)) {
+        throw 'AssemblyNames must be empty for a shipping-fidelity player.'
+    }
+    if ($IncludeComparisons) {
+        throw 'IncludeComparisons is not valid for a shipping-fidelity player.'
+    }
+    if (-not [string]::IsNullOrWhiteSpace($TestCategory)) {
+        throw 'TestCategory is not valid for a shipping-fidelity player.'
+    }
+    if ($StandaloneScriptingBackend -cne 'IL2CPP') {
+        throw 'A shipping-fidelity player requires the IL2CPP scripting backend.'
+    }
+    if ([string]::IsNullOrWhiteSpace($CanonicalProfilePath)) {
+        throw 'A shipping-fidelity player requires CanonicalProfilePath.'
+    }
+    if ($StandalonePlayerRunCount -ne 1) {
+        throw 'StandalonePlayerRunCount is not valid for a shipping-fidelity player.'
+    }
+} elseif ([string]::IsNullOrWhiteSpace($AssemblyNames)) {
+    throw "AssemblyNames must be non-empty for TestMode '$TestMode'."
+}
+
 $canonicalProfileId = ''
 $canonicalProfileSha256 = ''
 $resolvedCanonicalProfilePath = ''
+$managedStrippingLevel = 'Disabled'
+$includeTestAssemblies = $true
 if (-not [string]::IsNullOrWhiteSpace($CanonicalProfilePath)) {
-    if ($TestMode -ne 'standalone' -or $StandaloneScriptingBackend -cne 'IL2CPP') {
-        throw 'CanonicalProfilePath is valid only for a standalone IL2CPP run.'
+    if (($TestMode -ne 'standalone' -and -not $isShippingFidelity) -or $StandaloneScriptingBackend -cne 'IL2CPP') {
+        throw 'CanonicalProfilePath is valid only for a standalone or shipping IL2CPP run.'
     }
     $profileCandidate = if ([System.IO.Path]::IsPathRooted($CanonicalProfilePath)) {
         $CanonicalProfilePath
@@ -3964,11 +5421,30 @@ if (-not [string]::IsNullOrWhiteSpace($CanonicalProfilePath)) {
     $canonicalProfile = Get-Content -LiteralPath $resolvedCanonicalProfilePath -Raw | ConvertFrom-Json
     $canonicalProfileId = [string]$canonicalProfile.profileId
     $canonicalProfileSha256 = (Get-FileHash -LiteralPath $resolvedCanonicalProfilePath -Algorithm SHA256).Hash.ToLowerInvariant()
-    $profileArtifactPath = Join-Path $ArtifactsPath 'canonical-il2cpp-profile.v1.json'
+    $managedStrippingLevel = [string]$canonicalProfile.configuration.managedStrippingLevel
+    $includeTestAssemblies = [bool]$canonicalProfile.buildOptions.includeTestAssemblies
+    if ($isShippingFidelity) {
+        if (
+            $canonicalProfileId -cne 'shipping-fidelity-il2cpp-player-v1' -or
+            $managedStrippingLevel -cne 'High' -or
+            $includeTestAssemblies
+        ) {
+            throw 'Shipping fidelity requires its reviewed profile with High stripping and includeTestAssemblies=false.'
+        }
+    } elseif (
+        $canonicalProfileId -cne 'canonical-il2cpp-verdict-player-v1' -or
+        $managedStrippingLevel -cne 'Disabled' -or
+        -not $includeTestAssemblies
+    ) {
+        throw 'The standalone test player requires its reviewed profile with Disabled stripping and includeTestAssemblies=true.'
+    }
+    $profileArtifactFileName = [System.IO.Path]::GetFileName($resolvedCanonicalProfilePath)
+    $profileArtifactPath = Join-Path $ArtifactsPath $profileArtifactFileName
     Copy-Item -LiteralPath $resolvedCanonicalProfilePath -Destination $profileArtifactPath -Force
+    $profileHashFileName = "{0}.sha256" -f [System.IO.Path]::GetFileNameWithoutExtension($profileArtifactFileName)
     [System.IO.File]::WriteAllText(
-        (Join-Path $ArtifactsPath 'canonical-il2cpp-profile.v1.sha256'),
-        "$canonicalProfileSha256  canonical-il2cpp-profile.v1.json`n"
+        (Join-Path $ArtifactsPath $profileHashFileName),
+        "$canonicalProfileSha256  $profileArtifactFileName`n"
     )
 }
 
@@ -3981,7 +5457,27 @@ Initialize-UnityCacheEnvironment -Root $RepoRoot -Version $UnityVersion -Path $C
 $UseReleaseCodeOptimization = $true
 $UseReleasePlayerBuild = $true
 
-$ProjectPath = Initialize-EphemeralProject -Root $RepoRoot -Version $UnityVersion -Mode $TestMode -Path $ProjectPath -IncludeComparisons:$IncludeComparisons -Backend $StandaloneScriptingBackend -DevelopmentBuild:(-not $UseReleasePlayerBuild) -CanonicalProfileId $canonicalProfileId -CanonicalProfileSha256 $canonicalProfileSha256 -RepoRoot $RepoRoot -ArtifactsPath $ArtifactsPath
+$ProjectPath = Initialize-EphemeralProject `
+    -Root $RepoRoot `
+    -Version $UnityVersion `
+    -Mode $TestMode `
+    -Path $ProjectPath `
+    -IncludeComparisons:$IncludeComparisons `
+    -Backend $StandaloneScriptingBackend `
+    -ManagedStrippingLevel $managedStrippingLevel `
+    -DevelopmentBuild:(-not $UseReleasePlayerBuild) `
+    -CanonicalProfileId $canonicalProfileId `
+    -CanonicalProfileSha256 $canonicalProfileSha256 `
+    -RepoRoot $RepoRoot `
+    -ArtifactsPath $ArtifactsPath
+$shippingPreResolutionManifestSha256 = ''
+if ($isShippingFidelity) {
+    $shippingPreResolutionManifestSha256 = (
+        Get-FileHash `
+            -LiteralPath (Join-Path $ProjectPath 'Packages/manifest.json') `
+            -Algorithm SHA256
+    ).Hash.ToLowerInvariant()
+}
 $LibraryPath = Join-Path $ProjectPath 'Library'
 $LibraryEntries = @(
     if (Test-Path -LiteralPath $LibraryPath -PathType Container) {
@@ -4000,6 +5496,8 @@ Write-Host "ArtifactsPath: $ArtifactsPath"
 Write-Host "IncludeComparisons: $IncludeComparisons"
 Write-Host "StandaloneScriptingBackend: $StandaloneScriptingBackend"
 Write-Host "StandalonePlayerRunCount: $StandalonePlayerRunCount"
+Write-Host "ManagedStrippingLevel: $managedStrippingLevel"
+Write-Host "IncludeTestAssemblies: $includeTestAssemblies"
 Write-Host "ReleasePlayerBuild: $UseReleasePlayerBuild"
 Write-Host "ReleaseCodeOptimization: $UseReleaseCodeOptimization"
 Write-Host "Manifest:"
@@ -4076,6 +5574,7 @@ $testPlatform = switch ($TestMode) {
     'editmode' { 'EditMode' }
     'playmode' { 'PlayMode' }
     'standalone' { 'StandaloneWindows64' }
+    'shipping' { '' }
 }
 
 $categoryArgs = @()
@@ -4108,8 +5607,18 @@ $runtimeProfileEvidencePath = Join-Path $ArtifactsPath 'runtime-profile.json'
 # it before this script's post-build assertion runs. The player still stays out
 # of $ArtifactsPath because a full IL2CPP player is hundreds of MB; only the
 # small player log and NUnit XML are uploaded.
-$standaloneExe = [System.IO.Path]::Combine($ProjectPath, 'Build', 'DxmTestPlayer', 'DxmTestPlayer.exe')
+$standaloneExe = if ($isShippingFidelity) {
+    [System.IO.Path]::Combine($ProjectPath, 'Build', 'DxmShippingPlayer', 'DxmShippingPlayer.exe')
+} else {
+    [System.IO.Path]::Combine($ProjectPath, 'Build', 'DxmTestPlayer', 'DxmTestPlayer.exe')
+}
 $playerLogPath = Join-Path $ArtifactsPath 'player.log'
+$shippingBuildMarkerPath = Join-Path $ArtifactsPath 'shipping-build-complete.marker'
+$shippingAssemblyEvidencePath = Join-Path $ArtifactsPath 'shipping-assemblies.json'
+$shippingPositiveResultPath = Join-Path $ArtifactsPath 'shipping-positive.json'
+$shippingPositiveRuntimeProfilePath = Join-Path $ArtifactsPath 'shipping-positive-runtime-profile.json'
+$shippingMutantResultPath = Join-Path $ArtifactsPath 'shipping-missing-root-mutant.json'
+$shippingMutantRuntimeProfilePath = Join-Path $ArtifactsPath 'shipping-missing-root-mutant-runtime-profile.json'
 
 # Activation/return carry the serial/email/password in their argument arrays and
 # Unity may echo account/serial fragments into the activation log, so these logs
@@ -4147,7 +5656,8 @@ try {
         Invoke-UnityLicenseActivate -EditorPath $UnityEditorPath -Serial $env:UNITY_SERIAL -Email $env:UNITY_EMAIL -Password $env:UNITY_PASSWORD -LogPath $activateLogPath
     }
 
-    if ($TestMode -eq 'standalone') {
+    if ($TestMode -eq 'standalone' -or $isShippingFidelity) {
+        $configurationScope = if ($isShippingFidelity) { 'shipping-fidelity' } else { 'standalone' }
         # CONFIGURE the standalone IL2CPP project. The CONFIGURED PROJECT (proven by
         # the success marker DxmCiTestConfigurator.Apply writes as its final action)
         # is the source of truth -- NOT Unity's process exit code. Delete any stale
@@ -4161,10 +5671,13 @@ try {
             Remove-Item -LiteralPath $configureMarkerPath -Force
         }
         $env:DXM_CONFIGURE_MARKER_PATH = $configureMarkerPath
-        if (-not [string]::IsNullOrWhiteSpace($canonicalProfileId)) {
-            if (Test-Path -LiteralPath $configuredProfileEvidencePath -PathType Leaf) {
-                Remove-Item -LiteralPath $configuredProfileEvidencePath -Force
-            }
+        if (Test-Path -LiteralPath $configuredProfileEvidencePath -PathType Leaf) {
+            Remove-Item -LiteralPath $configuredProfileEvidencePath -Force
+        }
+        if (
+            -not [string]::IsNullOrWhiteSpace($canonicalProfileId) -and
+            -not $isShippingFidelity
+        ) {
             $env:DXM_CONFIGURED_PROFILE_PATH = $configuredProfileEvidencePath
         }
         $configureStartedUtc = [DateTime]::UtcNow
@@ -4180,7 +5693,7 @@ try {
         $configureExit = Invoke-UnityEditor `
             -EditorPath $UnityEditorPath `
             -Arguments $configureArgs `
-            -Label 'Configure standalone IL2CPP project' `
+            -Label "Configure $configurationScope IL2CPP project" `
             -LogPath $configureLogPath
         # The configurator has run; drop the marker-path env var so it cannot be
         # inherited by the later build/player child processes (only Apply reads it,
@@ -4192,24 +5705,214 @@ try {
             Write-UnityRunFailureDiagnostics `
                 -Project $ProjectPath `
                 -LogPath $configureLogPath `
-                -CscLabel 'standalone configure' `
-                -DiagnosticsLabel 'Unity standalone configure'
-            throw "Configure standalone IL2CPP project failed ($configureProblem; Unity exit code $configureExit / $(Get-NativeExitCodeDescription -ExitCode $configureExit)). See the streamed Unity log above (also saved to $configureLogPath)."
+                -CscLabel "$configurationScope configure" `
+                -DiagnosticsLabel "Unity $configurationScope configure"
+            throw "Configure $configurationScope IL2CPP project failed ($configureProblem; Unity exit code $configureExit / $(Get-NativeExitCodeDescription -ExitCode $configureExit)). See the streamed Unity log above (also saved to $configureLogPath)."
         }
         if ($configureExit -ne 0) {
-            Write-UnityBenignExitWarning -Label 'Configure standalone IL2CPP project' -ExitCode $configureExit -LogPath $configureLogPath
+            Write-UnityBenignExitWarning -Label "Configure $configurationScope IL2CPP project" -ExitCode $configureExit -LogPath $configureLogPath
         }
-        Write-AnalyzerSetupDiagnostics -Project $ProjectPath -LogPath $configureLogPath -Label 'standalone configure'
-        if (-not [string]::IsNullOrWhiteSpace($canonicalProfileId)) {
+        Write-AnalyzerSetupDiagnostics -Project $ProjectPath -LogPath $configureLogPath -Label "$configurationScope configure"
+        if (
+            -not [string]::IsNullOrWhiteSpace($canonicalProfileId) -and
+            -not $isShippingFidelity
+        ) {
             & $profileValidatorPath `
                 -ProfilePath $resolvedCanonicalProfilePath `
                 -EvidencePath $configuredProfileEvidencePath `
                 -EvidenceKind configuration `
                 -ExpectedSha256 $canonicalProfileSha256
+        } elseif (
+            $isShippingFidelity -and
+            (Test-Path -LiteralPath $configuredProfileEvidencePath -PathType Leaf)
+        ) {
+            throw 'Shipping configuration must defer reviewed engine-stripping evidence to the direct player build.'
         }
     }
 
-    if ($TestMode -eq 'standalone') {
+    if ($isShippingFidelity) {
+        Write-ShippingPackageResolutionEvidence `
+            -ProjectPath $ProjectPath `
+            -ArtifactsPath $ArtifactsPath `
+            -ExpectedRepoRoot $RepoRoot `
+            -ExpectedManifestSha256 $shippingPreResolutionManifestSha256
+        # Build a stripped consumer through BuildPipeline directly. This path does
+        # not invoke Unity Test Framework, add test assemblies, or establish a
+        # PlayerConnection. The same immutable binary runs both the positive AOT
+        # root proof and the expected-failure missing-root control.
+        $shippingPositiveLogPath = Join-Path $ArtifactsPath 'shipping-positive-player.log'
+        $shippingMutantLogPath = Join-Path $ArtifactsPath 'shipping-missing-root-mutant-player.log'
+        $shippingManifestPath = Join-Path $ArtifactsPath 'shipping-player-manifest.json'
+        $shippingBuildStartedUtc = [DateTime]::UtcNow
+        foreach ($staleShippingPath in @(
+            $shippingBuildMarkerPath,
+            $shippingAssemblyEvidencePath,
+            $prebuildProfileEvidencePath,
+            $postbuildProfileEvidencePath,
+            $buildOptionsProfileEvidencePath,
+            $shippingPositiveResultPath,
+            $shippingPositiveRuntimeProfilePath,
+            $shippingMutantResultPath,
+            $shippingMutantRuntimeProfilePath,
+            $shippingPositiveLogPath,
+            $shippingMutantLogPath,
+            $shippingManifestPath
+        )) {
+            if (Test-Path -LiteralPath $staleShippingPath -PathType Leaf) {
+                Remove-Item -LiteralPath $staleShippingPath -Force
+            }
+        }
+        $standaloneExeDir = Split-Path -Parent $standaloneExe
+        if ($standaloneExeDir -and (Test-Path -LiteralPath $standaloneExeDir -PathType Container)) {
+            Remove-Item -LiteralPath $standaloneExeDir -Recurse -Force
+        }
+        if ($standaloneExeDir) {
+            New-Item -ItemType Directory -Force -Path $standaloneExeDir | Out-Null
+        }
+
+        $env:DXM_PLAYER_BUILD_PATH = $standaloneExe
+        $env:DXM_SHIPPING_BUILD_MARKER_PATH = $shippingBuildMarkerPath
+        $env:DXM_SHIPPING_ASSEMBLY_EVIDENCE_PATH = $shippingAssemblyEvidencePath
+        $env:DXM_PREBUILD_CONFIG_PROFILE_PATH = $prebuildProfileEvidencePath
+        $env:DXM_POSTBUILD_CONFIG_PROFILE_PATH = $postbuildProfileEvidencePath
+        $env:DXM_BUILD_OPTIONS_PROFILE_PATH = $buildOptionsProfileEvidencePath
+        $shippingBuildArgs = @(
+            '-quit',
+            '-batchmode',
+            '-nographics',
+            '-projectPath', $ProjectPath,
+            '-buildTarget', 'StandaloneWindows64',
+            '-executeMethod', 'DxmShippingFidelityBuilder.Build',
+            '-releaseCodeOptimization',
+            '-logFile', '-'
+        ) + $acceleratorArgs
+        $shippingBuildResult = Invoke-ProcessWithTreeKillTimeout `
+            -FilePath $UnityEditorPath `
+            -Arguments $shippingBuildArgs `
+            -TimeoutSeconds (Get-StandaloneBuildTimeoutSeconds) `
+            -LogPath $logPath `
+            -Label "Build shipping-fidelity IL2CPP player (Unity $UnityVersion)"
+        foreach ($buildEnvironmentVariable in @(
+            'DXM_SHIPPING_BUILD_MARKER_PATH',
+            'DXM_SHIPPING_ASSEMBLY_EVIDENCE_PATH',
+            'DXM_BUILD_OPTIONS_PROFILE_PATH',
+            'DXM_PREBUILD_CONFIG_PROFILE_PATH',
+            'DXM_POSTBUILD_CONFIG_PROFILE_PATH'
+        )) {
+            Remove-Item -LiteralPath "Env:\$buildEnvironmentVariable" -ErrorAction SilentlyContinue
+        }
+
+        $shippingMarkerProblem = Test-UnityConfigureMarker `
+            -MarkerPath $shippingBuildMarkerPath `
+            -StartedUtc $shippingBuildStartedUtc
+        $shippingBuildProblem = Test-StandalonePlayerBuildOutput `
+            -ExpectedExe $standaloneExe `
+            -BuildStartedUtc $shippingBuildStartedUtc
+        if (
+            -not [string]::IsNullOrWhiteSpace($shippingMarkerProblem) -or
+            -not [string]::IsNullOrWhiteSpace($shippingBuildProblem)
+        ) {
+            Write-UnityRunFailureDiagnostics `
+                -Project $ProjectPath `
+                -LogPath $logPath `
+                -CscLabel "$UnityVersion shipping-fidelity build" `
+                -DiagnosticsLabel "Unity $UnityVersion shipping-fidelity build"
+            Write-StandaloneBuildOutputDiagnostics `
+                -Project $ProjectPath `
+                -ExpectedExe $standaloneExe `
+                -LogPath $logPath `
+                -BuildStartedUtc $shippingBuildStartedUtc
+            throw "Shipping-fidelity build did not produce fresh complete evidence (marker: $shippingMarkerProblem; player: $shippingBuildProblem; exit code $($shippingBuildResult.ExitCode))."
+        }
+        if ($shippingBuildResult.TimedOut -or $shippingBuildResult.ExitCode -ne 0) {
+            Write-UnityBenignExitWarning `
+                -Label "Build shipping-fidelity IL2CPP player (Unity $UnityVersion)" `
+                -ExitCode $shippingBuildResult.ExitCode `
+                -TimedOut:$shippingBuildResult.TimedOut `
+                -LogPath $logPath
+        }
+        foreach ($shippingBuildConfigurationPath in @(
+            $prebuildProfileEvidencePath,
+            $postbuildProfileEvidencePath
+        )) {
+            & $profileValidatorPath `
+                -ProfilePath $resolvedCanonicalProfilePath `
+                -EvidencePath $shippingBuildConfigurationPath `
+                -EvidenceKind configuration `
+                -ExpectedSha256 $canonicalProfileSha256
+        }
+        & $profileValidatorPath `
+            -ProfilePath $resolvedCanonicalProfilePath `
+            -EvidencePath $buildOptionsProfileEvidencePath `
+            -EvidenceKind buildOptions `
+            -ExpectedSha256 $canonicalProfileSha256
+        Test-ShippingAssemblyEvidence `
+            -Path $shippingAssemblyEvidencePath `
+            -ExpectedProfileId $canonicalProfileId `
+            -ExpectedProfileSha256 $canonicalProfileSha256 `
+            -ExpectedUnityVersion $UnityVersion
+
+        $shippingManifestBefore = Get-StandalonePlayerManifest -ExecutablePath $standaloneExe
+        $shippingRuns = @(
+            [ordered]@{
+                Mode = 'positive'
+                ResultPath = $shippingPositiveResultPath
+                RuntimePath = $shippingPositiveRuntimeProfilePath
+                LogPath = $shippingPositiveLogPath
+            },
+            [ordered]@{
+                Mode = 'missing-root-mutant'
+                ResultPath = $shippingMutantResultPath
+                RuntimePath = $shippingMutantRuntimeProfilePath
+                LogPath = $shippingMutantLogPath
+            }
+        )
+        $shippingPlayerTimeoutSeconds = Get-StandaloneTestPlayerTimeoutSeconds
+        foreach ($shippingRun in $shippingRuns) {
+            $shippingPlayerResult = Invoke-ShippingFidelityPlayer `
+                -ExecutablePath $standaloneExe `
+                -Mode $shippingRun.Mode `
+                -ResultPath $shippingRun.ResultPath `
+                -RuntimeProfilePath $shippingRun.RuntimePath `
+                -LogPath $shippingRun.LogPath `
+                -TimeoutSeconds $shippingPlayerTimeoutSeconds
+            Test-ShippingFidelityResult `
+                -Path $shippingRun.ResultPath `
+                -ExpectedMode $shippingRun.Mode `
+                -ExpectedProfileId $canonicalProfileId `
+                -ExpectedProfileSha256 $canonicalProfileSha256 `
+                -ExpectedUnityVersion $UnityVersion
+            & $profileValidatorPath `
+                -ProfilePath $resolvedCanonicalProfilePath `
+                -EvidencePath $shippingRun.RuntimePath `
+                -EvidenceKind runtime `
+                -ExpectedSha256 $canonicalProfileSha256
+            if ($shippingPlayerResult.TimedOut -or $shippingPlayerResult.ExitCode -ne 0) {
+                Write-UnityBenignExitWarning `
+                    -Label "Run shipping-fidelity player ($($shippingRun.Mode))" `
+                    -ExitCode $shippingPlayerResult.ExitCode `
+                    -TimedOut:$shippingPlayerResult.TimedOut `
+                    -LogPath $shippingRun.LogPath
+            }
+        }
+
+        $shippingManifestAfter = Get-StandalonePlayerManifest -ExecutablePath $standaloneExe
+        $shippingManifestMatches = (
+            ($shippingManifestBefore | ConvertTo-Json -Depth 10 -Compress) -ceq
+            ($shippingManifestAfter | ConvertTo-Json -Depth 10 -Compress)
+        )
+        Write-JsonArtifact -Path $shippingManifestPath -Value ([ordered]@{
+                schemaVersion = 1
+                playerDirectoryManifestMatches = $shippingManifestMatches
+                playerDirectoryManifestBefore = $shippingManifestBefore
+                playerDirectoryManifestAfter = $shippingManifestAfter
+                runs = @('positive', 'missing-root-mutant')
+            })
+        if (-not $shippingManifestMatches) {
+            throw 'Shipping player directory manifest changed between the positive and missing-root-mutant runs.'
+        }
+        Write-CiNotice 'Shipping-fidelity player passed positive AOT dispatch and the missing-root mutant with an unchanged stripped binary.'
+    } elseif ($TestMode -eq 'standalone') {
         # STANDALONE SPLIT BUILD + FILE-BASED RESULTS (zero PlayerConnection
         # dependency). The legacy `-runTests -testPlatform StandaloneWindows64` flow
         # had the built player stream NUnit results back to the editor over
@@ -4540,7 +6243,9 @@ try {
         'DXM_PREBUILD_CONFIG_PROFILE_PATH',
         'DXM_POSTBUILD_CONFIG_PROFILE_PATH',
         'DXM_BUILD_OPTIONS_PROFILE_PATH',
-        'DXM_PLAYER_BUILD_PATH'
+        'DXM_PLAYER_BUILD_PATH',
+        'DXM_SHIPPING_BUILD_MARKER_PATH',
+        'DXM_SHIPPING_ASSEMBLY_EVIDENCE_PATH'
     )) {
         Remove-Item -LiteralPath "Env:\$temporaryEnvironmentVariable" -ErrorAction SilentlyContinue
     }

--- a/scripts/unity/validate-il2cpp-profile.ps1
+++ b/scripts/unity/validate-il2cpp-profile.ps1
@@ -83,24 +83,24 @@ function Assert-EquivalentJsonValue {
     throw "$Path uses an unsupported profile value type '$($Expected.GetType().FullName)'."
 }
 
-$profile = Get-RequiredJsonObject -Path $ProfilePath -Label 'Canonical IL2CPP profile'
+$profile = Get-RequiredJsonObject -Path $ProfilePath -Label 'IL2CPP profile'
 
 Assert-ExactProperties `
     -Value $profile `
     -Expected @('schemaVersion', 'profileId', 'configuration', 'buildOptions', 'runtime') `
-    -Label 'Canonical IL2CPP profile'
+    -Label 'IL2CPP profile'
 
 if (
     ($profile.schemaVersion -isnot [int] -and $profile.schemaVersion -isnot [long]) -or
     [long]$profile.schemaVersion -ne 1
 ) {
-    throw "Unsupported canonical IL2CPP profile schemaVersion '$($profile.schemaVersion)'."
+    throw "Unsupported IL2CPP profile schemaVersion '$($profile.schemaVersion)'."
 }
 if (
     $profile.profileId -isnot [string] -or
     $profile.profileId -cnotmatch '^[a-z0-9][a-z0-9-]*-v1$'
 ) {
-    throw "Invalid canonical IL2CPP profileId '$($profile.profileId)'."
+    throw "Invalid IL2CPP profileId '$($profile.profileId)'."
 }
 
 $profileSchemas = [ordered]@{
@@ -135,16 +135,78 @@ foreach ($group in $profileSchemas.Keys) {
     Assert-ExactProperties `
         -Value $profile.$group `
         -Expected @($profileSchemas[$group].Keys) `
-        -Label "Canonical IL2CPP profile $group"
+        -Label "IL2CPP profile $group"
     foreach ($property in $profile.$group.PSObject.Properties) {
         $expectedType = $profileSchemas[$group][$property.Name]
         if ($expectedType -eq 'bool' -and $property.Value -isnot [bool]) {
-            throw "Canonical IL2CPP profile $group.$($property.Name) must be a Boolean."
+            throw "IL2CPP profile $group.$($property.Name) must be a Boolean."
         }
         if ($expectedType -eq 'string' -and $property.Value -isnot [string]) {
-            throw "Canonical IL2CPP profile $group.$($property.Name) must be a string."
+            throw "IL2CPP profile $group.$($property.Name) must be a string."
         }
     }
+}
+
+$fixedProfileValues = [ordered]@{
+    configuration = [ordered]@{
+        buildTarget = 'StandaloneWindows64'
+        scriptingBackend = 'IL2CPP'
+        apiCompatibilityLevel = 'NET_Standard_2_0'
+        codeOptimization = 'Release'
+        il2cppCompilerConfiguration = 'Release'
+        il2cppCodeGeneration = 'OptimizeSpeed'
+        incrementalGc = $true
+        stripEngineCode = $true
+    }
+    buildOptions = [ordered]@{
+        developmentBuild = $false
+        allowDebugging = $false
+        deepProfiling = $false
+        enableAssertions = $false
+        autoRunPlayer = $false
+        connectToHost = $false
+        connectWithProfiler = $false
+        cleanBuildCache = $true
+        detailedBuildReport = $true
+    }
+    runtime = [ordered]@{
+        debugBuild = $false
+    }
+}
+foreach ($group in $fixedProfileValues.Keys) {
+    foreach ($property in $fixedProfileValues[$group].Keys) {
+        Assert-EquivalentJsonValue `
+            -Expected $fixedProfileValues[$group][$property] `
+            -Actual $profile.$group.$property `
+            -Path "profile.$group.$property"
+    }
+}
+
+$profileVariants = [ordered]@{
+    'canonical-il2cpp-verdict-player-v1' = [ordered]@{
+        managedStrippingLevel = 'Disabled'
+        includeTestAssemblies = $true
+    }
+    'shipping-fidelity-il2cpp-player-v1' = [ordered]@{
+        managedStrippingLevel = 'High'
+        includeTestAssemblies = $false
+    }
+}
+if (-not $profileVariants.Contains($profile.profileId)) {
+    $supportedProfileIds = @($profileVariants.Keys) -join "', '"
+    throw "Unsupported IL2CPP profileId '$($profile.profileId)'. Supported profileIds: '$supportedProfileIds'."
+}
+$selectedVariant = $profileVariants[$profile.profileId]
+foreach ($variantProperty in $selectedVariant.Keys) {
+    $variantGroup = if ($variantProperty -ceq 'managedStrippingLevel') {
+        'configuration'
+    } else {
+        'buildOptions'
+    }
+    Assert-EquivalentJsonValue `
+        -Expected $selectedVariant[$variantProperty] `
+        -Actual $profile.$variantGroup.$variantProperty `
+        -Path "profile.$variantGroup.$variantProperty"
 }
 
 $profileSha256 = (Get-FileHash -LiteralPath $ProfilePath -Algorithm SHA256).Hash.ToLowerInvariant()
@@ -152,14 +214,14 @@ if (
     -not [string]::IsNullOrWhiteSpace($ExpectedSha256) -and
     $profileSha256 -cne $ExpectedSha256.ToLowerInvariant()
 ) {
-    throw "Canonical IL2CPP profile SHA-256 differs (expected=$($ExpectedSha256.ToLowerInvariant()), actual=$profileSha256)."
+    throw "IL2CPP profile SHA-256 differs (expected=$($ExpectedSha256.ToLowerInvariant()), actual=$profileSha256)."
 }
 
 if ($ProfileOnly) {
     if (-not [string]::IsNullOrWhiteSpace($EvidencePath) -or -not [string]::IsNullOrWhiteSpace($EvidenceKind)) {
         throw 'Do not pass EvidencePath or EvidenceKind with ProfileOnly.'
     }
-    Write-Host "Validated canonical IL2CPP profile $($profile.profileId) ($profileSha256)."
+    Write-Host "Validated IL2CPP profile $($profile.profileId) ($profileSha256)."
     return
 }
 if ([string]::IsNullOrWhiteSpace($EvidencePath) -or [string]::IsNullOrWhiteSpace($EvidenceKind)) {

--- a/scripts/validate-unity-pr-policy.py
+++ b/scripts/validate-unity-pr-policy.py
@@ -2604,12 +2604,44 @@ def validate_grouped_unity_correctness() -> None:
             f"{mode}: artifact evidence must remain isolated",
         )
     require(run_positions == sorted(run_positions), "grouped Unity modes must run in order")
-    require(job.count("-LicenseReturnOwner Central") == 3, "every grouped mode needs central cleanup")
+
+    shipping = step_block(job, "Run stripped shipping-fidelity player")
+    run_positions.append(job.index(shipping))
+    for fragment in (
+        "id: run_shipping",
+        "!cancelled()",
+        "steps.acquire_lock.outputs.acquired == 'true'",
+        "matrix.unity-version == '2021.3.45f1'",
+        "matrix.unity-version == '6000.5.2f1'",
+        "continue-on-error: true",
+        "timeout-minutes: 150",
+        "-TestMode shipping",
+        "-AssemblyNames ''",
+        "-CanonicalProfilePath '.github/perf/shipping-fidelity-il2cpp-profile.v1.json'",
+        "-LicenseReturnOwner Central",
+    ):
+        require(fragment in shipping, f"shipping: grouped run missing {fragment!r}")
+    require(
+        run_positions == sorted(run_positions),
+        "shipping fidelity must run after the grouped Unity test modes",
+    )
+    shipping_upload = step_block(job, "Upload shipping-fidelity artifacts")
+    require(
+        "if-no-files-found: error" in shipping_upload
+        and "!cancelled()" in shipping_upload
+        and "steps.acquire_lock.outputs.acquired == 'true'" in shipping_upload
+        and "unity-${{ matrix.unity-version }}-shipping" in shipping_upload
+        and ".artifacts/unity/${{ matrix.unity-version }}-shipping" in shipping_upload,
+        "shipping fidelity must upload isolated evidence after lock acquisition, skip cancellation, and fail when it is absent",
+    )
+    require(job.count("-LicenseReturnOwner Central") == 4, "every grouped mode needs central cleanup")
 
     gate = step_block(job, "Require every Unity mode to pass")
     require(
         "!cancelled() && steps.acquire_lock.outputs.acquired == 'true'" in gate
         and "Empty -eq 'true' -and $mode.Run -ne 'skipped'" in gate
+        and "$env:SHIPPING_REQUIRED -eq 'true'" in gate
+        and "$env:SHIPPING_RUN -ne 'success'" in gate
         and 'throw "Unity mode failures:' in gate,
         "grouped mode gate must fail closed on run, skip, and verification outcomes",
     )
@@ -2618,6 +2650,7 @@ def validate_grouped_unity_correctness() -> None:
             "EDIT_COMPUTE": "success", "EDIT_EMPTY": "false", "EDIT_RUN": "success", "EDIT_VERIFY": "success",
             "PLAY_COMPUTE": "success", "PLAY_EMPTY": "false", "PLAY_RUN": "success", "PLAY_VERIFY": "success",
             "STANDALONE_COMPUTE": "success", "STANDALONE_EMPTY": "false", "STANDALONE_RUN": "success", "STANDALONE_VERIFY": "success",
+            "SHIPPING_REQUIRED": "true", "SHIPPING_RUN": "success",
         }
         cases = (
             ("all modes pass", {}, 0),
@@ -2626,6 +2659,9 @@ def validate_grouped_unity_correctness() -> None:
             ("nonempty run skips", {"PLAY_RUN": "skipped"}, 1),
             ("empty mode runs", {"EDIT_EMPTY": "true"}, 1),
             ("verification fails", {"STANDALONE_VERIFY": "failure"}, 1),
+            ("required shipping fails", {"SHIPPING_RUN": "failure"}, 1),
+            ("non-target shipping skips", {"SHIPPING_REQUIRED": "false", "SHIPPING_RUN": "skipped"}, 0),
+            ("non-target shipping runs", {"SHIPPING_REQUIRED": "false"}, 1),
         )
         for name, mutation, expected in cases:
             environment = os.environ.copy()


### PR DESCRIPTION
## Why

The canonical test player includes test assemblies and disables managed stripping. It cannot prove generated AOT roots survive a production-shaped IL2CPP build.

## What changed

- Add a separate High-stripping Release profile with no test assemblies.
- Build an Assembly-CSharp consumer directly without Unity Test Framework.
- Exercise 18 message shapes before registration and through typed and untyped delivery.
- Keep a private missing-root message as the negative control.
- Bind evidence to exact inputs, package resolution, player assemblies, profile values, and binary hashes.
- Run the player on Unity 2021.3 and the current Unity editor.
- Keep the runtime settings assembly independent of the optional IMGUI module by hosting its asset-creation menu in the editor assembly.

## How we know

- The script suite passes 518 tests.
- Source-generator tests pass 257 cases.
- Documentation compilation tests pass 616 cases.
- Mutation tests reject stale inputs, linked-path cleanup, type drift, shape omissions, and wrong package roots.
- Repository validation, formatting, spelling, actionlint, yamllint, and pre-commit checks pass.
- The final head passes hosted CI, devcontainer validation, all four Unity jobs, both stripped-player endpoints, and both performance jobs.
- Two final adversarial reviews report zero actionable findings.

## Remaining scope

This advances #506 without closing it. Other stripping levels, larger topologies, timing, size, and native-output retention remain separate work.

Refs #506

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches licensed CI timing and a new IL2CPP correctness path, plus a runtime assembly reference change that affects stripped consumer builds; mitigated by endpoint-only matrix scope and extensive contract tests.
> 
> **Overview**
> Adds a **shipping-fidelity** CI leg that builds a second **High-stripping, test-free IL2CPP Release player** via `BuildPipeline` (not Unity Test Framework), driven by `.github/perf/shipping-fidelity-il2cpp-profile.v1.json` and `-TestMode shipping` in `run-ci-tests.ps1`. **Unity Tests** runs it on the oldest and newest matrix editors (`2021.3.45f1`, `6000.5.2f1`), extends the job timeout to **1050** minutes, uploads/fails on missing shipping artifacts, folds shipping into the terminal mode gate, and dumps logs on failure.
> 
> **Runtime compile fix:** editor-only **Resources** menu creation moves from `DxMessagingRuntimeSettings` into `Editor/Settings/DxMessagingRuntimeSettingsCreator.cs` so the runtime assembly no longer pulls **UnityEngine.IMGUIModule**—required for stripped 2021.3 projects ([#515]). New editor contract tests lock that dependency split.
> 
> **Diagnostics:** `dump-unity-log-tail` tails every `*.log` under the results dir (e.g. `player.log`, shipping process logs), not only `unity.log`, while deduping the primary log.
> 
> Docs/skills/runbooks, CHANGELOG, workflow policy tests, and a large `shipping-fidelity.test.ps1` contract suite document and enforce profile evidence, shape inventory, package resolution, and project reuse behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8a8a0d90723537cdc54eb0b413364e7d4ac8754. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->