### PR TITLE
Fix compiler options and inspector startup; verify foreign handles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix project base-call ignore wiring and preserve consumer compiler options during cleanup
   ([#537](https://github.com/Ambiguous-Interactive/DxMessaging/issues/537),
   [#538](https://github.com/Ambiguous-Interactive/DxMessaging/issues/538)).
-
+- Keep the Inspector's empty warning area hidden while its first refresh waits for imports
+  ([#540](https://github.com/Ambiguous-Interactive/DxMessaging/issues/540)).
 - Fix corrupted boxed struct payloads and IL2CPP failures when emitting registered manual messages
   through untyped dispatch ([#527](https://github.com/Ambiguous-Interactive/DxMessaging/issues/527),
   [#529](https://github.com/Ambiguous-Interactive/DxMessaging/issues/529)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,9 +35,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix project base-call ignore wiring and preserve consumer compiler options during cleanup
+- Fix base-call ignore compiler wiring and batch preparation while preserving consumer options
   ([#537](https://github.com/Ambiguous-Interactive/DxMessaging/issues/537),
-  [#538](https://github.com/Ambiguous-Interactive/DxMessaging/issues/538)).
+  [#538](https://github.com/Ambiguous-Interactive/DxMessaging/issues/538),
+  [#541](https://github.com/Ambiguous-Interactive/DxMessaging/issues/541)).
 - Keep the Inspector's empty warning area hidden while its first refresh waits for imports
   ([#540](https://github.com/Ambiguous-Interactive/DxMessaging/issues/540)).
 - Fix corrupted boxed struct payloads and IL2CPP failures when emitting registered manual messages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix project base-call ignore wiring and preserve consumer compiler options during cleanup
+  ([#537](https://github.com/Ambiguous-Interactive/DxMessaging/issues/537),
+  [#538](https://github.com/Ambiguous-Interactive/DxMessaging/issues/538)).
+
 - Fix corrupted boxed struct payloads and IL2CPP failures when emitting registered manual messages
   through untyped dispatch ([#527](https://github.com/Ambiguous-Interactive/DxMessaging/issues/527),
   [#529](https://github.com/Ambiguous-Interactive/DxMessaging/issues/529)).

--- a/Editor/CustomEditors/MessageAwareComponentFallbackEditor.cs
+++ b/Editor/CustomEditors/MessageAwareComponentFallbackEditor.cs
@@ -129,6 +129,8 @@ namespace DxMessaging.Editor.CustomEditors
             root.AddToClassList(RootClassName);
 
             VisualElement warningHost = new() { name = WarningHostName };
+            // The first resolution may defer while Unity imports; an empty host stays hidden.
+            warningHost.style.display = DisplayStyle.None;
             warningHost.AddToClassList(WarningHostClassName);
             root.Add(warningHost);
 

--- a/Editor/Settings/DxMessagingBaseCallIgnoreSync.cs
+++ b/Editor/Settings/DxMessagingBaseCallIgnoreSync.cs
@@ -26,6 +26,8 @@ namespace DxMessaging.Editor.Settings
         /// </summary>
         public const string SidecarAssetPath = "Assets/Editor/DxMessaging.BaseCallIgnore.txt";
 
+        internal static bool SidecarImportPending;
+
         private const string HeaderComment =
             "# Auto-generated from Assets/Editor/DxMessagingSettings.asset; edit there instead.";
         private const string FormatComment =
@@ -187,24 +189,9 @@ namespace DxMessaging.Editor.Settings
             {
                 return;
             }
-
             try
             {
-                string newContent = BuildContent(settings._baseCallIgnoredTypes);
-                string absolutePath = GetAbsolutePath();
-                EnsureParentDirectoryExists(absolutePath);
-
-                if (File.Exists(absolutePath))
-                {
-                    string existing = File.ReadAllText(absolutePath);
-                    if (string.Equals(existing, newContent, StringComparison.Ordinal))
-                    {
-                        return;
-                    }
-                }
-
-                File.WriteAllText(absolutePath, newContent);
-                AssetDatabase.ImportAsset(SidecarAssetPath);
+                RegenerateSidecarOrThrow(settings);
             }
             catch (Exception ex)
             {
@@ -212,6 +199,52 @@ namespace DxMessaging.Editor.Settings
                     $"Failed to write base-call ignore sidecar at '{SidecarAssetPath}'.",
                     ex
                 );
+            }
+        }
+
+        internal static void RegenerateSidecarOrThrow(DxMessagingSettings settings)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+            WriteSidecarOrThrow(
+                GetAbsolutePath(),
+                settings._baseCallIgnoredTypes,
+                path => AssetDatabase.ImportAsset(path),
+                ref SidecarImportPending
+            );
+        }
+
+        internal static void WriteSidecarOrThrow(
+            string absolutePath,
+            IList<string> ignoredTypes,
+            Action<string> importAsset,
+            ref bool importPending
+        )
+        {
+            string newContent = BuildContent(ignoredTypes);
+            EnsureParentDirectoryExists(absolutePath);
+            if (
+                !File.Exists(absolutePath)
+                || !string.Equals(
+                    File.ReadAllText(absolutePath),
+                    newContent,
+                    StringComparison.Ordinal
+                )
+            )
+            {
+                DxMessaging.Editor.SetupCscRsp.WriteTextFileAtomically(
+                    absolutePath,
+                    newContent,
+                    new UTF8Encoding(false)
+                );
+                importPending = true;
+            }
+            if (importPending)
+            {
+                importAsset(SidecarAssetPath);
+                importPending = false;
             }
         }
 

--- a/Editor/SetupCscRsp.cs
+++ b/Editor/SetupCscRsp.cs
@@ -6,6 +6,7 @@ namespace DxMessaging.Editor
     using System.Collections.Generic;
     using System.IO;
     using System.Text;
+    using System.Threading;
     using DxMessaging.Editor.Settings;
     using UnityEditor;
     using UnityEngine;
@@ -15,6 +16,7 @@ namespace DxMessaging.Editor
     {
         internal const string RspAssetPath = "Assets/csc.rsp";
         private static bool responseFileImportPending;
+        private static readonly int EditorThreadId = Thread.CurrentThread.ManagedThreadId;
 
         // Older package versions copied the analyzer + Roslyn runtime DLLs into the consumer
         // project here so the source generator applied project-wide. The generator now ships
@@ -66,6 +68,110 @@ namespace DxMessaging.Editor
                 "remove redundant in-project analyzer copy"
             );
             ScheduleAdditionalFileForIgnoreListSync();
+        }
+
+        /// <summary>
+        /// Saves the settings and compiler inputs before a separate batch build or test process starts.
+        /// </summary>
+        /// <remarks>
+        /// Call from an idle editor configuration entry point before changing player settings.
+        /// Do not call from InitializeOnLoad, OnValidate, or other asset-import callbacks.
+        /// This method writes and imports the ignore sidecar and response file synchronously;
+        /// Unity can then compile the changed inputs. Let the configuration process finish before
+        /// starting the build process. Preparation failures propagate to the caller, which must
+        /// not report configuration success. Pending import retries last only within this domain.
+        /// </remarks>
+        /// <exception cref="InvalidOperationException">The editor is not idle on its main thread.</exception>
+        /// <example>
+        /// <code>
+        /// public static void ConfigureProject()
+        /// {
+        ///     DxMessaging.Editor.SetupCscRsp.PrepareCompilerInputs();
+        ///     // Apply player settings in this configuration process, then exit it.
+        /// }
+        /// </code>
+        /// </example>
+        public static void PrepareCompilerInputs()
+        {
+            bool canPrepare =
+                Thread.CurrentThread.ManagedThreadId == EditorThreadId
+                && DxMessagingEditorIdle.CanMutateAssetDatabase()
+                && !EditorApplication.isPlayingOrWillChangePlaymode
+                && !BuildPipeline.isBuildingPlayer
+                && !AssetDatabase.IsAssetImportWorkerProcess();
+            PrepareCompilerInputs(
+                canPrepare,
+                () =>
+                {
+                    DxMessagingSettings settings = DxMessagingSettings.GetOrCreateSettings();
+                    DxMessagingBaseCallIgnoreSync.RegenerateSidecarOrThrow(settings);
+                },
+                EnsureCscRsp,
+                AssetDatabase.StartAssetEditing,
+                AssetDatabase.StopAssetEditing,
+                ref DxMessagingBaseCallIgnoreSync.SidecarImportPending,
+                ref responseFileImportPending
+            );
+        }
+
+        internal static void PrepareCompilerInputs(
+            bool canPrepare,
+            Action prepareSidecar,
+            Action prepareResponseFile,
+            Action startAssetEditing,
+            Action stopAssetEditing,
+            ref bool sidecarImportPending,
+            ref bool rspImportPending
+        )
+        {
+            if (!canPrepare)
+            {
+                throw new InvalidOperationException(
+                    "PrepareCompilerInputs requires an idle main-thread editor configuration phase."
+                );
+            }
+            try
+            {
+                startAssetEditing();
+                Exception preparationFailure = null;
+                try
+                {
+                    prepareSidecar();
+                    prepareResponseFile();
+                }
+                catch (Exception ex)
+                {
+                    preparationFailure = ex;
+                    throw;
+                }
+                finally
+                {
+                    try
+                    {
+                        stopAssetEditing();
+                    }
+                    catch (Exception stopFailure)
+                    {
+                        if (preparationFailure != null)
+                        {
+                            throw new AggregateException(
+                                "Compiler input preparation and asset import completion both failed.",
+                                preparationFailure,
+                                stopFailure
+                            );
+                        }
+                        throw;
+                    }
+                }
+            }
+            catch
+            {
+                // ImportAsset calls inside the batch only enqueue imports. StopAssetEditing can
+                // fail after either file was written, so preserve both imports for an explicit retry.
+                sidecarImportPending = true;
+                rspImportPending = true;
+                throw;
+            }
         }
 
         internal static void ScheduleAdditionalFileForIgnoreListSync()
@@ -420,13 +526,18 @@ namespace DxMessaging.Editor
 
         private static void WriteResponseFile(string path, string[] lines, Encoding encoding)
         {
+            WriteTextFileAtomically(path, string.Concat(lines), encoding);
+        }
+
+        internal static void WriteTextFileAtomically(string path, string content, Encoding encoding)
+        {
             string temporaryPath = Path.Combine(
                 Path.GetDirectoryName(path),
-                $".csc.rsp.{Guid.NewGuid():N}.tmp"
+                $".{Path.GetFileName(path)}.{Guid.NewGuid():N}.tmp"
             );
             try
             {
-                File.WriteAllText(temporaryPath, string.Concat(lines), encoding);
+                File.WriteAllText(temporaryPath, content, encoding);
                 if (File.Exists(path))
                 {
                     File.Replace(temporaryPath, path, null);

--- a/Editor/SetupCscRsp.cs
+++ b/Editor/SetupCscRsp.cs
@@ -5,6 +5,7 @@ namespace DxMessaging.Editor
     using System;
     using System.Collections.Generic;
     using System.IO;
+    using System.Text;
     using DxMessaging.Editor.Settings;
     using UnityEditor;
     using UnityEngine;
@@ -12,12 +13,8 @@ namespace DxMessaging.Editor
     [InitializeOnLoad]
     public static class SetupCscRsp
     {
-        private static readonly string RspFilePath = Path.Combine(
-                Application.dataPath,
-                "..",
-                "csc.rsp"
-            )
-            .Replace("\\", "/");
+        internal const string RspAssetPath = "Assets/csc.rsp";
+        private static bool responseFileImportPending;
 
         // Older package versions copied the analyzer + Roslyn runtime DLLs into the consumer
         // project here so the source generator applied project-wide. The generator now ships
@@ -68,16 +65,12 @@ namespace DxMessaging.Editor
                 () => TryRemoveLegacyAnalyzerCopy(),
                 "remove redundant in-project analyzer copy"
             );
-            ScheduleSetupStep(EnsureCscRsp, "clean csc.rsp analyzer entries");
             ScheduleAdditionalFileForIgnoreListSync();
         }
 
         internal static void ScheduleAdditionalFileForIgnoreListSync()
         {
-            ScheduleSetupStep(
-                EnsureAdditionalFileForIgnoreList,
-                "sync csc.rsp base-call ignore additionalfile entry"
-            );
+            ScheduleSetupStep(EnsureCscRsp, "sync Assets/csc.rsp compiler options");
         }
 
         private static void ScheduleSetupStep(Action work, string description)
@@ -295,36 +288,160 @@ namespace DxMessaging.Editor
         /// </remarks>
         private static void EnsureCscRsp()
         {
-            try
+            SynchronizeResponseFiles(
+                Application.dataPath,
+                path => AssetDatabase.ImportAsset(path),
+                ref responseFileImportPending
+            );
+        }
+
+        internal static string GetRspFilePath(string assetsDirectory)
+        {
+            return Path.Combine(assetsDirectory, "csc.rsp").Replace("\\", "/");
+        }
+
+        internal static void SynchronizeResponseFiles(
+            string assetsDirectory,
+            Action<string> importAsset,
+            ref bool importPending
+        )
+        {
+            string rspPath = GetRspFilePath(assetsDirectory);
+            string projectRoot = Path.GetFullPath(Path.Combine(assetsDirectory, ".."));
+            string legacyRspPath = Path.Combine(projectRoot, "csc.rsp");
+            string sidecarPath = DxMessagingBaseCallIgnoreSync.SidecarAssetPath;
+            bool sidecarExists = File.Exists(Path.Combine(projectRoot, sidecarPath));
+
+            string[] assetLines = ReadResponseFile(rspPath, out Encoding assetEncoding);
+            string newline = FindNewline(assetLines);
+            assetLines = CleanDxMessagingAnalyzerLines(assetLines, out bool removedAnalyzers);
+            assetLines = SynchronizeAdditionalFileForIgnoreListLines(
+                assetLines,
+                sidecarPath,
+                sidecarExists,
+                out bool changedSidecar,
+                newline
+            );
+
+            // Only remove package-managed options from the old root file. Moving unrelated
+            // options to Assets would activate compiler settings Unity previously ignored.
+            string[] legacyLines = ReadResponseFile(legacyRspPath, out Encoding legacyEncoding);
+            legacyLines = CleanDxMessagingAnalyzerLines(
+                legacyLines,
+                out bool removedLegacyAnalyzers
+            );
+            legacyLines = SynchronizeAdditionalFileForIgnoreListLines(
+                legacyLines,
+                sidecarPath,
+                false,
+                out bool removedLegacySidecar
+            );
+
+            if (removedAnalyzers || changedSidecar)
             {
-                if (!File.Exists(RspFilePath))
+                WriteResponseFile(rspPath, assetLines, assetEncoding);
+                importPending = true;
+            }
+
+            // Keep an unsuccessful import pending even if the file was already written. The
+            // next scheduled sync must retry the import without rewriting unchanged contents.
+            if (importPending)
+            {
+                importAsset(RspAssetPath);
+                importPending = false;
+            }
+
+            // Do not retire the old wiring until the destination write and import succeeded.
+            if (removedLegacyAnalyzers || removedLegacySidecar)
+            {
+                if (string.IsNullOrWhiteSpace(string.Concat(legacyLines)))
                 {
-                    return;
+                    File.Delete(legacyRspPath);
                 }
-
-                string rspContent = File.ReadAllText(RspFilePath);
-
-                string[] newLines = CleanDxMessagingAnalyzerLines(
-                    rspContent.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries),
-                    out bool foundStaleEntries
-                );
-
-                if (foundStaleEntries)
+                else
                 {
-                    // Write the cleaned up content
-                    string newContent = string.Join(Environment.NewLine, newLines);
-                    if (!string.IsNullOrEmpty(newContent))
-                    {
-                        newContent += Environment.NewLine;
-                    }
-                    File.WriteAllText(RspFilePath, newContent);
-                    AssetDatabase.ImportAsset("csc.rsp");
-                    Debug.Log("Updated csc.rsp.");
+                    WriteResponseFile(legacyRspPath, legacyLines, legacyEncoding);
                 }
             }
-            catch (IOException ex)
+        }
+
+        private static string[] ReadResponseFile(string path, out Encoding encoding)
+        {
+            encoding = new UTF8Encoding(false, true);
+            if (!File.Exists(path))
             {
-                DxMessagingEditorLog.LogError("Failed to modify csc.rsp.", ex);
+                return Array.Empty<string>();
+            }
+
+            using StreamReader reader = new(path, encoding, true);
+            string text = reader.ReadToEnd();
+            encoding = reader.CurrentEncoding;
+            List<string> lines = new();
+            int start = 0;
+            for (int index = 0; index < text.Length; ++index)
+            {
+                if (text[index] != '\r' && text[index] != '\n')
+                {
+                    continue;
+                }
+                if (text[index] == '\r' && index + 1 < text.Length && text[index + 1] == '\n')
+                {
+                    ++index;
+                }
+                lines.Add(text.Substring(start, index + 1 - start));
+                start = index + 1;
+            }
+            if (start < text.Length)
+            {
+                lines.Add(text.Substring(start));
+            }
+            return lines.ToArray();
+        }
+
+        private static string FindNewline(IEnumerable<string> lines)
+        {
+            foreach (string line in lines)
+            {
+                if (line.EndsWith("\r\n", StringComparison.Ordinal))
+                {
+                    return "\r\n";
+                }
+                if (line.EndsWith("\n", StringComparison.Ordinal))
+                {
+                    return "\n";
+                }
+                if (line.EndsWith("\r", StringComparison.Ordinal))
+                {
+                    return "\r";
+                }
+            }
+            return Environment.NewLine;
+        }
+
+        private static void WriteResponseFile(string path, string[] lines, Encoding encoding)
+        {
+            string temporaryPath = Path.Combine(
+                Path.GetDirectoryName(path),
+                $".csc.rsp.{Guid.NewGuid():N}.tmp"
+            );
+            try
+            {
+                File.WriteAllText(temporaryPath, string.Concat(lines), encoding);
+                if (File.Exists(path))
+                {
+                    File.Replace(temporaryPath, path, null);
+                }
+                else
+                {
+                    File.Move(temporaryPath, path);
+                }
+            }
+            finally
+            {
+                if (File.Exists(temporaryPath))
+                {
+                    File.Delete(temporaryPath);
+                }
             }
         }
 
@@ -333,216 +450,178 @@ namespace DxMessaging.Editor
             out bool foundStaleEntries
         )
         {
-            List<string> newLines = new();
+            List<string> result = new();
             foundStaleEntries = false;
-
             foreach (string line in lines ?? Array.Empty<string>())
             {
-                string trimmedLine = line?.Trim();
-                if (string.IsNullOrEmpty(trimmedLine))
-                {
-                    continue;
-                }
-
-                if (IsResponseFileComment(trimmedLine))
-                {
-                    newLines.Add(trimmedLine);
-                    continue;
-                }
-
-                List<string> retainedArguments = new();
-                bool removedFromLine = false;
-                foreach (string argument in SplitResponseFileArguments(trimmedLine))
-                {
-                    if (IsDxMessagingAnalyzerArgument(argument))
+                string rewritten = RewriteResponseFileLine(
+                    line,
+                    argument =>
                     {
-                        foundStaleEntries = true;
-                        removedFromLine = true;
-                        continue;
+                        if (
+                            !TryGetCompilerOptionValue(argument, "a", out string value)
+                            && !TryGetCompilerOptionValue(argument, "analyzer", out value)
+                        )
+                        {
+                            return argument;
+                        }
+                        return FilterCompilerPaths(
+                            argument,
+                            value,
+                            path => !IsDxMessagingAnalyzerPath(DecodeCompilerPath(path))
+                        );
                     }
-
-                    retainedArguments.Add(argument);
-                }
-
-                if (removedFromLine)
-                {
-                    if (retainedArguments.Count > 0)
-                    {
-                        newLines.Add(string.Join(" ", retainedArguments));
-                    }
-                    continue;
-                }
-
-                newLines.Add(trimmedLine);
-            }
-
-            return newLines.ToArray();
-        }
-
-        private static bool IsDxMessagingAnalyzerArgument(string trimmedLine)
-        {
-            return (
-                    TryGetCompilerOptionValue(trimmedLine, "a", out string _)
-                    || TryGetCompilerOptionValue(trimmedLine, "analyzer", out string _)
-                )
-                && (
-                    trimmedLine.Contains(
-                        "com.wallstop-studios.dxmessaging",
-                        StringComparison.OrdinalIgnoreCase
-                    )
-                    || trimmedLine.Contains(
-                        "WallstopStudios.DxMessaging",
-                        StringComparison.OrdinalIgnoreCase
-                    )
                 );
-        }
-
-        /// <summary>
-        /// Ensures <c>csc.rsp</c> contains a single <c>-additionalfile:</c> line pointing at the
-        /// base-call ignore sidecar, when (and only when) that sidecar physically exists. Stale
-        /// entries pointing at moved or deleted sidecar paths are removed.
-        /// </summary>
-        /// <remarks>
-        /// The sidecar is generated by <see cref="DxMessagingBaseCallIgnoreSync"/>. csc happily
-        /// runs without it, so this method does NOT auto-create; sidecar writes schedule this sync
-        /// again after deferred regeneration completes.
-        /// </remarks>
-        private static void EnsureAdditionalFileForIgnoreList()
-        {
-            try
-            {
-                string sidecarRelativePath = DxMessagingBaseCallIgnoreSync.SidecarAssetPath;
-                string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."))
-                    .Replace("\\", "/");
-                string sidecarAbsolutePath = Path.Combine(projectRoot, sidecarRelativePath)
-                    .Replace("\\", "/");
-
-                bool sidecarExists = File.Exists(sidecarAbsolutePath);
-                if (!File.Exists(RspFilePath))
+                foundStaleEntries |= !string.Equals(line, rewritten, StringComparison.Ordinal);
+                if (rewritten != null)
                 {
-                    if (!sidecarExists)
-                    {
-                        return;
-                    }
-
-                    File.WriteAllText(
-                        RspFilePath,
-                        FormatAdditionalFileArgument(sidecarRelativePath) + Environment.NewLine
-                    );
-                    AssetDatabase.ImportAsset("csc.rsp");
-                    Debug.Log("Updated csc.rsp additionalfile entries.");
-                    return;
-                }
-
-                string[] newLines = SynchronizeAdditionalFileForIgnoreListLines(
-                    File.ReadAllLines(RspFilePath),
-                    sidecarRelativePath,
-                    sidecarExists,
-                    out bool modified
-                );
-
-                if (modified)
-                {
-                    string newContent = string.Join(Environment.NewLine, newLines);
-                    if (!string.IsNullOrEmpty(newContent))
-                    {
-                        newContent += Environment.NewLine;
-                    }
-                    File.WriteAllText(RspFilePath, newContent);
-                    AssetDatabase.ImportAsset("csc.rsp");
-                    Debug.Log("Updated csc.rsp additionalfile entries.");
+                    result.Add(rewritten);
                 }
             }
-            catch (IOException ex)
-            {
-                DxMessagingEditorLog.LogError("Failed to update csc.rsp additionalfile entry.", ex);
-            }
+            return result.ToArray();
         }
 
         internal static string[] SynchronizeAdditionalFileForIgnoreListLines(
             IEnumerable<string> lines,
             string sidecarRelativePath,
             bool sidecarExists,
-            out bool modified
+            out bool modified,
+            string newline = null
         )
         {
-            string desiredLine = FormatAdditionalFileArgument(sidecarRelativePath);
-            List<string> newLines = new();
+            string desired = FormatAdditionalFileArgument(sidecarRelativePath);
+            List<string> result = new();
             bool foundDesired = false;
-            bool foundStale = false;
-
+            modified = false;
             foreach (string line in lines ?? Array.Empty<string>())
             {
-                string trimmedLine = line?.Trim();
-                if (string.IsNullOrEmpty(trimmedLine))
-                {
-                    continue;
-                }
-
-                if (IsResponseFileComment(trimmedLine))
-                {
-                    newLines.Add(trimmedLine);
-                    continue;
-                }
-
-                List<string> retainedArguments = new();
-                bool removedFromLine = false;
-                foreach (string argument in SplitResponseFileArguments(trimmedLine))
-                {
-                    if (!IsDxMessagingBaseCallIgnoreAdditionalFile(argument))
+                string rewritten = RewriteResponseFileLine(
+                    line,
+                    argument =>
                     {
-                        retainedArguments.Add(argument);
-                        continue;
+                        if (
+                            !TryGetCompilerOptionValue(argument, "additionalfile", out string value)
+                        )
+                        {
+                            return argument;
+                        }
+                        bool insertDesired = false;
+                        string retained = FilterCompilerPaths(
+                            argument,
+                            value,
+                            path =>
+                            {
+                                string decoded = DecodeCompilerPath(path).Replace("\\", "/");
+                                string fileName = GetLegacyAnalyzerCopyEntryName(decoded);
+                                if (
+                                    !string.Equals(
+                                        fileName,
+                                        "DxMessaging.BaseCallIgnore.txt",
+                                        StringComparison.OrdinalIgnoreCase
+                                    )
+                                    && !string.Equals(
+                                        fileName,
+                                        "DxMessaging.BaseCallIgnore.generated.txt",
+                                        StringComparison.OrdinalIgnoreCase
+                                    )
+                                )
+                                {
+                                    return true;
+                                }
+                                if (
+                                    sidecarExists
+                                    && !foundDesired
+                                    && string.Equals(
+                                        decoded,
+                                        sidecarRelativePath,
+                                        StringComparison.OrdinalIgnoreCase
+                                    )
+                                )
+                                {
+                                    foundDesired = true;
+                                    insertDesired = true;
+                                }
+                                return false;
+                            }
+                        );
+                        return insertDesired
+                            ? (retained == null ? desired : retained + " " + desired)
+                            : retained;
                     }
-
-                    bool isDesired =
-                        sidecarExists
-                        && IsAdditionalFileArgumentForPath(argument, sidecarRelativePath);
-                    if (!isDesired)
-                    {
-                        // Stale entry pointing at a moved/renamed/deleted sidecar; drop it.
-                        foundStale = true;
-                        removedFromLine = true;
-                        continue;
-                    }
-
-                    if (foundDesired)
-                    {
-                        // Drop duplicate.
-                        foundStale = true;
-                        removedFromLine = true;
-                        continue;
-                    }
-
-                    retainedArguments.Add(desiredLine);
-                    foundDesired = true;
-                    if (!string.Equals(argument, desiredLine, StringComparison.Ordinal))
-                    {
-                        foundStale = true;
-                        removedFromLine = true;
-                    }
-                }
-
-                if (retainedArguments.Count > 0)
+                );
+                modified |= !string.Equals(line, rewritten, StringComparison.Ordinal);
+                if (rewritten != null)
                 {
-                    newLines.Add(string.Join(" ", retainedArguments));
-                    continue;
-                }
-
-                if (!removedFromLine)
-                {
-                    newLines.Add(trimmedLine);
+                    result.Add(rewritten);
                 }
             }
-
-            bool needsAppend = sidecarExists && !foundDesired;
-            if (needsAppend)
+            if (sidecarExists && !foundDesired)
             {
-                newLines.Add(desiredLine);
+                if (newline != null && result.Count > 0)
+                {
+                    string last = result[result.Count - 1];
+                    if (
+                        !last.EndsWith("\n", StringComparison.Ordinal)
+                        && !last.EndsWith("\r", StringComparison.Ordinal)
+                    )
+                    {
+                        result[result.Count - 1] += newline;
+                    }
+                }
+                result.Add(desired + newline);
+                modified = true;
             }
+            return result.ToArray();
+        }
 
-            modified = foundStale || needsAppend;
-            return newLines.ToArray();
+        private static bool IsDxMessagingAnalyzerPath(string path)
+        {
+            string normalized = path.Replace("\\", "/");
+            string fileName = GetLegacyAnalyzerCopyEntryName(normalized);
+            if (
+                string.Equals(
+                    fileName,
+                    LegacySourceGeneratorDllName,
+                    StringComparison.OrdinalIgnoreCase
+                )
+                || string.Equals(
+                    fileName,
+                    "WallstopStudios.DxMessaging.Analyzer.dll",
+                    StringComparison.OrdinalIgnoreCase
+                )
+            )
+            {
+                return true;
+            }
+            if (!KnownLegacyAnalyzerCopyDlls.Contains(fileName))
+            {
+                return false;
+            }
+            foreach (string segment in normalized.Split('/'))
+            {
+                if (
+                    string.Equals(
+                        segment,
+                        "com.wallstop-studios.dxmessaging",
+                        StringComparison.OrdinalIgnoreCase
+                    )
+                    || segment.StartsWith(
+                        "com.wallstop-studios.dxmessaging@",
+                        StringComparison.OrdinalIgnoreCase
+                    )
+                )
+                {
+                    return true;
+                }
+            }
+            return normalized.StartsWith(
+                    LegacyAnalyzerCopyFolder + "/",
+                    StringComparison.OrdinalIgnoreCase
+                )
+                || normalized.Contains(
+                    "/" + LegacyAnalyzerCopyFolder + "/",
+                    StringComparison.OrdinalIgnoreCase
+                );
         }
 
         private static string FormatAdditionalFileArgument(string sidecarRelativePath)
@@ -550,34 +629,160 @@ namespace DxMessaging.Editor
             return $"-additionalfile:\"{sidecarRelativePath}\"";
         }
 
-        private static bool IsResponseFileComment(string trimmedLine)
-        {
-            return trimmedLine.StartsWith("#", StringComparison.Ordinal);
-        }
-
-        private static bool IsDxMessagingBaseCallIgnoreAdditionalFile(string trimmedLine)
-        {
-            return TryGetCompilerOptionValue(trimmedLine, "additionalfile", out string value)
-                && value.Contains("DxMessaging.", StringComparison.OrdinalIgnoreCase)
-                && value.Contains("BaseCallIgnore", StringComparison.OrdinalIgnoreCase);
-        }
-
-        private static bool IsAdditionalFileArgumentForPath(
+        private static string FilterCompilerPaths(
             string argument,
-            string sidecarRelativePath
+            string value,
+            Func<string, bool> retain
         )
         {
-            if (!TryGetCompilerOptionValue(argument, "additionalfile", out string value))
+            StringBuilder kept = new();
+            bool changed = false;
+            bool inQuotes = false;
+            int start = 0;
+            // Roslyn splits analyzer/additionalfile path lists on comma and semicolon outside
+            // quotes. Retain each surviving path and its original separator without decoding it.
+            for (int index = 0; index <= value.Length; ++index)
             {
-                return false;
+                if (index < value.Length && value[index] == '"')
+                {
+                    inQuotes = !inQuotes;
+                }
+                if (
+                    index < value.Length
+                    && (inQuotes || (value[index] != ',' && value[index] != ';'))
+                )
+                {
+                    continue;
+                }
+                string path = value.Substring(start, index - start);
+                if (retain(path))
+                {
+                    if (kept.Length > 0)
+                    {
+                        kept.Append(value[start - 1]);
+                    }
+                    kept.Append(path);
+                }
+                else
+                {
+                    changed = true;
+                }
+                start = index + 1;
             }
+            if (!changed)
+            {
+                return argument;
+            }
+            if (kept.Length == 0)
+            {
+                return null;
+            }
+            string unquoted = UnquoteWholeArgument(argument);
+            string rewritten = unquoted.Substring(0, unquoted.Length - value.Length) + kept;
+            return unquoted == argument ? rewritten : "\"" + rewritten + "\"";
+        }
 
-            string unquotedValue = UnquoteWholeArgument(value.Trim());
-            return string.Equals(
-                unquotedValue.Replace("\\", "/"),
-                sidecarRelativePath,
-                StringComparison.OrdinalIgnoreCase
-            );
+        private static string RewriteResponseFileLine(string line, Func<string, string> rewrite)
+        {
+            if (line == null)
+            {
+                return null;
+            }
+            int length = line.Length;
+            while (length > 0 && (line[length - 1] == '\r' || line[length - 1] == '\n'))
+            {
+                --length;
+            }
+            StringBuilder output = null;
+            int copied = 0;
+            int index = 0;
+            while (index < length)
+            {
+                while (index < length && char.IsWhiteSpace(line[index]))
+                {
+                    ++index;
+                }
+                // Roslyn recognizes # at the beginning of a token. An embedded or quoted #
+                // belongs to its argument and must not hide following compiler options.
+                if (index == length || line[index] == '#')
+                {
+                    break;
+                }
+                int start = index;
+                bool inQuotes = false;
+                int backslashes = 0;
+                while (index < length && (inQuotes || !char.IsWhiteSpace(line[index])))
+                {
+                    char character = line[index++];
+                    if (character == '"' && backslashes % 2 == 0)
+                    {
+                        inQuotes = !inQuotes;
+                    }
+                    backslashes = character == '\\' ? backslashes + 1 : 0;
+                }
+                string argument = line.Substring(start, index - start);
+                string replacement = rewrite(argument);
+                if (string.Equals(argument, replacement, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+                output ??= new StringBuilder();
+                if (replacement == null)
+                {
+                    while (index < length && char.IsWhiteSpace(line[index]))
+                    {
+                        ++index;
+                    }
+                    if (index == length)
+                    {
+                        while (start > copied && char.IsWhiteSpace(line[start - 1]))
+                        {
+                            --start;
+                        }
+                    }
+                }
+                output.Append(line, copied, start - copied);
+                output.Append(replacement);
+                copied = index;
+            }
+            if (output == null)
+            {
+                return line;
+            }
+            output.Append(line, copied, line.Length - copied);
+            string result = output.ToString();
+            return string.IsNullOrWhiteSpace(result) ? null : result;
+        }
+
+        private static string DecodeCompilerPath(string path)
+        {
+            StringBuilder decoded = new();
+            for (int index = 0; index < path.Length; ++index)
+            {
+                int slashes = 0;
+                while (index < path.Length && path[index] == '\\')
+                {
+                    ++slashes;
+                    ++index;
+                }
+                if (index < path.Length && path[index] == '"')
+                {
+                    decoded.Append('\\', slashes / 2);
+                    if (slashes % 2 != 0)
+                    {
+                        decoded.Append('"');
+                    }
+                }
+                else
+                {
+                    decoded.Append('\\', slashes);
+                    if (index < path.Length)
+                    {
+                        decoded.Append(path[index]);
+                    }
+                }
+            }
+            return decoded.ToString();
         }
 
         private static bool TryGetCompilerOptionValue(
@@ -628,52 +833,21 @@ namespace DxMessaging.Editor
 
         private static string UnquoteWholeArgument(string argument)
         {
-            if (argument.Length >= 2 && argument[0] == '"' && argument[argument.Length - 1] == '"')
+            int quotes = 0;
+            int backslashes = 0;
+            foreach (char character in argument)
             {
-                return argument.Substring(1, argument.Length - 2).Replace("\"\"", "\"");
+                if (character == '"' && backslashes % 2 == 0)
+                {
+                    ++quotes;
+                }
+                backslashes = character == '\\' ? backslashes + 1 : 0;
             }
-
+            if (quotes == 2 && argument[0] == '"' && argument[argument.Length - 1] == '"')
+            {
+                return argument.Substring(1, argument.Length - 2);
+            }
             return argument;
-        }
-
-        private static List<string> SplitResponseFileArguments(string line)
-        {
-            List<string> arguments = new();
-            if (string.IsNullOrWhiteSpace(line))
-            {
-                return arguments;
-            }
-
-            System.Text.StringBuilder current = new();
-            bool inQuotes = false;
-            foreach (char character in line)
-            {
-                if (character == '"')
-                {
-                    inQuotes = !inQuotes;
-                    current.Append(character);
-                    continue;
-                }
-
-                if (char.IsWhiteSpace(character) && !inQuotes)
-                {
-                    if (current.Length > 0)
-                    {
-                        arguments.Add(current.ToString());
-                        current.Clear();
-                    }
-                    continue;
-                }
-
-                current.Append(character);
-            }
-
-            if (current.Length > 0)
-            {
-                arguments.Add(current.ToString());
-            }
-
-            return arguments;
         }
     }
 

--- a/Tests/Editor/DxMessagingBaseCallIgnoreSyncTests.cs
+++ b/Tests/Editor/DxMessagingBaseCallIgnoreSyncTests.cs
@@ -3,6 +3,7 @@ namespace DxMessaging.Tests.Editor
 {
     using System;
     using System.Collections.Generic;
+    using System.IO;
     using System.Reflection;
     using DxMessaging.Core.MessageBus;
     using DxMessaging.Editor;
@@ -460,6 +461,86 @@ namespace DxMessaging.Tests.Editor
                 DxMessagingBaseCallIgnoreSync.SidecarApplier = _originalApplier;
                 DxMessagingBaseCallIgnoreSync.CscRspAdditionalFileSyncScheduler =
                     _originalCscRspAdditionalFileSyncScheduler;
+            }
+        }
+
+        [Test]
+        public void DeferredCallbacksDoNotRewritePreparedCompilerInputs()
+        {
+            string project = Path.Combine(Path.GetTempPath(), $"dxm_prepared_{Guid.NewGuid():N}");
+            string assets = Path.Combine(project, "Assets");
+            string sidecar = Path.Combine(project, DxMessagingBaseCallIgnoreSync.SidecarAssetPath);
+            Directory.CreateDirectory(assets);
+            try
+            {
+                DxMessagingSettings settings = NewSettings();
+                settings._baseCallIgnoredTypes = new List<string> { "Consumer.IgnoredType" };
+                bool sidecarPending = false;
+                bool rspPending = false;
+                List<string> imports = new();
+                Action writeSidecar = () =>
+                    DxMessagingBaseCallIgnoreSync.WriteSidecarOrThrow(
+                        sidecar,
+                        settings._baseCallIgnoredTypes,
+                        imports.Add,
+                        ref sidecarPending
+                    );
+                Action writeResponse = () =>
+                    SetupCscRsp.SynchronizeResponseFiles(assets, imports.Add, ref rspPending);
+                DxMessagingBaseCallIgnoreSync.SidecarApplier = _ => writeSidecar();
+                DxMessagingBaseCallIgnoreSync.CscRspAdditionalFileSyncScheduler = () =>
+                    _scheduled.Add(writeResponse);
+                _scheduled.Clear();
+                DxMessagingBaseCallIgnoreSync.RegenerateSidecarDeferred(settings);
+
+                SetupCscRsp.PrepareCompilerInputs(
+                    true,
+                    writeSidecar,
+                    writeResponse,
+                    () => { },
+                    () => { },
+                    ref sidecarPending,
+                    ref rspPending
+                );
+                DateTime unchangedTime = new(2001, 2, 3, 4, 5, 6, DateTimeKind.Utc);
+                File.SetLastWriteTimeUtc(sidecar, unchangedTime);
+                File.SetLastWriteTimeUtc(Path.Combine(assets, "csc.rsp"), unchangedTime);
+                for (int callback = 0; callback < 2; ++callback)
+                {
+                    Assert.AreEqual(
+                        1,
+                        _scheduled.Count,
+                        $"Callback {callback + 1} must be the sole pending sidecar or response-file work item."
+                    );
+                    Action work = _scheduled[0];
+                    _scheduled.RemoveAt(0);
+                    work();
+                }
+
+                Assert.IsEmpty(
+                    _scheduled,
+                    "The sidecar and response-file callbacks must finish without requeuing work."
+                );
+                CollectionAssert.AreEqual(
+                    new[] { DxMessagingBaseCallIgnoreSync.SidecarAssetPath, "Assets/csc.rsp" },
+                    imports,
+                    "Deferred callbacks must not import already-prepared compiler inputs again."
+                );
+                Assert.AreEqual(
+                    unchangedTime,
+                    File.GetLastWriteTimeUtc(sidecar),
+                    "Deferred regeneration must leave sidecar bytes untouched."
+                );
+                Assert.AreEqual(
+                    unchangedTime,
+                    File.GetLastWriteTimeUtc(Path.Combine(assets, "csc.rsp")),
+                    "Deferred response-file synchronization must leave compiler inputs untouched."
+                );
+            }
+            finally
+            {
+                _scheduled.Clear();
+                Directory.Delete(project, true);
             }
         }
 

--- a/Tests/Editor/DxMessagingBaseCallIgnoreSyncTests.cs
+++ b/Tests/Editor/DxMessagingBaseCallIgnoreSyncTests.cs
@@ -609,16 +609,15 @@ namespace DxMessaging.Tests.Editor
             );
         }
 
+        /// <remarks>
+        /// 2026-09-06: An ambient editor-update assumption skipped this test on Unity 2021 CI
+        /// even though SetUp controls the idle predicate and captures every side effect.
+        /// </remarks>
         [Test]
-        public void RegenerateSidecarAppliesSynchronouslyOutsideUpdateAndCompile()
+        public void RegenerateSidecarAppliesSynchronouslyWhenEditorCanMutateAssets()
         {
-            // Add/Remove ignored-type actions are explicit user edits (button clicks, Project
-            // Settings UI), not deserialization callbacks, so the synchronous path is correct there
-            // and must be preserved. EditMode tests run outside update/compile, exercising it.
-            Assume.That(
-                !EditorApplication.isUpdating && !EditorApplication.isCompiling,
-                "Test must run outside an editor update/compile window to exercise the synchronous path."
-            );
+            // SetUp supplies an idle predicate and captures the apply and scheduling actions.
+            // Explicit ignored-type edits must apply immediately under that controlled state.
             DxMessagingSettings settings = NewSettings();
 
             DxMessagingBaseCallIgnoreSync.RegenerateSidecar(settings);

--- a/Tests/Editor/MessageAwareComponentFallbackEditorTests.cs
+++ b/Tests/Editor/MessageAwareComponentFallbackEditorTests.cs
@@ -49,6 +49,9 @@ namespace DxMessaging.Tests.Editor
             _previousBaseCallCheckEnabled = settings._baseCallCheckEnabled;
             _baseCallCheckOverridden = true;
             settings._baseCallCheckEnabled = false;
+            // State-transition tests must not inherit asset refresh activity from the editor.
+            // Tests for transient blocking replace this seam explicitly and own their retry queue.
+            MessageAwareComponentInspectorOverlay.InspectorResolutionTransientBlocker = () => false;
         }
 
         [TearDown]
@@ -723,9 +726,22 @@ namespace DxMessaging.Tests.Editor
             Assert.That(ignoreType.enabledSelf, Is.False);
         }
 
-        [Test]
-        public void FallbackEditorCreateInspectorGUIOmitsNoneWarningViewAndHostsDefaultInspectorBody()
+        /// <remarks>
+        /// 2026-09-06: Unity 2021 CI exposed an initially visible empty warning host when
+        /// resolution was blocked. Exercise both initial states without ambient editor activity.
+        /// </remarks>
+        [TestCase(false)]
+        [TestCase(true)]
+        public void FallbackEditorCreateInspectorGUIOmitsNoneWarningViewAndHostsDefaultInspectorBody(
+            bool transientlyBlocked
+        )
         {
+            bool blocked = transientlyBlocked;
+            List<Action> scheduledRetries = new();
+            MessageAwareComponentInspectorOverlay.InspectorResolutionTransientBlocker = () =>
+                blocked;
+            MessageAwareComponentInspectorOverlay.TransientRefreshScheduler = work =>
+                scheduledRetries.Add(work);
             MessageAwareComponent component = CreateTrackedMessageAwareComponent(
                 "FallbackEditorCreateInspectorGuiHost",
                 typeof(SerializedFieldMessageAwareComponentForFallbackTest)
@@ -754,7 +770,31 @@ namespace DxMessaging.Tests.Editor
                 MessageAwareComponentFallbackEditor.WarningHostName
             );
             Assert.That(warningHost, Is.Not.Null);
-            Assert.That(warningHost.style.display.value, Is.EqualTo(DisplayStyle.None));
+            Assert.That(
+                warningHost.style.display.value,
+                Is.EqualTo(DisplayStyle.None),
+                $"transientlyBlocked={transientlyBlocked}: an initial empty warning host must stay hidden even before a deferred refresh."
+            );
+            Assert.That(
+                scheduledRetries.Count,
+                Is.EqualTo(transientlyBlocked ? 1 : 0),
+                $"transientlyBlocked={transientlyBlocked}: only blocked resolution should schedule a retry."
+            );
+            if (transientlyBlocked)
+            {
+                blocked = false;
+                scheduledRetries[0].Invoke();
+                Assert.That(
+                    warningHost.style.display.value,
+                    Is.EqualTo(DisplayStyle.None),
+                    "transientlyBlocked=true: resolving a genuine None state after the block clears must leave the host hidden."
+                );
+                Assert.That(
+                    scheduledRetries.Count,
+                    Is.EqualTo(1),
+                    "transientlyBlocked=true: an idle retry must not schedule another refresh."
+                );
+            }
 
             VisualElement body = root.Q<VisualElement>(
                 MessageAwareComponentFallbackEditor.DefaultInspectorBodyName

--- a/Tests/Editor/SetupCscRspTests.cs
+++ b/Tests/Editor/SetupCscRspTests.cs
@@ -5,6 +5,7 @@ namespace DxMessaging.Tests.Editor
     using System.Collections.Generic;
     using System.IO;
     using System.Text;
+    using System.Threading.Tasks;
     using DxMessaging.Editor;
     using DxMessaging.Editor.Settings;
     using NUnit.Framework;
@@ -47,6 +48,329 @@ namespace DxMessaging.Tests.Editor
                 Path.GetFullPath(Path.Combine(Application.dataPath, "csc.rsp")),
                 Path.GetFullPath(SetupCscRsp.GetRspFilePath(Application.dataPath)),
                 "Unity reads the response file from Assets/csc.rsp, not the project root."
+            );
+        }
+
+        [Test]
+        public void PublicPreparationRejectsAWorkerBeforeReadingUnityEditorState()
+        {
+            // Initialize the class on the editor thread before exercising its worker guard.
+            SetupCscRsp.GetRspFilePath(_assetsDirectory);
+            Exception failure = Task.Run<Exception>(() =>
+                {
+                    try
+                    {
+                        SetupCscRsp.PrepareCompilerInputs();
+                        return null;
+                    }
+                    catch (Exception ex)
+                    {
+                        return ex;
+                    }
+                })
+                .GetAwaiter()
+                .GetResult();
+
+            Assert.That(failure, Is.TypeOf<InvalidOperationException>());
+            Assert.AreEqual(
+                "PrepareCompilerInputs requires an idle main-thread editor configuration phase.",
+                failure.Message,
+                "The public API must reject the worker itself before invoking Unity editor APIs."
+            );
+        }
+
+        [TestCase(false)]
+        [TestCase(true)]
+        public void PreparationCreatesColdInputsBeforeCompletingTheImportBatch(
+            bool existingConsumerOptions
+        )
+        {
+            if (existingConsumerOptions)
+            {
+                File.WriteAllText(_testRspFilePath, "-define:CONSUMER\n");
+            }
+            string sidecarPath = Path.Combine(
+                _projectDirectory,
+                DxMessagingBaseCallIgnoreSync.SidecarAssetPath
+            );
+            List<string> events = new();
+            bool sidecarPending = false;
+            bool rspPending = false;
+            Action prepareSidecar = () =>
+                DxMessagingBaseCallIgnoreSync.WriteSidecarOrThrow(
+                    sidecarPath,
+                    new[] { "Consumer.IgnoredType" },
+                    path => events.Add(path),
+                    ref sidecarPending
+                );
+            Action prepareResponse = () =>
+                SetupCscRsp.SynchronizeResponseFiles(
+                    _assetsDirectory,
+                    path => events.Add(path),
+                    ref rspPending
+                );
+
+            SetupCscRsp.PrepareCompilerInputs(
+                true,
+                prepareSidecar,
+                prepareResponse,
+                () => events.Add("begin"),
+                () => events.Add("end"),
+                ref sidecarPending,
+                ref rspPending
+            );
+
+            string context = $"existingConsumerOptions={existingConsumerOptions}";
+            CollectionAssert.AreEqual(
+                new[]
+                {
+                    "begin",
+                    DxMessagingBaseCallIgnoreSync.SidecarAssetPath,
+                    "Assets/csc.rsp",
+                    "end",
+                },
+                events,
+                $"Cold sidecar and response-file imports must finish in one ordered batch: {context}."
+            );
+            Assert.IsTrue(
+                File.ReadAllText(sidecarPath).Contains("\nConsumer.IgnoredType\n"),
+                $"Preparation must persist ignored types before returning: {context}."
+            );
+            AssertResponseFile(
+                _testRspFilePath,
+                existingConsumerOptions
+                    ? new[] { "-define:CONSUMER", SidecarArgument }
+                    : new[] { SidecarArgument },
+                context
+            );
+            Assert.IsFalse(
+                sidecarPending || rspPending,
+                $"Successful batch must finish both imports: {context}."
+            );
+
+            events.Clear();
+            prepareSidecar();
+            prepareResponse();
+            Assert.IsEmpty(
+                events,
+                $"Later deferred sidecar/response synchronization must not import again: {context}."
+            );
+        }
+
+        [TestCase("start")]
+        [TestCase("sidecar")]
+        [TestCase("response")]
+        [TestCase("stop")]
+        public void PreparationPropagatesFailuresAndRetainsPendingImports(string failureStage)
+        {
+            List<string> events = new();
+            IOException expected = new("Injected " + failureStage + " failure");
+            Action<string> step = name =>
+            {
+                events.Add(name);
+                if (name == failureStage)
+                {
+                    throw expected;
+                }
+            };
+            bool sidecarPending = false;
+            bool rspPending = false;
+            IOException actual = Assert.Throws<IOException>(
+                () =>
+                    SetupCscRsp.PrepareCompilerInputs(
+                        true,
+                        () => step("sidecar"),
+                        () => step("response"),
+                        () => step("start"),
+                        () => step("stop"),
+                        ref sidecarPending,
+                        ref rspPending
+                    ),
+                $"Preparation must fail at {failureStage}."
+            );
+            Assert.AreSame(
+                expected,
+                actual,
+                $"The original {failureStage} failure must reach the caller."
+            );
+            Assert.IsTrue(
+                sidecarPending && rspPending,
+                $"The failed {failureStage} phase must retain both import retries."
+            );
+            CollectionAssert.AreEqual(
+                failureStage == "start" ? new[] { "start" }
+                    : failureStage == "sidecar" ? new[] { "start", "sidecar", "stop" }
+                    : new[] { "start", "sidecar", "response", "stop" },
+                events,
+                $"An entered batch must stop even when {failureStage} fails."
+            );
+        }
+
+        [Test]
+        public void PreparationRejectsAnUnsafeEditorBeforeStartingWork()
+        {
+            List<string> events = new();
+            bool sidecarPending = false;
+            bool rspPending = false;
+            Assert.Throws<InvalidOperationException>(
+                () =>
+                    SetupCscRsp.PrepareCompilerInputs(
+                        false,
+                        () => events.Add("sidecar"),
+                        () => events.Add("response"),
+                        () => events.Add("start"),
+                        () => events.Add("stop"),
+                        ref sidecarPending,
+                        ref rspPending
+                    ),
+                "A busy or non-main-thread editor must reject preparation."
+            );
+            Assert.IsEmpty(events, "Rejected preparation must not perform any asset operation.");
+            Assert.IsFalse(
+                sidecarPending || rspPending,
+                "Rejected preparation must not change import state."
+            );
+        }
+
+        [Test]
+        public void PreparationPreservesBothTheWorkAndStopFailures()
+        {
+            IOException workFailure = new("Sidecar write failed");
+            IOException stopFailure = new("Batch completion failed");
+            bool sidecarPending = false;
+            bool rspPending = false;
+            AggregateException actual = Assert.Throws<AggregateException>(
+                () =>
+                    SetupCscRsp.PrepareCompilerInputs(
+                        true,
+                        () => throw workFailure,
+                        () => Assert.Fail("Response sync cannot follow a failed sidecar"),
+                        () => { },
+                        () => throw stopFailure,
+                        ref sidecarPending,
+                        ref rspPending
+                    ),
+                "Batch cleanup must not replace the original preparation failure."
+            );
+            CollectionAssert.AreEqual(
+                new Exception[] { workFailure, stopFailure },
+                actual.InnerExceptions,
+                "Both failures must remain available for CI diagnosis."
+            );
+        }
+
+        [Test]
+        public void FailedBatchCompletionRetriesBothImportsWithoutRewritingInputs()
+        {
+            string sidecarPath = Path.Combine(
+                _projectDirectory,
+                DxMessagingBaseCallIgnoreSync.SidecarAssetPath
+            );
+            List<string> imports = new();
+            bool sidecarPending = false;
+            bool rspPending = false;
+            Action prepareSidecar = () =>
+                DxMessagingBaseCallIgnoreSync.WriteSidecarOrThrow(
+                    sidecarPath,
+                    Array.Empty<string>(),
+                    imports.Add,
+                    ref sidecarPending
+                );
+            Action prepareResponse = () =>
+                SetupCscRsp.SynchronizeResponseFiles(_assetsDirectory, imports.Add, ref rspPending);
+            Assert.Throws<IOException>(
+                () =>
+                    SetupCscRsp.PrepareCompilerInputs(
+                        true,
+                        prepareSidecar,
+                        prepareResponse,
+                        () => { },
+                        () => throw new IOException("Stop failed"),
+                        ref sidecarPending,
+                        ref rspPending
+                    ),
+                "A failed StopAssetEditing must fail preparation."
+            );
+            DateTime unchangedTime = new(2001, 2, 3, 4, 5, 6, DateTimeKind.Utc);
+            File.SetLastWriteTimeUtc(sidecarPath, unchangedTime);
+            File.SetLastWriteTimeUtc(_testRspFilePath, unchangedTime);
+            imports.Clear();
+
+            SetupCscRsp.PrepareCompilerInputs(
+                true,
+                prepareSidecar,
+                prepareResponse,
+                () => { },
+                () => { },
+                ref sidecarPending,
+                ref rspPending
+            );
+
+            CollectionAssert.AreEqual(
+                new[] { DxMessagingBaseCallIgnoreSync.SidecarAssetPath, "Assets/csc.rsp" },
+                imports,
+                "Both queued imports must be retried after failed batch completion."
+            );
+            Assert.AreEqual(
+                unchangedTime,
+                File.GetLastWriteTimeUtc(sidecarPath),
+                "Retry must not rewrite identical sidecar bytes."
+            );
+            Assert.AreEqual(
+                unchangedTime,
+                File.GetLastWriteTimeUtc(_testRspFilePath),
+                "Retry must not rewrite identical response-file bytes."
+            );
+            Assert.IsFalse(
+                sidecarPending || rspPending,
+                "A successful retry must clear both pending imports."
+            );
+        }
+
+        [Test]
+        public void AFailedSidecarWriteStopsPreparationBeforeResponseFileMutation()
+        {
+            string sidecarPath = Path.Combine(
+                _projectDirectory,
+                DxMessagingBaseCallIgnoreSync.SidecarAssetPath
+            );
+            Directory.CreateDirectory(sidecarPath);
+            File.WriteAllText(_testRspFilePath, "-define:CONSUMER\n");
+            bool sidecarPending = false;
+            bool rspPending = false;
+            List<string> imports = new();
+            Assert.Throws<IOException>(
+                () =>
+                    SetupCscRsp.PrepareCompilerInputs(
+                        true,
+                        () =>
+                            DxMessagingBaseCallIgnoreSync.WriteSidecarOrThrow(
+                                sidecarPath,
+                                Array.Empty<string>(),
+                                imports.Add,
+                                ref sidecarPending
+                            ),
+                        () =>
+                            SetupCscRsp.SynchronizeResponseFiles(
+                                _assetsDirectory,
+                                imports.Add,
+                                ref rspPending
+                            ),
+                        () => { },
+                        () => { },
+                        ref sidecarPending,
+                        ref rspPending
+                    ),
+                "A real sidecar write error must propagate instead of being logged and ignored."
+            );
+            Assert.IsEmpty(
+                imports,
+                "Failed sidecar persistence must not import either compiler input."
+            );
+            Assert.AreEqual(
+                "-define:CONSUMER\n",
+                File.ReadAllText(_testRspFilePath),
+                "A failed sidecar write must leave consumer response-file bytes untouched."
             );
         }
 

--- a/Tests/Editor/SetupCscRspTests.cs
+++ b/Tests/Editor/SetupCscRspTests.cs
@@ -4,28 +4,533 @@ namespace DxMessaging.Tests.Editor
     using System;
     using System.Collections.Generic;
     using System.IO;
+    using System.Text;
     using DxMessaging.Editor;
     using DxMessaging.Editor.Settings;
     using NUnit.Framework;
+    using UnityEngine;
 
     [TestFixture]
     public sealed class SetupCscRspTests
     {
         private string _testRspFilePath;
+        private string _projectDirectory;
+        private string _assetsDirectory;
+
+        private const string SidecarArgument =
+            "-additionalfile:\"Assets/Editor/DxMessaging.BaseCallIgnore.txt\"";
+        private const string LegacyAnalyzerArgument =
+            "-a:\"Assets/Plugins/Editor/WallstopStudios.DxMessaging/WallstopStudios.DxMessaging.Analyzer.dll\"";
 
         [SetUp]
         public void SetUp()
         {
-            _testRspFilePath = Path.Combine(Path.GetTempPath(), $"test_csc_{Guid.NewGuid()}.rsp");
+            _projectDirectory = Path.Combine(Path.GetTempPath(), $"dxm_rsp_{Guid.NewGuid():N}");
+            _assetsDirectory = Path.Combine(_projectDirectory, "Assets");
+            Directory.CreateDirectory(_assetsDirectory);
+            _testRspFilePath = Path.Combine(_assetsDirectory, "csc.rsp");
         }
 
         [TearDown]
         public void TearDown()
         {
-            if (File.Exists(_testRspFilePath))
+            if (Directory.Exists(_projectDirectory))
             {
-                File.Delete(_testRspFilePath);
+                Directory.Delete(_projectDirectory, true);
             }
+        }
+
+        [Test]
+        public void ResponseFilePathIsUnderAssetsWhereUnityReadsIt()
+        {
+            Assert.AreEqual(
+                Path.GetFullPath(Path.Combine(Application.dataPath, "csc.rsp")),
+                Path.GetFullPath(SetupCscRsp.GetRspFilePath(Application.dataPath)),
+                "Unity reads the response file from Assets/csc.rsp, not the project root."
+            );
+        }
+
+        public static IEnumerable<TestCaseData> ResponseFileMigrationCases()
+        {
+            yield return new TestCaseData(
+                null,
+                null,
+                true,
+                new[] { SidecarArgument },
+                null,
+                1
+            ).SetName("creates the response file under Assets when the sidecar exists");
+            yield return new TestCaseData(null, null, false, null, null, 0).SetName(
+                "does not create an empty response file before sidecar generation"
+            );
+            yield return new TestCaseData(
+                new[] { "# consumer asset options", "-define:ASSET", LegacyAnalyzerArgument },
+                new[] { LegacyAnalyzerArgument + " -define:ROOT", SidecarArgument },
+                true,
+                new[] { "# consumer asset options", "-define:ASSET", SidecarArgument },
+                new[] { "-define:ROOT" },
+                1
+            ).SetName("preserves consumer options in each location while migrating managed wiring");
+            yield return new TestCaseData(
+                null,
+                new[] { SidecarArgument, LegacyAnalyzerArgument },
+                true,
+                new[] { SidecarArgument },
+                null,
+                1
+            ).SetName("deletes a package-only root response file after migration");
+            yield return new TestCaseData(
+                null,
+                new[] { "  # root options", "  -define:ROOT", "", "-r:Other.dll" },
+                false,
+                null,
+                new[] { "  # root options", "  -define:ROOT", "", "-r:Other.dll" },
+                0
+            ).SetName("leaves unrelated root response-file content untouched and inactive");
+            yield return new TestCaseData(
+                null,
+                Array.Empty<string>(),
+                false,
+                null,
+                Array.Empty<string>(),
+                0
+            ).SetName("does not delete an empty consumer root response file");
+            yield return new TestCaseData(
+                new[] { SidecarArgument, LegacyAnalyzerArgument },
+                new[] { SidecarArgument, LegacyAnalyzerArgument },
+                false,
+                Array.Empty<string>(),
+                null,
+                1
+            ).SetName(
+                "removes stale managed options from both locations when the sidecar is missing"
+            );
+            yield return new TestCaseData(
+                new[] { "-r:Other.dll", SidecarArgument },
+                new[] { "# consumer root comment", SidecarArgument },
+                true,
+                new[] { "-r:Other.dll", SidecarArgument },
+                new[] { "# consumer root comment" },
+                0
+            ).SetName("retains root comments and skips importing an already-correct asset");
+        }
+
+        [TestCaseSource(nameof(ResponseFileMigrationCases))]
+        public void SynchronizesAssetAndLegacyResponseFilesWithoutRepeatedImports(
+            string[] assetLines,
+            string[] rootLines,
+            bool sidecarExists,
+            string[] expectedAssetLines,
+            string[] expectedRootLines,
+            int expectedImports
+        )
+        {
+            string rootRspPath = Path.Combine(_projectDirectory, "csc.rsp");
+            if (assetLines != null)
+            {
+                File.WriteAllLines(_testRspFilePath, assetLines);
+            }
+            if (rootLines != null)
+            {
+                File.WriteAllLines(rootRspPath, rootLines);
+            }
+            if (sidecarExists)
+            {
+                CreateSidecar();
+            }
+
+            string context =
+                $"asset=[{string.Join(",", assetLines ?? Array.Empty<string>())}], "
+                + $"root=[{string.Join(",", rootLines ?? Array.Empty<string>())}], "
+                + $"sidecarExists={sidecarExists}, expectedImports={expectedImports}";
+            List<string> imports = new();
+            bool importPending = false;
+            SetupCscRsp.SynchronizeResponseFiles(_assetsDirectory, imports.Add, ref importPending);
+
+            AssertResponseFile(_testRspFilePath, expectedAssetLines, context);
+            AssertResponseFile(rootRspPath, expectedRootLines, context);
+            CollectionAssert.AreEqual(
+                expectedImports == 0 ? Array.Empty<string>() : new[] { "Assets/csc.rsp" },
+                imports,
+                $"Only the Unity asset path may be imported once per update: {context}."
+            );
+            Assert.IsFalse(
+                importPending,
+                $"Successful imports must clear pending state: {context}."
+            );
+
+            DateTime unchangedTime = new(2001, 2, 3, 4, 5, 6, DateTimeKind.Utc);
+            foreach (string path in new[] { _testRspFilePath, rootRspPath })
+            {
+                if (File.Exists(path))
+                {
+                    File.SetLastWriteTimeUtc(path, unchangedTime);
+                }
+            }
+            SetupCscRsp.SynchronizeResponseFiles(_assetsDirectory, imports.Add, ref importPending);
+            Assert.AreEqual(
+                expectedImports,
+                imports.Count,
+                $"An unchanged sync must not reimport: {context}."
+            );
+            foreach (string path in new[] { _testRspFilePath, rootRspPath })
+            {
+                if (File.Exists(path))
+                {
+                    Assert.AreEqual(
+                        unchangedTime,
+                        File.GetLastWriteTimeUtc(path),
+                        $"An unchanged sync must not rewrite {path}: {context}."
+                    );
+                }
+            }
+        }
+
+        [Test]
+        public void FailedAssetWritePreservesLegacyFileAndCanBeRetried()
+        {
+            CreateSidecar();
+            string rootRspPath = Path.Combine(_projectDirectory, "csc.rsp");
+            File.WriteAllLines(rootRspPath, new[] { SidecarArgument });
+            Directory.CreateDirectory(_testRspFilePath);
+            List<string> imports = new();
+            bool importPending = false;
+
+            Assert.Throws<IOException>(
+                () =>
+                    SetupCscRsp.SynchronizeResponseFiles(
+                        _assetsDirectory,
+                        imports.Add,
+                        ref importPending
+                    ),
+                "A directory at the destination must report a failed response-file write."
+            );
+
+            AssertResponseFile(
+                rootRspPath,
+                new[] { SidecarArgument },
+                "Failed destination write must preserve the legacy file"
+            );
+            Assert.IsEmpty(imports, "A failed write must not import a response file.");
+            Assert.IsFalse(
+                importPending,
+                "No import is pending until the destination has been written."
+            );
+            Assert.IsEmpty(
+                Directory.GetFiles(_assetsDirectory, ".csc.rsp.*.tmp"),
+                "Failed writes must remove temporary response files."
+            );
+
+            Directory.Delete(_testRspFilePath);
+            SetupCscRsp.SynchronizeResponseFiles(_assetsDirectory, imports.Add, ref importPending);
+
+            AssertResponseFile(
+                _testRspFilePath,
+                new[] { SidecarArgument },
+                "Retry must create the active response file"
+            );
+            Assert.IsFalse(
+                File.Exists(rootRspPath),
+                "Successful retry must retire the package-only root file."
+            );
+            CollectionAssert.AreEqual(
+                new[] { "Assets/csc.rsp" },
+                imports,
+                "Retry must import the asset once."
+            );
+        }
+
+        [Test]
+        public void FailedImportRemainsPendingAndPreservesLegacyFileUntilRetry()
+        {
+            CreateSidecar();
+            string rootRspPath = Path.Combine(_projectDirectory, "csc.rsp");
+            File.WriteAllLines(rootRspPath, new[] { SidecarArgument });
+            bool importPending = false;
+            Assert.Throws<IOException>(
+                () =>
+                    SetupCscRsp.SynchronizeResponseFiles(
+                        _assetsDirectory,
+                        _ => throw new IOException("Injected import failure"),
+                        ref importPending
+                    ),
+                "An import failure must remain observable to the setup error handler."
+            );
+
+            Assert.IsTrue(
+                importPending,
+                "A written response file still needs its failed import retried."
+            );
+            AssertResponseFile(
+                _testRspFilePath,
+                new[] { SidecarArgument },
+                "Destination must exist before import"
+            );
+            AssertResponseFile(
+                rootRspPath,
+                new[] { SidecarArgument },
+                "Failed import must preserve legacy wiring"
+            );
+
+            List<string> imports = new();
+            SetupCscRsp.SynchronizeResponseFiles(_assetsDirectory, imports.Add, ref importPending);
+            Assert.IsFalse(importPending, "Successful retry must clear the pending import.");
+            Assert.IsFalse(
+                File.Exists(rootRspPath),
+                "Successful import must allow legacy cleanup."
+            );
+            SetupCscRsp.SynchronizeResponseFiles(_assetsDirectory, imports.Add, ref importPending);
+            CollectionAssert.AreEqual(
+                new[] { "Assets/csc.rsp" },
+                imports,
+                "An unchanged destination must retry the failed import once."
+            );
+        }
+
+        private void CreateSidecar()
+        {
+            string sidecarPath = Path.Combine(
+                _projectDirectory,
+                DxMessagingBaseCallIgnoreSync.SidecarAssetPath
+            );
+            Directory.CreateDirectory(Path.GetDirectoryName(sidecarPath));
+            File.WriteAllText(sidecarPath, "Consumer.IgnoredType");
+        }
+
+        private static void AssertResponseFile(string path, string[] expectedLines, string context)
+        {
+            Assert.AreEqual(
+                expectedLines != null,
+                File.Exists(path),
+                $"Unexpected response-file presence at {path}: {context}."
+            );
+            if (expectedLines != null)
+            {
+                CollectionAssert.AreEqual(
+                    expectedLines,
+                    File.ReadAllLines(path),
+                    $"Unexpected response-file contents at {path}: {context}."
+                );
+            }
+        }
+
+        [TestCase("-define:FOO # ")]
+        [TestCase("-define:FOO #comment ")]
+        public void InlineCommentsDoNotCountAsActiveSidecarWiring(string prefix)
+        {
+            string input = prefix + SidecarArgument;
+            string[] actual = SetupCscRsp.SynchronizeAdditionalFileForIgnoreListLines(
+                new[] { input },
+                DxMessagingBaseCallIgnoreSync.SidecarAssetPath,
+                true,
+                out bool modified
+            );
+            CollectionAssert.AreEqual(
+                new[] { input, SidecarArgument },
+                actual,
+                $"Commented sidecar options must stay inactive for prefix [{prefix}]."
+            );
+            Assert.IsTrue(modified, $"Missing active wiring must be added for prefix [{prefix}].");
+        }
+
+        [TestCase(",")]
+        [TestCase(";")]
+        public void MixedAnalyzerListsPreserveConsumerAnalyzers(string separator)
+        {
+            string input =
+                "  /analyzer:WallstopStudios.DxMessaging.Analyzer.dll"
+                + separator
+                + "\"Other,Analyzer.dll\""
+                + separator
+                + "Third.dll  # consumer";
+            string[] actual = SetupCscRsp.CleanDxMessagingAnalyzerLines(
+                new[] { input },
+                out bool modified
+            );
+            CollectionAssert.AreEqual(
+                new[]
+                {
+                    "  /analyzer:\"Other,Analyzer.dll\"" + separator + "Third.dll  # consumer",
+                },
+                actual,
+                $"Only managed paths may be removed from analyzer lists separated by [{separator}]."
+            );
+            Assert.IsTrue(
+                modified,
+                $"The managed analyzer must be removed for separator [{separator}]."
+            );
+        }
+
+        [TestCase("utf8", "\r\n")]
+        [TestCase("utf8-bom", "\n")]
+        [TestCase("utf16-le", "\r\n")]
+        [TestCase("utf16-be", "\n")]
+        [TestCase("utf32-le", "\r")]
+        [TestCase("utf32-be", "\r\n")]
+        public void SynchronizationPreservesConsumerEncodingAndWhitespace(
+            string encodingName,
+            string newline
+        )
+        {
+            CreateSidecar();
+            Encoding encoding = encodingName switch
+            {
+                "utf8" => new UTF8Encoding(false),
+                "utf8-bom" => new UTF8Encoding(true),
+                "utf16-le" => new UnicodeEncoding(false, true),
+                "utf16-be" => new UnicodeEncoding(true, true),
+                "utf32-le" => new UTF32Encoding(false, true),
+                "utf32-be" => new UTF32Encoding(true, true),
+                _ => throw new ArgumentException(encodingName),
+            };
+            string original = "  # Consumer comment" + newline + " \t\n" + "  -define:FOO";
+            File.WriteAllText(_testRspFilePath, original, encoding);
+            string rootRspPath = Path.Combine(_projectDirectory, "csc.rsp");
+            File.WriteAllText(
+                rootRspPath,
+                original + newline + SidecarArgument + newline,
+                encoding
+            );
+            bool importPending = false;
+            List<string> imports = new();
+            SetupCscRsp.SynchronizeResponseFiles(_assetsDirectory, imports.Add, ref importPending);
+
+            string expected = original + newline + SidecarArgument + newline;
+            byte[] expectedBytes = CombineEncodingPreamble(encoding, expected);
+            string context = $"encoding={encodingName}, newline=[{newline}]";
+            CollectionAssert.AreEqual(
+                expectedBytes,
+                File.ReadAllBytes(_testRspFilePath),
+                $"Asset content, mixed newlines, whitespace and BOM must survive synchronization: {context}."
+            );
+            CollectionAssert.AreEqual(
+                CombineEncodingPreamble(encoding, original + newline),
+                File.ReadAllBytes(rootRspPath),
+                $"Root content, mixed newlines, whitespace and BOM must survive migration: {context}."
+            );
+            SetupCscRsp.SynchronizeResponseFiles(_assetsDirectory, imports.Add, ref importPending);
+            CollectionAssert.AreEqual(
+                expectedBytes,
+                File.ReadAllBytes(_testRspFilePath),
+                $"A second sync must preserve identical bytes: {context}."
+            );
+            CollectionAssert.AreEqual(
+                new[] { "Assets/csc.rsp" },
+                imports,
+                $"A second sync must not import again: {context}."
+            );
+        }
+
+        [TestCase(",", true)]
+        [TestCase(";", true)]
+        [TestCase(",", false)]
+        [TestCase(";", false)]
+        public void MixedAdditionalFileListsPreserveConsumerFiles(
+            string separator,
+            bool sidecarExists
+        )
+        {
+            string input =
+                "  /additionalfile:\"Other,File.txt\""
+                + separator
+                + "Assets/Editor/DxMessaging.BaseCallIgnore.txt"
+                + separator
+                + "Third.txt  # consumer";
+            string retained = "  /additionalfile:\"Other,File.txt\"" + separator + "Third.txt";
+            string expected =
+                retained + (sidecarExists ? " " + SidecarArgument : "") + "  # consumer";
+            string[] actual = SetupCscRsp.SynchronizeAdditionalFileForIgnoreListLines(
+                new[] { input },
+                DxMessagingBaseCallIgnoreSync.SidecarAssetPath,
+                sidecarExists,
+                out bool modified
+            );
+            string context = $"separator=[{separator}], sidecarExists={sidecarExists}";
+            CollectionAssert.AreEqual(
+                new[] { expected },
+                actual,
+                $"Consumer additional files must remain registered: {context}."
+            );
+            Assert.IsTrue(modified, $"The managed option must be synchronized: {context}.");
+            CollectionAssert.AreEqual(
+                actual,
+                SetupCscRsp.SynchronizeAdditionalFileForIgnoreListLines(
+                    actual,
+                    DxMessagingBaseCallIgnoreSync.SidecarAssetPath,
+                    sidecarExists,
+                    out bool modifiedAgain
+                ),
+                $"List synchronization must be idempotent: {context}."
+            );
+            Assert.IsFalse(
+                modifiedAgain,
+                $"A second pass must not change list contents: {context}."
+            );
+        }
+
+        [TestCase("-r:Folder#Name.dll ")]
+        [TestCase("-r:\"Folder # Name.dll\" ")]
+        [TestCase("-r:Folder\\\"Name.dll ")]
+        public void HashesAndEscapedQuotesInsideArgumentsDoNotHideActiveOptions(string prefix)
+        {
+            string input = prefix + SidecarArgument;
+            string[] actual = SetupCscRsp.SynchronizeAdditionalFileForIgnoreListLines(
+                new[] { input },
+                DxMessagingBaseCallIgnoreSync.SidecarAssetPath,
+                true,
+                out bool modified
+            );
+            CollectionAssert.AreEqual(
+                new[] { input },
+                actual,
+                $"An embedded hash or escaped quote must not hide active options after [{prefix}]."
+            );
+            Assert.IsFalse(
+                modified,
+                $"Existing active options after [{prefix}] must remain unchanged."
+            );
+        }
+
+        [TestCase("-a:OtherWallstopStudios.DxMessaging.Analyzer.dll")]
+        [TestCase(
+            "-a:Packages/com.wallstop-studios.dxmessaging.extension/Microsoft.CodeAnalysis.dll"
+        )]
+        [TestCase(
+            "-a:Assets/Plugins/Editor/WallstopStudios.DxMessaging.Custom/Microsoft.CodeAnalysis.dll"
+        )]
+        [TestCase("-additionalfile:Assets/Consumer.DxMessaging.BaseCallIgnore.Notes.txt")]
+        [TestCase("-additionalfile:Assets/DxMessaging.BaseCallIgnore/Consumer.txt")]
+        public void ConsumerOptionsWithSimilarNamesArePreserved(string argument)
+        {
+            string[] cleaned = SetupCscRsp.CleanDxMessagingAnalyzerLines(
+                new[] { argument },
+                out bool removedAnalyzer
+            );
+            string[] synchronized = SetupCscRsp.SynchronizeAdditionalFileForIgnoreListLines(
+                cleaned,
+                DxMessagingBaseCallIgnoreSync.SidecarAssetPath,
+                false,
+                out bool removedSidecar
+            );
+            CollectionAssert.AreEqual(
+                new[] { argument },
+                synchronized,
+                $"A similar name does not make a consumer option package-owned: [{argument}]."
+            );
+            Assert.IsFalse(
+                removedAnalyzer || removedSidecar,
+                $"No package-managed path was present in [{argument}]."
+            );
+        }
+
+        private static byte[] CombineEncodingPreamble(Encoding encoding, string text)
+        {
+            byte[] preamble = encoding.GetPreamble();
+            byte[] encoded = encoding.GetBytes(text);
+            byte[] bytes = new byte[preamble.Length + encoded.Length];
+            Buffer.BlockCopy(preamble, 0, bytes, 0, preamble.Length);
+            Buffer.BlockCopy(encoded, 0, bytes, preamble.Length, encoded.Length);
+            return bytes;
         }
 
         public static IEnumerable<TestCaseData> CscRspCleanupCases()

--- a/Tests/Runtime/Core/DifferentialBusTraceTests.cs
+++ b/Tests/Runtime/Core/DifferentialBusTraceTests.cs
@@ -27,7 +27,7 @@ namespace DxMessaging.Tests.Runtime.Core
         public void TearDown() => _diagnostics.Dispose();
 
         [Test]
-        public void GeneratorVersionPinsKnownSeedPrefix([Values(1, 2, 3, 4, 5)] int version)
+        public void GeneratorVersionPinsKnownSeedPrefix([Values(1, 2, 3, 4, 5, 6)] int version)
         {
             BusTraceSequence sequence = DifferentialBusTrace.Generate(
                 MessageScenario.Untargeted(),
@@ -37,18 +37,26 @@ namespace DxMessaging.Tests.Runtime.Core
             );
             Assert.That(
                 BusTraceSequence.GeneratorVersion,
-                Is.EqualTo(5),
+                Is.EqualTo(6),
                 "Changing generation requires a new version and a reviewed replay fixture."
             );
             CollectionAssert.AreEqual(
-                version == 5
-                    ? new[]
-                    {
-                        "Register(token=0,context=0,value=1409999377,priority=1)",
-                        "Emit(token=0,context=0,value=1481184789,priority=1)",
-                        "Register(token=3,context=1,value=-541008231,priority=1)",
-                        "EmitNested(token=0,context=0,value=-1592061232,priority=0)[kindOffset=0,nestedToken=0,depth=1]",
-                    }
+                version == 6
+                        ? new[]
+                        {
+                            "Register(token=0,context=0,value=1409999377,priority=1)",
+                            "Emit(token=0,context=0,value=1481184789,priority=1)",
+                            "Emit(token=3,context=1,value=-541008231,priority=1)",
+                            "EmitNested(token=0,context=0,value=-1592061232,priority=0)[kindOffset=0,nestedToken=0,depth=1]",
+                        }
+                    : version == 5
+                        ? new[]
+                        {
+                            "Register(token=0,context=0,value=1409999377,priority=1)",
+                            "Emit(token=0,context=0,value=1481184789,priority=1)",
+                            "Register(token=3,context=1,value=-541008231,priority=1)",
+                            "EmitNested(token=0,context=0,value=-1592061232,priority=0)[kindOffset=0,nestedToken=0,depth=1]",
+                        }
                     : new[]
                     {
                         "Register(token=0,context=0,value=1409999377,priority=1)",
@@ -247,7 +255,7 @@ namespace DxMessaging.Tests.Runtime.Core
             Assert.That(DifferentialBusTrace.IsValid(minimal), Is.True, report);
             Assert.That(replayed?.Category, Is.EqualTo(mismatch.Category), report);
             Assert.That(minimal.Seed, Is.EqualTo(original.Seed), report);
-            Assert.That(minimal.Version, Is.EqualTo(5), report);
+            Assert.That(minimal.Version, Is.EqualTo(BusTraceSequence.GeneratorVersion), report);
             CollectionAssert.AreEqual(
                 fault == "nested"
                     ? new[]
@@ -549,7 +557,7 @@ namespace DxMessaging.Tests.Runtime.Core
                 minimal.Operations.Select(operation => operation.Kind),
                 report
             );
-            Assert.That(minimal.Version, Is.EqualTo(5), report);
+            Assert.That(minimal.Version, Is.EqualTo(BusTraceSequence.GeneratorVersion), report);
             Assert.That(minimal.Seed, Is.EqualTo(original.Seed), report);
             Assert.That(
                 EvaluateMutant(minimal, "trim-force")?.Category,
@@ -742,7 +750,7 @@ namespace DxMessaging.Tests.Runtime.Core
             [ValueSource(typeof(MessageScenarios), nameof(MessageScenarios.AllKinds))]
                 MessageScenario scenario,
             [Values(17, 42)] int seed,
-            [Values(3, 4, 5)] int version
+            [Values(3, 4, 5, 6)] int version
         )
         {
             BusTraceSequence sequence = DifferentialBusTrace.Generate(
@@ -1114,7 +1122,7 @@ namespace DxMessaging.Tests.Runtime.Core
         }
 
         [TestCase(0)]
-        [TestCase(6)]
+        [TestCase(7)]
         public void UnsupportedGeneratorVersionsAreRejected(int version)
         {
             Assert.Throws<ArgumentOutOfRangeException>(
@@ -1368,6 +1376,249 @@ namespace DxMessaging.Tests.Runtime.Core
             }
         }
 
+        /// <remarks>
+        /// 2026-09-06: A reused registration can make a five-operation trace irreducible by
+        /// single deletion. Check that contract instead of assuming a global three-operation minimum.
+        /// </remarks>
+        [Test]
+        public void ForeignHandleReplayPreservesBothOwnersAndDetectsAliasing(
+            [ValueSource(typeof(MessageScenarios), nameof(MessageScenarios.AllKinds))]
+                MessageScenario scenario
+        )
+        {
+            BusTraceSequence sequence = new(
+                scenario,
+                509,
+                new[]
+                {
+                    new BusTraceOperation(BusTraceOperationKind.Enable, token: 3),
+                    new BusTraceOperation(BusTraceOperationKind.Register, priority: -1),
+                    new BusTraceOperation(BusTraceOperationKind.Register, token: 1, priority: 1),
+                    new BusTraceOperation(BusTraceOperationKind.RemoveForeign, token: 1),
+                    new BusTraceOperation(BusTraceOperationKind.Emit, value: 11),
+                    new BusTraceOperation(BusTraceOperationKind.Disable, token: 1),
+                    new BusTraceOperation(BusTraceOperationKind.RemoveForeign, token: 1),
+                    new BusTraceOperation(BusTraceOperationKind.Enable, token: 1),
+                    new BusTraceOperation(BusTraceOperationKind.Emit, value: 12),
+                    new BusTraceOperation(BusTraceOperationKind.Remove),
+                    new BusTraceOperation(BusTraceOperationKind.RemoveForeign, token: 1),
+                    new BusTraceOperation(BusTraceOperationKind.Emit, value: 13),
+                    new BusTraceOperation(BusTraceOperationKind.Register, priority: -1),
+                    new BusTraceOperation(BusTraceOperationKind.RemoveForeign, handleToken: 1),
+                    new BusTraceOperation(BusTraceOperationKind.Emit, value: 14),
+                    new BusTraceOperation(BusTraceOperationKind.Remove, token: 1),
+                    new BusTraceOperation(BusTraceOperationKind.Emit, value: 15),
+                }
+            );
+            IReadOnlyList<BusTraceObservation> control = DifferentialBusTrace.Replay(
+                sequence,
+                kind => CreateAdapter(kind, false)
+            );
+            string report =
+                $"[{scenario.Kind}] foreign handle trace: " + string.Join("\n", control);
+            Assert.That(control.All(item => item.Exception == null), Is.True, report);
+            CollectionAssert.AreEqual(
+                new[] { "token=0,value=11", "token=1,value=11" },
+                control[4].Callbacks,
+                report
+            );
+            CollectionAssert.AreEqual(
+                new[] { "token=0,value=12", "token=1,value=12" },
+                control[8].Callbacks,
+                report
+            );
+            CollectionAssert.AreEqual(new[] { "token=1,value=13" }, control[11].Callbacks, report);
+            CollectionAssert.AreEqual(
+                new[] { "token=0,value=14", "token=1,value=14" },
+                control[14].Callbacks,
+                report
+            );
+            CollectionAssert.AreEqual(new[] { "token=0,value=15" }, control[16].Callbacks, report);
+            Assert.That(Evaluate(sequence, dropEmits: false), Is.Null, report);
+
+            BusTraceMismatch mismatch = EvaluateMutant(sequence, "foreign");
+            Assert.That(mismatch, Is.Not.Null, report);
+            Assert.That(mismatch.Index, Is.EqualTo(3), mismatch.BuildReport(sequence));
+            Assert.That(mismatch.Category, Is.EqualTo("state"), mismatch.BuildReport(sequence));
+            BusTraceSequence minimal = DifferentialBusTrace.Shrink(
+                sequence,
+                replay => EvaluateMutant(replay, "foreign")
+            );
+            Assert.That(DifferentialBusTrace.IsValid(minimal), Is.True, report);
+            Assert.That(EvaluateMutant(minimal, "foreign")?.Category, Is.EqualTo("state"), report);
+            Assert.That(minimal.Seed, Is.EqualTo(sequence.Seed), report);
+            Assert.That(minimal.Version, Is.EqualTo(sequence.Version), report);
+            string minimalReport =
+                $"[{scenario.Kind}] minimalCount={minimal.Operations.Count}; minimal={string.Join(";", minimal.Operations)}";
+            Assert.That(
+                minimal.Operations.Count,
+                Is.LessThan(sequence.Operations.Count),
+                minimalReport
+            );
+            for (int index = 0; index < minimal.Operations.Count; ++index)
+            {
+                List<BusTraceOperation> remaining = new(minimal.Operations);
+                remaining.RemoveAt(index);
+                BusTraceSequence deletion = new(
+                    minimal.Scenario,
+                    minimal.Seed,
+                    remaining,
+                    minimal.Version
+                );
+                Assert.That(
+                    !DifferentialBusTrace.IsValid(deletion)
+                        || EvaluateMutant(deletion, "foreign")?.Category != mismatch.Category,
+                    Is.True,
+                    $"{minimalReport}; deleting operation {index} must invalidate dependencies or lose the original mismatch."
+                );
+            }
+
+            BusTraceSequence simple = new(
+                scenario,
+                509,
+                new[]
+                {
+                    new BusTraceOperation(BusTraceOperationKind.Enable, token: 3),
+                    new BusTraceOperation(BusTraceOperationKind.Register),
+                    new BusTraceOperation(BusTraceOperationKind.Register, token: 1),
+                    new BusTraceOperation(BusTraceOperationKind.RemoveForeign, token: 1),
+                    new BusTraceOperation(BusTraceOperationKind.Emit),
+                }
+            );
+            BusTraceSequence simpleMinimum = DifferentialBusTrace.Shrink(
+                simple,
+                replay => EvaluateMutant(replay, "foreign")
+            );
+            Assert.That(DifferentialBusTrace.IsValid(simpleMinimum), Is.True, report);
+            Assert.That(
+                EvaluateMutant(simpleMinimum, "foreign")?.Category,
+                Is.EqualTo("state"),
+                report
+            );
+            Assert.That(simpleMinimum.Seed, Is.EqualTo(simple.Seed), report);
+            Assert.That(simpleMinimum.Version, Is.EqualTo(simple.Version), report);
+            CollectionAssert.AreEqual(
+                new[]
+                {
+                    BusTraceOperationKind.Register,
+                    BusTraceOperationKind.Register,
+                    BusTraceOperationKind.RemoveForeign,
+                },
+                simpleMinimum.Operations.Select(operation => operation.Kind),
+                $"[{scenario.Kind}] simple minimum must retain both owners and foreign cleanup: {string.Join(";", simpleMinimum.Operations)}"
+            );
+        }
+
+        [Test]
+        public void ForeignHandleValidityPreservesIssuedHandleDependencies()
+        {
+            MessageScenario scenario = MessageScenario.Untargeted();
+            BusTraceOperation owner = new(BusTraceOperationKind.Register, token: 1);
+            BusTraceOperation foreign = new(BusTraceOperationKind.RemoveForeign, handleToken: 1);
+            foreach (
+                BusTraceOperation[] operations in new[]
+                {
+                    new[] { owner, foreign, foreign },
+                    new[]
+                    {
+                        owner,
+                        new BusTraceOperation(BusTraceOperationKind.Remove, token: 1),
+                        foreign,
+                    },
+                }
+            )
+            {
+                Assert.That(
+                    DifferentialBusTrace.IsValid(new BusTraceSequence(scenario, 509, operations)),
+                    Is.True,
+                    string.Join(";", operations)
+                );
+                Assert.That(
+                    DifferentialBusTrace.IsValid(
+                        new BusTraceSequence(scenario, 509, operations, generatorVersion: 5)
+                    ),
+                    Is.False,
+                    string.Join(";", operations)
+                );
+            }
+            foreach (
+                BusTraceOperation[] operations in new[]
+                {
+                    new[] { foreign },
+                    new[]
+                    {
+                        owner,
+                        new BusTraceOperation(
+                            BusTraceOperationKind.RemoveForeign,
+                            token: 1,
+                            handleToken: 1
+                        ),
+                    },
+                    new[]
+                    {
+                        owner,
+                        new BusTraceOperation(BusTraceOperationKind.RemoveForeign, handleToken: -1),
+                    },
+                    new[]
+                    {
+                        owner,
+                        new BusTraceOperation(
+                            BusTraceOperationKind.RemoveForeign,
+                            handleToken: BusTraceSequence.TokenCount
+                        ),
+                    },
+                    new[]
+                    {
+                        owner,
+                        new BusTraceOperation(BusTraceOperationKind.Emit, handleToken: 1),
+                    },
+                }
+            )
+            {
+                Assert.That(
+                    DifferentialBusTrace.IsValid(new BusTraceSequence(scenario, 509, operations)),
+                    Is.False,
+                    string.Join(";", operations)
+                );
+            }
+            BusTraceSequence generated = DifferentialBusTrace.Generate(scenario, 17, 256);
+            Assert.That(
+                DifferentialBusTrace.IsValid(generated),
+                Is.True,
+                "Version 6 seed 17 must retain foreign handle dependencies."
+            );
+            Assert.That(
+                generated.Operations.Any(operation =>
+                    operation.Kind == BusTraceOperationKind.RemoveForeign
+                ),
+                Is.True,
+                "Version 6 seed 17 must generate foreign cleanup."
+            );
+            StringAssert.Contains(
+                "handleToken=1",
+                foreign.ToString(),
+                "Replay evidence must identify the foreign handle owner."
+            );
+        }
+
+        private sealed class ForeignHandleAliasAdapter : MessageBusTraceAdapter
+        {
+            internal ForeignHandleAliasAdapter(MessageScenario scenario, MessageBus bus)
+                : base(scenario, bus, reset: bus.ResetState) { }
+
+            protected override void Remove(BusTraceOperation operation)
+            {
+                if (operation.Kind == BusTraceOperationKind.RemoveForeign)
+                {
+                    // Simulate treating a foreign identity as the destination's own slot.
+                    // The production API performs the removal; the observer stays unchanged.
+                    Token(operation.Token).RemoveRegistration(Handle(operation.Token));
+                    return;
+                }
+                base.Remove(operation);
+            }
+        }
+
         private static BusTraceMismatch EvaluateMutant(BusTraceSequence sequence, string fault) =>
             DifferentialBusTrace.Compare(
                 DifferentialBusTrace.Replay(sequence, kind => CreateAdapter(kind, false)),
@@ -1387,6 +1638,7 @@ namespace DxMessaging.Tests.Runtime.Core
             {
                 "order" => new EqualPriorityReorderAdapter(scenario, bus),
                 "stale" => new StaleHandleReuseAdapter(scenario, bus),
+                "foreign" => new ForeignHandleAliasAdapter(scenario, bus),
                 "exception-cleanup" => new SkippedExceptionCleanupAdapter(scenario, bus),
                 "diagnostics" => new DuplicateDiagnosticsAdapter(scenario, bus),
                 "leak" => new RegistrationLeakAdapter(scenario, bus),
@@ -1629,7 +1881,7 @@ namespace DxMessaging.Tests.Runtime.Core
             foreach (
                 string expected in new[]
                 {
-                    "generator=5",
+                    "generator=" + BusTraceSequence.GeneratorVersion,
                     "seed=42",
                     "kind=" + scenario.Kind,
                     "firstMismatch=1",

--- a/Tests/Runtime/TestUtilities/DifferentialBusTrace.cs
+++ b/Tests/Runtime/TestUtilities/DifferentialBusTrace.cs
@@ -22,6 +22,7 @@ namespace DxMessaging.Tests.Runtime
         Trim,
         EmitNested,
         EmitWithDisable,
+        RemoveForeign,
     }
 
     /// <summary>Replay input with stable logical token identity, route, payload, and priority.</summary>
@@ -35,7 +36,8 @@ namespace DxMessaging.Tests.Runtime
             int priority = 0,
             int kindOffset = 0,
             int nestedToken = 0,
-            int depth = 0
+            int depth = 0,
+            int handleToken = 0
         )
         {
             Kind = kind;
@@ -46,6 +48,7 @@ namespace DxMessaging.Tests.Runtime
             KindOffset = kindOffset;
             NestedToken = nestedToken;
             Depth = depth;
+            HandleToken = handleToken;
         }
 
         internal BusTraceOperationKind Kind { get; }
@@ -58,11 +61,19 @@ namespace DxMessaging.Tests.Runtime
         internal int NestedToken { get; }
         internal int Depth { get; }
 
+        // RemoveForeign passes this owner's most recently issued handle to Token.
+        internal int HandleToken { get; }
+
         public override string ToString() =>
             $"{Kind}(token={Token},context={Context},value={Value},priority={Priority})"
             + (
                 KindOffset != 0 || NestedToken != 0 || Depth != 0
                     ? $"[kindOffset={KindOffset},nestedToken={NestedToken},depth={Depth}]"
+                    : string.Empty
+            )
+            + (
+                Kind == BusTraceOperationKind.RemoveForeign
+                    ? $"[handleToken={HandleToken}]"
                     : string.Empty
             );
     }
@@ -70,7 +81,7 @@ namespace DxMessaging.Tests.Runtime
     /// <summary>Immutable, versioned replay inputs; a seed identifies the original generator sequence.</summary>
     internal sealed class BusTraceSequence
     {
-        internal const int GeneratorVersion = 5;
+        internal const int GeneratorVersion = 6;
         internal const int TokenCount = 4;
         internal const int MaxOperations = 256;
 
@@ -217,7 +228,8 @@ namespace DxMessaging.Tests.Runtime
                         : generatorVersion == 2 ? 6U
                         : generatorVersion == 3 ? 9U
                         : generatorVersion == 4 ? 10U
-                        : 12U
+                        : generatorVersion == 5 ? 12U
+                        : 13U
                     )
                 );
                 if (index == 0)
@@ -271,6 +283,15 @@ namespace DxMessaging.Tests.Runtime
                 {
                     nestedToken = token;
                 }
+                int handleToken = kind == BusTraceOperationKind.RemoveForeign ? nestedToken : 0;
+                if (
+                    kind == BusTraceOperationKind.RemoveForeign
+                    && (handleToken == token || (!registered[handleToken] && !removed[handleToken]))
+                )
+                {
+                    kind = BusTraceOperationKind.Emit;
+                    handleToken = 0;
+                }
                 if (generatorVersion >= 5)
                 {
                     if (index < 2)
@@ -300,7 +321,8 @@ namespace DxMessaging.Tests.Runtime
                         (int)(Next(ref state) % 3) - 1,
                         kindOffset,
                         nestedToken: kind == BusTraceOperationKind.EmitNested ? nestedToken : 0,
-                        depth: depth
+                        depth: depth,
+                        handleToken: handleToken
                     )
                 );
                 if (kind == BusTraceOperationKind.Register)
@@ -353,6 +375,12 @@ namespace DxMessaging.Tests.Runtime
                     || operation.KindOffset > 2
                     || operation.NestedToken < 0
                     || operation.NestedToken >= registered.Length
+                    || operation.HandleToken < 0
+                    || operation.HandleToken >= registered.Length
+                    || (
+                        operation.Kind != BusTraceOperationKind.RemoveForeign
+                        && operation.HandleToken != 0
+                    )
                     || operation.Depth < 0
                     || operation.Depth > 10
                     || (
@@ -387,6 +415,21 @@ namespace DxMessaging.Tests.Runtime
                         }
                         registered[operation.Token] = false;
                         removed[operation.Token] = true;
+                        break;
+                    case BusTraceOperationKind.RemoveForeign:
+                        if (
+                            sequence.Version < 6
+                            || operation.Token == operation.HandleToken
+                            || (
+                                !registered[operation.HandleToken]
+                                && !removed[operation.HandleToken]
+                            )
+                        )
+                        {
+                            return false;
+                        }
+                        // Foreign cleanup owns neither the destination nor source registration.
+                        // A removed source still supplies its actual stale handle for replay.
                         break;
                     case BusTraceOperationKind.Enable:
                     case BusTraceOperationKind.Disable:

--- a/Tests/Runtime/TestUtilities/MessageBusTraceAdapter.cs
+++ b/Tests/Runtime/TestUtilities/MessageBusTraceAdapter.cs
@@ -96,6 +96,7 @@ namespace DxMessaging.Tests.Runtime
                         break;
                     case BusTraceOperationKind.Remove:
                     case BusTraceOperationKind.RemoveStale:
+                    case BusTraceOperationKind.RemoveForeign:
                         Remove(operation);
                         break;
                     case BusTraceOperationKind.Enable:
@@ -274,9 +275,10 @@ namespace DxMessaging.Tests.Runtime
         {
             int slot = operation.Token;
             MessageRegistrationHandle handle =
-                operation.Kind == BusTraceOperationKind.RemoveStale
-                    ? _staleHandles[slot]
-                    : _handles[slot];
+                operation.Kind == BusTraceOperationKind.RemoveStale ? _staleHandles[slot]
+                : operation.Kind == BusTraceOperationKind.RemoveForeign
+                    ? _handles[operation.HandleToken]
+                : _handles[slot];
             _tokens[slot].RemoveRegistration(handle);
             if (operation.Kind == BusTraceOperationKind.Remove)
             {

--- a/docs/guides/inspector-overlay.md
+++ b/docs/guides/inspector-overlay.md
@@ -300,7 +300,7 @@ The settings asset itself lives at
 `Assets/Editor/DxMessagingSettings.asset`. The ignored-types list is
 mirrored to the sidecar
 `Assets/Editor/DxMessaging.BaseCallIgnore.txt` that the analyzer reads
-via `csc.rsp`'s `-additionalfile:` switch.
+via `Assets/csc.rsp`'s `-additionalfile:` switch.
 
 > **Note**: The Inspector overlay's **Ignore this type** / **Stop ignoring**
 > buttons read and write the same ignore-list field that Project Settings

--- a/docs/guides/inspector-overlay.md
+++ b/docs/guides/inspector-overlay.md
@@ -93,6 +93,10 @@ subclasses keep their normal inspector body; the package injects the
 same warning data through Unity's component-header hook as an IMGUI
 HelpBox so the user's editor can stay in charge of its body.
 
+While Unity imports or compiles, a new Inspector keeps its empty warning area
+hidden until it can resolve the warning state. An existing warning stays visible
+until that refresh completes.
+
 The title includes the contributing diagnostic ID. An aggregated report sorts
 and deduplicates multiple IDs before rendering them.
 

--- a/docs/reference/analyzers.md
+++ b/docs/reference/analyzers.md
@@ -474,6 +474,15 @@ unrelated options there. Existing consumer options in `Assets/csc.rsp` are
 preserved. Review any custom root-file options before moving them into `Assets`,
 because moving them activates them for compilation.
 
+For automated builds, call `DxMessaging.Editor.SetupCscRsp.PrepareCompilerInputs()`
+from an explicit configuration entry point before changing compilation settings.
+Added in 4.0.0, this method prepares the settings asset, ignore sidecar, and response
+file synchronously and throws if preparation fails. Run configuration before the
+separate build or test editor invocation, as the repository's CI runner does.
+Preparation can request script compilation; it does not wait for compilation to
+finish. Do not call it from initialization or deserialization callbacks, or start
+a player build immediately after it in the same callback.
+
 ---
 
 ## Unity 2021 setup notes

--- a/docs/reference/analyzers.md
+++ b/docs/reference/analyzers.md
@@ -450,7 +450,7 @@ compiler host supplies Roslyn and `System.Collections.Immutable`; DxMessaging
 does not bundle private copies of those compiler assemblies.
 
 `Editor/SetupCscRsp.cs` is still used for the base-call ignore sidecar. It keeps
-`csc.rsp` in sync by removing stale DxMessaging analyzer `-a:` entries (left
+`Assets/csc.rsp` in sync by removing stale DxMessaging analyzer `-a:` entries (left
 behind by older package versions that copied analyzers into the project) and
 ensuring there is at most one ignore-list entry when the sidecar exists:
 
@@ -459,13 +459,20 @@ ensuring there is at most one ignore-list entry when the sidecar exists:
 ```
 
 The `-additionalfile:` line is only emitted when the ignore-list sidecar
-physically exists. Sidecar regeneration also schedules a follow-up `csc.rsp`
+physically exists. Sidecar regeneration also schedules a follow-up `Assets/csc.rsp`
 sync, so deferred `OnValidate` writes and the Inspector overlay's ignore-list
 buttons repair missing response-file wiring during the same editor session.
 
-Manual edits to `csc.rsp` are rarely necessary; the setup helper detects
+Manual edits to `Assets/csc.rsp` are rarely necessary; the setup helper detects
 existing lines and only appends or removes the DxMessaging lines that need
 normalization.
+
+Starting in 4.0.0, the helper uses `Assets/csc.rsp`, where Unity reads compiler
+options. Earlier versions wrote an unused `csc.rsp` at the project root. The
+helper removes its own obsolete entries from that root file and preserves
+unrelated options there. Existing consumer options in `Assets/csc.rsp` are
+preserved. Review any custom root-file options before moving them into `Assets`,
+because moving them activates them for compilation.
 
 ---
 

--- a/scripts/unity/__tests__/il2cpp-profile.test.ps1
+++ b/scripts/unity/__tests__/il2cpp-profile.test.ps1
@@ -104,6 +104,14 @@ try {
         Assert-That 'generated C# embeds the profile SHA-256' ($source.Contains($profileSha256))
     }
     $buildModifierSource = New-StandaloneBuildModifierSource -CanonicalProfileId $profile.profileId
+    $applyStart = $generatedSources[0].IndexOf('public static void Apply()')
+    $compilerPreparation = $generatedSources[0].IndexOf('DxMessaging.Editor.SetupCscRsp.PrepareCompilerInputs();', $applyStart)
+    $compilationChange = $generatedSources[0].IndexOf('CompilationPipeline.codeOptimization =', $applyStart)
+    $completionMarker = $generatedSources[0].IndexOf('File.WriteAllText(markerPath,', $applyStart)
+    Assert-That 'configuration prepares compiler inputs before changing compilation settings and writing its success marker' (
+        $compilerPreparation -gt $applyStart -and $compilerPreparation -lt $compilationChange -and
+        $compilationChange -lt $completionMarker
+    )
     Assert-That 'the configurator pins OptimizeSpeed' (
         $generatedSources[0].Contains('Il2CppCodeGeneration.OptimizeSpeed')
     )

--- a/scripts/unity/run-ci-tests.ps1
+++ b/scripts/unity/run-ci-tests.ps1
@@ -1566,8 +1566,13 @@ public static class DxmCiTestConfigurator
 
     public static void Apply()
     {
-        // Prove Release editor code optimization for every Unity CI leg. Set FIRST
-        // so the effective value is logged below.
+        // Finish package compiler inputs before this process exits. Deferring the
+        // sidecar/response-file sync lets the next test launch trigger compilation
+        // after its player build has already started.
+        DxMessaging.Editor.SetupCscRsp.PrepareCompilerInputs();
+
+        // Prove Release editor code optimization for every Unity CI leg before
+        // logging the effective configuration below.
         UnityEditor.Compilation.CompilationPipeline.codeOptimization = UnityEditor.Compilation.CodeOptimization.Release;
 
         EditorUserBuildSettings.SwitchActiveBuildTarget(BuildTargetGroup.Standalone, BuildTarget.StandaloneWindows64);


### PR DESCRIPTION
## Why

Project ignore settings did not reach Unity's compiler because the response file was outside `Assets`. Cleanup also removed consumer analyzers from grouped arguments and mistook comments for active options.

Activating the response file exposed a deferred import that could interrupt automated player builds. Inspectors opened during imports could leave an empty warning area.

## What changed

- Use `Assets/csc.rsp`. Preserve consumer options, comments, encoding, line endings, and quoted lists. Retire only package-owned legacy entries.
- Prepare settings, the ignore sidecar, and compiler options first in the existing configuration phase. Propagate failures before its completion marker.
- Hide the empty inspector warning area until its first state resolves. Preserve existing warnings during deferred refreshes.
- Add foreign-handle replay to the differential oracle. Preserve older generator versions and verify failure detection and valid shrinking.

## How we know

All four Unity versions pass editor, PlayMode, and standalone tests. All 38 applicable PR checks pass. There are no open review findings.

Independent artifact checks verify 13,702 Unity passes and unchanged skips. Performance checks pass: 202 internal, 55 comparisons, and 363 contracts. Configuration logs and successful player tests verify the build-race correction.

Native verification passes twice: 120 focused tests, 943 editor tests, and 1,432 runtime tests. Preparation scenarios pass 150 repetitions. All 1,206 script tests, 617 documentation checks, and 324 real-Roslyn parser cases pass.

Performance test phases take 576/412 seconds versus baseline 576/416. The comparable Unity 6000.3 job takes 248 seconds versus 215. Compilation and startup account for most observed overhead; changed fixtures add about 0.65 seconds. No extra editor launch, benchmark window, or test wait was added. [Full acceptance and timing limits](https://github.com/Ambiguous-Interactive/DxMessaging/pull/539#issuecomment-5557636016).

## Related Issue

Closes #537.
Closes #538.
Closes #540.
Closes #541.
Advances #509; broader lifecycle and campaign evidence remain open.

## Type of Change

- [x] Bug fix
- [x] Documentation update

## Checklist

- [x] Changed behavior passes local and CI tests
- [x] Code is formatted
- [x] Regression tests prove the fixes
- [x] Documentation and changelog are updated
- [x] No breaking changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes editor asset mutation and `csc.rsp` contents that affect Roslyn/analyzer wiring for every consumer project; mistakes could break compilation or strip consumer compiler options, though migration logic and extensive tests target that risk.
> 
> **Overview**
> Fixes **base-call ignore settings not reaching the compiler** by syncing **`Assets/csc.rsp`** (where Unity reads options) instead of an unused project-root file. Package-owned analyzer and `-additionalfile` lines are cleaned or migrated from the legacy root file **without** moving unrelated consumer options; encoding, line endings, comments, and quoted multi-path arguments are preserved. Sidecar writes use **atomic** files, **import-pending** retries, and a new **`SetupCscRsp.PrepareCompilerInputs()`** API for CI/configuration to batch sidecar + response-file work before builds (also wired into the Unity CI configurator).
> 
> The **MessageAwareComponent** fallback inspector now keeps the warning host **`display: none`** until the first warning state resolves, so an empty gap does not show during import/compile deferral.
> 
> The differential bus trace oracle gains **`RemoveForeign`** and **generator version 6** to replay and shrink foreign-handle aliasing bugs; docs and changelog reflect the `Assets/csc.rsp` path and preparation API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f656f277e9082d5215edfc92dca1b53eebe2ff0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->