### PR TITLE
Fix messaging owner cleanup and inactive host delivery

### DIFF
--- a/.llm/context.md
+++ b/.llm/context.md
@@ -97,9 +97,13 @@ editor), NOT inside the devcontainer. The container ships no local Unity build. 
 
 - The devcontainer workspace IS the embedded package inside the host Unity project,
   so edits in-container are instantly visible to the editor.
-- Compile: first refuse if any open scene is dirty, a prefab stage is open, or the editor is
-  playing/compiling/updating; then execute `Assets/Refresh` through `Unity_ManageMenuItem`.
-  Never use an operation that can raise a modal prompt in the developer's shared editor.
+- Preflight: prove framework idleness, idle editor flags, the main stage, and every open scene's
+  clean state through non-refreshing queries or an installed passive observer. `Unity_RunCommand`
+  refreshes assets before executing its snippet, so it cannot establish safety. Once safe, compile
+  through `Unity_ManageMenuItem` with `Assets/Refresh`. Never raise a save prompt in the shared editor.
+- Poll active tests through files only. Require passive framework cleanup and error checks after
+  the raw result reports `done`; never restart solely because observation timed out. See the
+  [framework cleanup gate](./skills/unity-mcp-test-loop/references/mcp-test-loop.md#framework-cleanup-gate).
 - Run tests: call the host bridge `DxMcpTestRunner.Run(testMode, assemblies, tests, categories, resultPath)` via `Unity_RunCommand`, then poll the `.status` sidecar from the container. `resultPath` resolves against the HOST project root, so it MUST be prefixed `Packages/com.wallstop-studios.dxmessaging/.artifacts/unity-mcp/<name>.json`; a bare `.artifacts/unity-mcp/<name>.json` lands where the container cannot see it and the poll waits forever next to stale files.
 - EditMode assemblies: `WallstopStudios.DxMessaging.Tests.Editor`, `...Tests.Editor.Allocations`, `...Tests.00.Editor.Benchmarks`. PlayMode: `...Tests.Runtime`, `...Tests.00.Runtime.Benchmarks` (category `PerfBench`), `...Tests.00.Runtime.Comparisons`, DI integrations (Reflex/VContainer/Zenject).
 - Perf baselines: the benchmark CSV defaults to `.artifacts/perf-baseline.csv` (override env `DX_PERF_BASELINE`; `DX_PERF_COMMIT` stamps the commit column).

--- a/.llm/skills/unity-mcp-test-loop/SKILL.md
+++ b/.llm/skills/unity-mcp-test-loop/SKILL.md
@@ -71,11 +71,13 @@ The devcontainer workspace is the same directory as the embedded package inside 
 ### The loop
 
 1. **Edit** files in the container.
-1. **Preflight the shared editor before any refresh or test.** Read `Unity_ManageEditor GetState`,
-   then use a read-only `Unity_RunCommand` to inspect every open scene's `isDirty`, confirm the
-   current stage is the main stage, and confirm the editor is not playing, compiling, or updating.
-   If any scene is dirty, a prefab stage is open, or the editor is busy, do not refresh or change
-   scenes. Wait or report the unsafe state; never invoke an API that can raise a save prompt.
+1. **Preflight before any refresh-capable command or test.** Establish framework idleness, idle editor
+   flags, the main stage, and clean state for every open scene using dedicated queries whose
+   installed implementation does not refresh assets, or an already-installed passive observer.
+   `GetState`, `GetPrefabStage`, and `GetActive` suffice only when their responses cover every
+   required field; an active-scene response cannot prove other scenes are clean. Never use
+   `Unity_RunCommand` to establish safety: it refreshes assets before checking the snippet's
+   guard. If evidence is missing or unsafe, wait or report it without refreshing or changing scenes.
 1. **Compile** with `Unity_ValidateScript` for changed C# under `Assets/`, then execute the
    `Assets/Refresh` menu item through `Unity_ManageMenuItem`. The validator rejects embedded
    `Packages/` paths, so package edits must use the refresh plus fresh-assembly proof. Wait for
@@ -83,6 +85,13 @@ The devcontainer workspace is the same directory as the embedded package inside 
    `Unity_RunCommand`; a modal prompt blocks the editor and only the developer can dismiss it.
 1. **Run** `DxMcpTestRunner.Run(testMode, assemblyNames, testNames, categoryNames, resultPath)` through `Unity_RunCommand`, locating the type by scanning `AppDomain` assemblies. Arguments are semicolon-separated lists and `null` means no filter. `testMode` is `EditMode` or `PlayMode`. `testNames` accepts a full fixture type name such as `DxMessaging.Tests.Runtime.Core.TestAttributeContractTests` for a single-fixture red-green loop.
 1. **Poll** the `.status` sidecar next to `resultPath` from bash. It moves `running` to `done` or `error: <message>`. The JSON result carries `{ passCount, failCount, skipCount, inconclusiveCount, durationSeconds, failures[] }`.
+1. **Wait for framework cleanup before another run or scene mutation.** `RunFinished` can write
+   `done` before Unity restores its temporary scenes. Check the installed Test Framework's active
+   job state and run-scoped framework errors through a passive host observer; do not poll
+   `Unity_RunCommand` during tests because it refreshes assets before executing the snippet.
+   See the [framework cleanup gate](./references/mcp-test-loop.md#framework-cleanup-gate).
+   A stale `running` sidecar alone is not a live job. Inspect framework state and errors before
+   treating an observation timeout as completion or starting another run.
 
 `resultPath` resolves relative to the HOST Unity project root, not the embedded package. To land somewhere the container can read, prefix it: `Packages/com.wallstop-studios.dxmessaging/.artifacts/unity-mcp/<name>.json`. A bare `.artifacts/unity-mcp/<name>.json` writes to the host project root, invisible to the container.
 
@@ -98,6 +107,15 @@ active scene. Re-read scene dirtiness after the run.
 ### Assemblies
 
 EditMode: `WallstopStudios.DxMessaging.Tests.Editor`, `...Tests.Editor.Allocations`, `...Tests.00.Editor.Benchmarks`. PlayMode: `...Tests.Runtime`, `...Tests.00.Runtime.Benchmarks` (category `PerfBench`), `...Tests.00.Runtime.Comparisons`, and the Reflex / VContainer / Zenject integrations. Keep choices consistent with `defaultIncludeAssemblies` in `scripts/unity/lib/asmdef-discovery.js`.
+
+### Default Editor scope
+
+For ordinary Editor verification, select `WallstopStudios.DxMessaging.Tests.Editor` and the
+EditMode category exclusions in `.github/workflows/unity-tests.yml`. Run allocation and benchmark
+assemblies separately. The bridge forwards semicolon-separated native filters, including `!`
+exclusions. An assembly selection can run `[Explicit]` tests; explicitly exclude the documentation
+PNG writer when testing the whole Editor assembly. See
+[default Editor filters and imported samples](./references/mcp-test-loop.md#default-editor-filters-and-imported-samples).
 
 ### Sandbox restrictions
 

--- a/.llm/skills/unity-mcp-test-loop/references/mcp-test-loop.md
+++ b/.llm/skills/unity-mcp-test-loop/references/mcp-test-loop.md
@@ -29,13 +29,16 @@ the host editor; the container only edits files and drives the editor over MCP.
 ## The Loop
 
 1. **Edit** files in the container as usual.
-1. **Preflight the shared editor.** Call `Unity_ManageEditor GetState`, then run one
-   read-only command that logs `SceneManager.sceneCount`, every scene's `path` and
-   `isDirty`, whether `StageUtility.GetCurrentStageHandle()` equals the main stage,
-   and `EditorApplication.isPlaying`, `isCompiling`, and `isUpdating`. Refuse to
-   refresh or change scenes while any scene is dirty, a prefab stage is open, or the
-   editor is busy. Never call an API that can raise a save prompt; a modal blocks the
-   main thread and only the developer can dismiss it.
+1. **Preflight before any refresh-capable command or test.** Use dedicated query actions
+   whose installed implementation does not refresh assets, or an already-installed passive
+   observer, to establish framework idleness, editor flags, current stage, loaded-scene count,
+   and every scene's path and dirty flag. `Unity_ManageEditor GetState` and `GetPrefabStage`
+   plus `Unity_ManageScene GetActive` suffice only when their responses provide all that
+   evidence. With multiple loaded scenes, an active-scene result alone is insufficient.
+   Do not use `Unity_RunCommand` to fill missing fields: its implicit refresh runs before any
+   guard in the supplied code. Report missing evidence or an unsafe state without refreshing,
+   installing a new observer, or changing scenes. A tool's read-only name does not prove its
+   implementation has no import side effects.
 1. **Compile**: validate changed C# under `Assets/` with `Unity_ValidateScript`, then
    execute the `Assets/Refresh` menu item through `Unity_ManageMenuItem`. The validator
    rejects embedded `Packages/` paths, so package edits rely on the refresh plus the
@@ -88,6 +91,42 @@ failures[] }`.
 The bridge survives domain reloads via `[InitializeOnLoad]` + `SessionState`, so a
 recompile mid-run does not lose the result.
 
+## Framework cleanup gate
+
+`DxMcpTestRunner` writes its result during `RunFinished`. Unity Test Framework can still be
+restoring scenes after that callback, even when `EditorApplication.isPlaying` is false. Starting
+another run in that interval can capture a temporary scene that the previous run then deletes.
+Session 266 observed `Invalid SceneManagerSetup` followed by `ReloadScene cannot be used with a
+scene without a SceneAsset` during repeated local runs.
+
+Do not poll `Unity_RunCommand` during a test run. The inspected MCP implementation calls
+`AssetDatabase.Refresh` before executing the supplied code, including read-only snippets. During
+local runtime tests that refresh imported malformed host assets and produced unrelated test
+failures. Use filesystem polling for the active run.
+
+Before repeated runs, prepare a host-side observer while the editor is safe. It must retain the
+current result path across reloads, capture `IErrorCallbacks.OnError` for that run, and use
+`EditorApplication.update` to observe framework cleanup without refreshing assets. On the
+inspected framework the active-job query is the internal static `TestRunnerApi.IsRunActive`.
+Inspect the installed source if that API changes; missing state is not proof of idleness.
+
+The observer must write a separate terminal marker only after the framework reports inactive.
+Capture errors through that point: cleanup can fail after `RunFinished` has already written a
+passing result. Require both successful framework completion and a result with a positive pass
+count, zero failures, and zero inconclusive cases. Keep expected skips visible. Check editor flags
+and every scene's dirtiness again before the next refresh, run, or scene change.
+
+The simple bridge implements only `ICallbacks`, so a framework-level `RunFailed` can leave its
+sidecar at `running` without a result. Inactive framework state with no result is a terminal
+framework failure, not a live test or a pass. Preserve that failed attempt and inspect the error
+before recovery. Restore the original saved scene only after verifying that the editor is idle
+and all scenes are clean. Never restart solely because polling timed out, cancel a run to resolve
+an observation timeout, or discard an unnamed scene containing unreviewed work.
+
+This is local orchestration. Add no delays, retries, or extra test launches to CI. Durable bridge
+ownership and regeneration are tracked in
+[issue #544](https://github.com/Ambiguous-Interactive/DxMessaging/issues/544).
+
 ## Shared Editor Safety
 
 The MCP host is the developer's editor, not an expendable test process. A normal
@@ -118,6 +157,33 @@ test batch.
 
 The canonical include list for CI is `scripts/unity/lib/asmdef-discovery.js`
 (`defaultIncludeAssemblies`); keep MCP-loop assembly choices consistent with it.
+
+## Default Editor filters and imported samples
+
+For an ordinary Editor run, select only `WallstopStudios.DxMessaging.Tests.Editor` and use the
+EditMode exclusions from the [Unity test workflow](../../../../.github/workflows/unity-tests.yml).
+Run `WallstopStudios.DxMessaging.Tests.Editor.Allocations` and benchmark assemblies as separate
+scopes so their measurement windows do not inflate the ordinary suite time.
+
+The bridge splits `categoryNames` and `testNames` at semicolons and forwards native filters
+unchanged. The framework separates leading `!` exclusions from inclusions and ANDs the
+exclusions. Inspect the installed `RuntimeTestRunnerFilter.AddFilters` if its behavior changes.
+An assembly-name inclusion can select an `[Explicit]` test. When running the whole Editor
+assembly, pass
+`!DxMessaging.Tests.Editor.EditorToolingDocumentationCaptureTests.CaptureAllPublishedEditorTooling`
+as `testNames` to prevent the documentation writer from regenerating tracked PNGs.
+Keep other tests in that fixture selected.
+
+Eight `SampleQualityContractTests` cases need imported runnable samples at `Assets/DxmCiSamples`.
+A missing fixture is an inconclusive result, not a passing verification. The CI provisioner
+`Copy-SamplesForCompilation` in `scripts/unity/run-ci-tests.ps1` copies `.cs`, `.asmdef`, and
+`.unity` files with their original `.meta` files. The local fixture needs Mini Combat,
+UI Buttons + Inspector, and Diagnostics Tooling Exerciser. Preserve their GUIDs, refuse an
+existing destination or duplicate imported sample GUIDs/assembly names, and record ownership
+and file hashes outside `Assets`. Import only while the editor is proven safe. After verification,
+remove only the owned fixture, preserving any unexpected changes for review, and confirm the
+editor's original scenes remain clean. Do not weaken the fixture assertions or accept the
+inconclusive results to obtain a green run.
 
 ## Perf Baselines
 

--- a/.llm/skills/unity-mcp-test-loop/references/mcp-test-loop.md
+++ b/.llm/skills/unity-mcp-test-loop/references/mcp-test-loop.md
@@ -66,8 +66,9 @@ the host editor; the container only edits files and drives the editor over MCP.
        System.IO.File.GetLastWriteTimeUtc(fixture.Assembly.Location).ToString("O"));
    ```
 
-   A stale timestamp means the compile failed. Read the CI job log or Unity's
-   `Editor.log` for the `CS####` rather than re-running the suite.
+   After the safe idle preflight, resolve the connected editor's `Application.consoleLogPath`
+   and read only the current compile's `CS####` errors. Do not assume a default `Editor.log`
+   belongs to that editor or print the entire log.
 
 1. **Run**: invoke the host bridge `DxMcpTestRunner.Run(testMode, assemblyNames,
 testNames, categoryNames, resultPath)` via `Unity_RunCommand`. Locate the type by

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix `MessagingComponent` retaining registrations after destruction and delivering to inactive
+  hosts before activation ([#542](https://github.com/Ambiguous-Interactive/DxMessaging/issues/542),
+  [#543](https://github.com/Ambiguous-Interactive/DxMessaging/issues/543)).
+
 - Fix base-call ignore compiler wiring and batch preparation while preserving consumer options
   ([#537](https://github.com/Ambiguous-Interactive/DxMessaging/issues/537),
   [#538](https://github.com/Ambiguous-Interactive/DxMessaging/issues/538),

--- a/Runtime/Unity/MessagingComponent.cs
+++ b/Runtime/Unity/MessagingComponent.cs
@@ -36,6 +36,7 @@ namespace DxMessaging.Unity
         private MessageBusProviderHandle _serializedProviderHandle;
 
         private MessageHandler _messageHandler;
+        private bool _destroyed;
 
         [NonSerialized]
         private IMessageBus _messageBusOverride;
@@ -81,8 +82,21 @@ namespace DxMessaging.Unity
         /// <returns>A <see cref="Core.MessageRegistrationToken"/> bound to the underlying <see cref="Core.MessageHandler"/>.</returns>
         /// <exception cref="ArgumentNullException">If <paramref name="listener"/> is null.</exception>
         /// <exception cref="ArgumentException">If <paramref name="listener"/> is not attached to this GameObject.</exception>
+        /// <exception cref="ObjectDisposedException">If Unity has invoked this owner's destruction callback.</exception>
+        /// <remarks>
+        /// A newly created handler respects the component and GameObject active state unless
+        /// <see cref="emitMessagesWhenDisabled"/> is true. Explicitly release tokens created before
+        /// first activation if the host is destroyed without ever becoming active: Unity does not
+        /// invoke <c>OnDestroy</c> for that host.
+        /// <para><b>Fixed in v4.0.0.</b></para>
+        /// </remarks>
         public MessageRegistrationToken Create(MonoBehaviour listener)
         {
+            if (_destroyed)
+            {
+                throw new ObjectDisposedException(nameof(MessagingComponent));
+            }
+
             if (listener == null)
             {
                 throw new ArgumentNullException(nameof(listener));
@@ -263,15 +277,68 @@ namespace DxMessaging.Unity
         }
 
         /// <summary>
+        /// Stops delivery and disposes retained tokens when Unity destroys this owner.
+        /// </summary>
+        /// <remarks>
+        /// Failed cleanup remains available through <see cref="Release"/> for an explicit retry.
+        /// Unity only sends this callback to hosts that were previously active. Owners of tokens
+        /// created before first activation must release them when abandoning a never-activated host.
+        /// <para><b>Fixed in v4.0.0.</b></para>
+        /// </remarks>
+        private void OnDestroy()
+        {
+            _destroyed = true;
+            if (_messageHandler != null)
+            {
+                _messageHandler.active = false;
+            }
+
+            DisposeRetainedListeners();
+        }
+
+        /// <summary>
+        /// Releases independent listeners while retaining failed cleanup for a later retry.
+        /// </summary>
+        private void DisposeRetainedListeners()
+        {
+            if (_registeredListeners.Count == 0)
+            {
+                return;
+            }
+
+            foreach (MonoBehaviour listener in _registeredListeners.Keys.ToArray())
+            {
+                try
+                {
+                    Release(listener);
+                }
+                catch (Exception exception)
+                {
+                    Debug.LogWarning(
+                        $"[DxMessaging] Disposing listener token failed. {exception}",
+                        this
+                    );
+                }
+            }
+        }
+
+        /// <summary>
         /// Explicitly toggle the underlying handler's active state.
         /// </summary>
         /// <param name="newActive">Desired active state.</param>
         /// <remarks>
-        /// Explicit calls always win: unlike the Unity lifecycle, this method is never gated by
-        /// <see cref="emitMessagesWhenDisabled"/>.
+        /// Explicit calls always win while the owner is alive: unlike the Unity enable/disable
+        /// lifecycle, this method is never gated by <see cref="emitMessagesWhenDisabled"/>.
+        /// Calls after this owner's destruction callback have no effect.
+        /// <para><b>Fixed in v4.0.0.</b></para>
         /// </remarks>
         public void ToggleMessageHandler(bool newActive)
         {
+            if (_destroyed)
+            {
+                return;
+            }
+
             if (_messageHandler != null && _messageHandler.active != newActive)
             {
                 _messageHandler.active = newActive;
@@ -300,7 +367,10 @@ namespace DxMessaging.Unity
         private MessageHandler CreateMessageHandler()
         {
             IMessageBus resolvedBus = ResolveConfiguredBus();
-            MessageHandler handler = new(gameObject, resolvedBus) { active = true };
+            MessageHandler handler = new(gameObject, resolvedBus)
+            {
+                active = emitMessagesWhenDisabled || isActiveAndEnabled,
+            };
             return handler;
         }
 
@@ -402,6 +472,12 @@ namespace DxMessaging.Unity
             {
                 Debug.Log($"[DxMessaging] Cleared runtime state for '{name}'.");
             }
+            else if (_registeredListeners.Count > 0)
+            {
+                Debug.LogWarning(
+                    $"[DxMessaging] Runtime state for '{name}' still has listener tokens awaiting cleanup. Retry the reset."
+                );
+            }
             else
             {
                 Debug.Log($"[DxMessaging] No runtime state to clear on '{name}'.");
@@ -412,28 +488,19 @@ namespace DxMessaging.Unity
         {
             bool cleared = false;
 
+            if (_messageHandler != null)
+            {
+                _messageHandler.active = false;
+            }
+
             if (_registeredListeners.Count > 0)
             {
-                foreach (MessageRegistrationToken token in _registeredListeners.Values.ToArray())
+                DisposeRetainedListeners();
+                if (_registeredListeners.Count > 0)
                 {
-                    try
-                    {
-                        if (token.Enabled)
-                        {
-                            token.Disable();
-                        }
-
-                        token.Dispose();
-                    }
-                    catch (Exception exception)
-                    {
-                        Debug.LogWarning(
-                            $"[DxMessaging] Disposing stale token on {name} failed. {exception}"
-                        );
-                    }
+                    return false;
                 }
 
-                _registeredListeners.Clear();
                 cleared = true;
             }
 

--- a/Tests/Editor/Allocations/AllocationMatrixTests.cs
+++ b/Tests/Editor/Allocations/AllocationMatrixTests.cs
@@ -936,6 +936,10 @@ namespace DxMessaging.Tests.Editor.Allocations
         /// <see cref="EmitWithDiagnosticsEnabledIsBoundedAlloc"/> already pins
         /// that axis.
         /// </summary>
+        /// <remarks>
+        /// 2026-09-06: Duplicate registrations at priority zero shared one post-processor
+        /// entry. Use distinct priorities and verify both exist before measuring allocation.
+        /// </remarks>
         [Test]
         [Category("Allocation")]
         public void EmitWithFullStackIsZeroAlloc()
@@ -953,8 +957,13 @@ namespace DxMessaging.Tests.Editor.Allocations
                     RegisterHandler(scenario, token, priority: 5);
                     RegisterHandler(scenario, token, priority: 10);
                     RegisterAllowingInterceptor(scenario, token);
-                    RegisterPostProcessor(scenario, token);
-                    RegisterPostProcessor(scenario, token);
+                    RegisterPostProcessor(scenario, token, priority: 0);
+                    RegisterPostProcessor(scenario, token, priority: 5);
+                    Assert.That(
+                        bus.RegisteredPostProcessors,
+                        Is.EqualTo(2),
+                        "Full-stack allocation coverage requires two distinct post-processor priorities."
+                    );
                     AllocationAssertions.AssertNoAllocations(
                         $"EmitFullStack-{scenario.Kind}",
                         emit
@@ -1956,7 +1965,8 @@ namespace DxMessaging.Tests.Editor.Allocations
 
         private static MessageRegistrationHandle RegisterPostProcessor(
             MessageScenario scenario,
-            MessageRegistrationToken token
+            MessageRegistrationToken token,
+            int priority = 0
         )
         {
             switch (scenario.Kind)
@@ -1966,7 +1976,8 @@ namespace DxMessaging.Tests.Editor.Allocations
                     return ScenarioHarness.RegisterUntargetedPostProcessor<SimpleUntargetedMessage>(
                         scenario,
                         token,
-                        NoOpUntargeted
+                        NoOpUntargeted,
+                        priority
                     );
                 }
                 case MessageKind.Targeted:
@@ -1975,7 +1986,8 @@ namespace DxMessaging.Tests.Editor.Allocations
                         scenario,
                         token,
                         StableTarget,
-                        NoOpTargeted
+                        NoOpTargeted,
+                        priority
                     );
                 }
                 case MessageKind.Broadcast:
@@ -1984,19 +1996,22 @@ namespace DxMessaging.Tests.Editor.Allocations
                         scenario,
                         token,
                         StableSource,
-                        NoOpBroadcast
+                        NoOpBroadcast,
+                        priority
                     );
                 }
                 case MessageKind.TargetedWithoutTargeting:
                 {
                     return token.RegisterTargetedWithoutTargetingPostProcessor<SimpleTargetedMessage>(
-                        NoOpTargetedWithoutTargeting
+                        NoOpTargetedWithoutTargeting,
+                        priority: priority
                     );
                 }
                 case MessageKind.BroadcastWithoutSource:
                 {
                     return token.RegisterBroadcastWithoutSourcePostProcessor<SimpleBroadcastMessage>(
-                        NoOpBroadcastWithoutSource
+                        NoOpBroadcastWithoutSource,
+                        priority: priority
                     );
                 }
                 default:

--- a/Tests/Runtime/Core/BaseCallContractTests.cs
+++ b/Tests/Runtime/Core/BaseCallContractTests.cs
@@ -36,16 +36,10 @@ namespace DxMessaging.Tests.Runtime.Core
     /// without expecting a log branch that was compiled out.
     /// </para>
     /// <para>
-    /// The leak tests
-    /// (<see cref="OmitBaseOnDisableAndOnDestroyLeaksRegistration"/> and
-    /// <see cref="OmitBaseOnDisableAndOnDestroyLeaksDefaultHandlersToo"/>)
-    /// intentionally produce registrations that survive component
-    /// destruction. The leaked registrations are cleaned up by the global
-    /// bus reset that <see cref="MessagingTestBase.UnitySetup"/> performs at
-    /// the start of every test, so they cannot bleed into subsequent tests;
-    /// both tests additionally invoke <c>DxMessagingStaticState.Reset</c>
-    /// after observing the leak so the bus is drained before
-    /// <see cref="MessagingTestBase.UnityCleanup"/> asserts the bus is fresh.
+    /// The leak tests destroy only the listener first, leaving its messaging owner alive.
+    /// This isolates missing listener base calls from the owner's destruction cleanup.
+    /// They then destroy the host and verify that owner cleanup removes every retained
+    /// registration before fixture teardown.
     /// </para>
     /// </remarks>
     public sealed class BaseCallContractTests : MessagingTestBase
@@ -248,142 +242,100 @@ namespace DxMessaging.Tests.Runtime.Core
         }
 
         /// <summary>
-        /// Skipping BOTH <c>base.OnDisable()</c> and <c>base.OnDestroy()</c>
-        /// means the framework never releases the messaging component or
-        /// disables the token, so the registration outlives the GameObject
-        /// and the bus's registration counter does not return to the baseline
-        /// captured by <see cref="LeakWatcher"/>. The fixture
-        /// <see cref="MissingBaseOnDestroyComponent"/> intentionally skips
-        /// both base calls because Unity's destroy lifecycle fires
-        /// <c>OnDisable</c> before <c>OnDestroy</c>; if only <c>OnDestroy</c>
-        /// were skipped, the inherited <c>OnDisable</c> would deregister the
-        /// handlers during destruction and the leak would be masked. The
-        /// companion test
-        /// <see cref="OnDisableDuringDestroyMasksOnDestroyLeak"/> pins that
-        /// masking behavior explicitly.
-        /// Cleanup choice: the test calls
-        /// <see cref="DxMessagingStaticState.Reset"/> after observing the leak
-        /// so the bus returns to a clean state before
-        /// <see cref="MessagingTestBase.UnityCleanup"/> asserts the bus is
-        /// fresh; this is the simplest deterministic way to drop an orphaned
-        /// registration whose owning GameObject no longer exists.
+        /// Skipping both listener cleanup base calls retains all registrations until
+        /// the messaging owner is destroyed.
         /// </summary>
+        /// <remarks>
+        /// 2026-09-06: Whole-host destruction also invokes MessagingComponent cleanup.
+        /// Destroy only the listener to observe its missing-base-call failure, then
+        /// destroy the host to prove the owner still drains the retained token.
+        /// </remarks>
         [UnityTest]
         public IEnumerator OmitBaseOnDisableAndOnDestroyLeaksRegistration(
             [ValueSource(typeof(MessageScenarios), nameof(MessageScenarios.AllKinds))]
                 MessageScenario scenario
         )
         {
-            // Construct the watcher BEFORE spawning the host so the baseline
-            // is the truly-fresh bus (0) that MessagingTestBase.UnitySetup
-            // guarantees. Capturing the baseline after spawn would understate
-            // the leak: the 3 default StringMessage handlers added by the
-            // inherited RegisterMessageHandlers would already be in the
-            // baseline, so a leak that includes them would only show as the
-            // user counter (1) instead of the full failure surface (4).
-            // Watching from before spawn lets the assertion pin the EXACT
-            // leak count (defaults + counter) and proves that skipping both
-            // base.OnDisable and base.OnDestroy strands every handler the
-            // framework added on Awake, not just the user-added one.
-            LeakWatcher watcher = new(
+            using LeakWatcher watcher = new(
                 bus: MessageHandler.MessageBus,
-                throwOnLeak: false,
                 label: scenario.DisplayName
             );
+            GameObject host = new(
+                nameof(OmitBaseOnDisableAndOnDestroyLeaksRegistration) + scenario.Kind,
+                typeof(MissingBaseOnDestroyComponent)
+            );
+            _spawned.Add(host);
+            MissingBaseOnDestroyComponent component =
+                host.GetComponent<MissingBaseOnDestroyComponent>();
+            MessageRegistrationToken token = GetToken(component);
+            Assert.IsNotNull(token, "[{0}] base.Awake() must create the token.", scenario.Kind);
+            Assert.AreEqual(
+                DefaultStringMessageHandlerCount,
+                watcher.Snapshot,
+                "[{0}] Spawn must install all default handlers. {1}",
+                scenario.Kind,
+                watcher.DescribeDelta()
+            );
 
-            int observedLeak;
-            string deltaDescription;
-            try
-            {
-                GameObject host = new(
-                    nameof(OmitBaseOnDisableAndOnDestroyLeaksRegistration) + scenario.Kind,
-                    typeof(MissingBaseOnDestroyComponent)
-                );
-                _spawned.Add(host);
-
-                MissingBaseOnDestroyComponent component =
-                    host.GetComponent<MissingBaseOnDestroyComponent>();
-                MessageRegistrationToken token = GetToken(component);
-                Assert.IsNotNull(
-                    token,
-                    "[{0}] Token must be created because base.Awake() still runs.",
-                    scenario.Kind
-                );
-
-                int snapshotAfterSpawn = watcher.Snapshot;
-                Assert.AreEqual(
-                    DefaultStringMessageHandlerCount,
-                    snapshotAfterSpawn,
-                    "[{0}] Spawning a MessageAwareComponent subclass that does not "
-                        + "override RegisterForStringMessages must add exactly the "
-                        + "default StringMessage handler count to the bus. {1}",
-                    scenario.Kind,
-                    watcher.DescribeDelta()
-                );
-
-                _ = RegisterCounter(scenario, token, host, () => { });
-                Assert.AreEqual(
-                    snapshotAfterSpawn + 1,
-                    watcher.Snapshot,
-                    "[{0}] Bus must reflect the new registration before destroy. {1}",
-                    scenario.Kind,
-                    watcher.DescribeDelta()
-                );
-
-                // Destroy the component / GameObject; because the override skips
-                // BOTH base.OnDisable() and base.OnDestroy(), neither the token's
-                // handler list nor the framework's MessagingComponent are torn
-                // down, and every handler installed during Awake leaks. The
-                // expected leak is therefore the default StringMessage handlers
-                // PLUS the counter handler, not just the counter.
-                UnityEngine.Object.Destroy(host);
-                _spawned.Remove(host);
-
-                if (Application.isPlaying)
-                {
-                    yield return null;
-                }
-
-                // Capture the live leak BEFORE Dispose/Reset so the assertion
-                // sees the actual orphaned count even if a later step throws.
-                observedLeak = watcher.LeakedRegistrations;
-                deltaDescription = watcher.DescribeDelta();
-            }
-            finally
-            {
-                // Idempotent: protects the watcher from being left undisposed
-                // if any earlier Assert in the try block throws. The values
-                // captured into observedLeak/deltaDescription above are taken
-                // from the live bus, so the assertion below remains correct
-                // regardless of when Dispose runs.
-                watcher.Dispose();
-            }
-
-            // Drop the orphaned registrations so they cannot bleed into the
-            // next test; UnityCleanup's WaitUntilMessageHandlerIsFresh would
-            // otherwise time out asserting bus staleness.
-            DxMessagingStaticState.Reset();
-
-            // Exact equality: the leak surface must be the default handlers
-            // PLUS the user counter. Asserting >= 1 (the prior behaviour)
-            // would silently allow a future regression that loses one or more
-            // of the default handlers but still leaks the counter.
+            _ = RegisterCounter(scenario, token, host, () => { });
             const int expectedLeak = DefaultStringMessageHandlerCount + 1;
             Assert.AreEqual(
                 expectedLeak,
-                observedLeak,
-                "[{0}] Skipping base.OnDisable() and base.OnDestroy() must leak "
-                    + "exactly {1} registrations ({2} default StringMessage "
-                    + "handlers + 1 counter), proving that NEITHER user nor "
-                    + "default handlers are deregistered when both base calls "
-                    + "are absent. {3}",
+                watcher.Snapshot,
+                "[{0}] Control must include defaults and the user registration. {1}",
                 scenario.Kind,
-                expectedLeak,
-                DefaultStringMessageHandlerCount,
-                deltaDescription
+                watcher.DescribeDelta()
             );
 
-            yield break;
+            UnityEngine.Object.Destroy(component);
+            yield return null;
+            Assert.That(
+                component == null,
+                Is.True,
+                "[{0}] Listener must be destroyed.",
+                scenario.Kind
+            );
+            Assert.That(
+                host != null,
+                Is.True,
+                "[{0}] Messaging owner must survive listener destruction.",
+                scenario.Kind
+            );
+            Assert.AreEqual(
+                expectedLeak,
+                watcher.LeakedRegistrations,
+                "[{0}] Missing listener base calls must retain all {1} registrations while the owner survives. {2}",
+                scenario.Kind,
+                expectedLeak,
+                watcher.DescribeDelta()
+            );
+            Assert.IsTrue(
+                token.Enabled,
+                "[{0}] Missing listener cleanup must leave its token enabled.",
+                scenario.Kind
+            );
+
+            UnityEngine.Object.Destroy(host);
+            _spawned.Remove(host);
+            yield return null;
+            Assert.That(
+                host == null,
+                Is.True,
+                "[{0}] Messaging owner must be destroyed.",
+                scenario.Kind
+            );
+            Assert.IsFalse(
+                token.Enabled,
+                "[{0}] Owner destruction must dispose the retained token.",
+                scenario.Kind
+            );
+            Assert.AreEqual(
+                0,
+                watcher.LeakedRegistrations,
+                "[{0}] Owner destruction must remove defaults and user registrations. {1}",
+                scenario.Kind,
+                watcher.DescribeDelta()
+            );
         }
 
         /// <summary>
@@ -456,19 +408,32 @@ namespace DxMessaging.Tests.Runtime.Core
                 watcher.DescribeDelta()
             );
 
-            // Destroy the GameObject. Unity fires OnDisable then OnDestroy;
+            // Destroy only the listener, so owner cleanup cannot mask a missing OnDisable.
+            // Unity fires OnDisable then OnDestroy;
             // the inherited base.OnDisable() runs (the override is absent on
             // this fixture) and disables the token before the broken
             // OnDestroy runs, so no registration leaks - including the
             // default StringMessage handlers, which is what makes the masking
             // observable end-to-end.
-            UnityEngine.Object.Destroy(host);
-            _spawned.Remove(host);
+            UnityEngine.Object.Destroy(component);
 
             if (Application.isPlaying)
             {
                 yield return null;
             }
+
+            Assert.That(
+                component == null,
+                Is.True,
+                "[{0}] Listener must be destroyed.",
+                scenario.Kind
+            );
+            Assert.That(
+                host != null,
+                Is.True,
+                "[{0}] Messaging owner must survive this negative control.",
+                scenario.Kind
+            );
 
             Assert.AreEqual(
                 0,
@@ -482,7 +447,7 @@ namespace DxMessaging.Tests.Runtime.Core
             );
 
             // Belt-and-braces: the live bus counters must each be 0 after the
-            // host is gone, not just the aggregate. Guards against a future
+            // listener is gone, not just the aggregate. Guards against a future
             // refactor that nets to zero by accidentally deregistering
             // unrelated registrations along with the user counter.
             IMessageBus bus = MessageHandler.MessageBus;
@@ -507,9 +472,10 @@ namespace DxMessaging.Tests.Runtime.Core
         /// individually so a future "fix" that accidentally only deregisters
         /// user handlers from one path (or that loses one of the default
         /// handlers but keeps another) cannot pass while still masking the
-        /// regression. The expected per-counter shape after destroy is:
+        /// regression. The messaging owner survives listener destruction so its cleanup
+        /// cannot mask the missing listener base calls. The expected counter shape is:
         /// Targeted == 2 (the two default StringMessage handlers) plus 1 if
-        /// the scenario registers a targeted/broadcast counter,
+        /// the scenario registers a targeted counter,
         /// Untargeted == 1 (the default GlobalStringMessage handler) plus 1
         /// if the scenario registers an untargeted counter, Broadcast == 1
         /// only when the scenario registers a broadcast counter.
@@ -524,7 +490,6 @@ namespace DxMessaging.Tests.Runtime.Core
             // anchored to a fresh bus.
             using LeakWatcher watcher = new(
                 bus: MessageHandler.MessageBus,
-                throwOnLeak: false,
                 label: scenario.DisplayName
             );
 
@@ -545,14 +510,25 @@ namespace DxMessaging.Tests.Runtime.Core
 
             _ = RegisterCounter(scenario, token, host, () => { });
 
-            UnityEngine.Object.Destroy(host);
-            _spawned.Remove(host);
+            UnityEngine.Object.Destroy(component);
 
             if (Application.isPlaying)
             {
                 yield return null;
             }
 
+            Assert.That(
+                component == null,
+                Is.True,
+                "[{0}] Listener must be destroyed.",
+                scenario.Kind
+            );
+            Assert.That(
+                host != null,
+                Is.True,
+                "[{0}] Messaging owner must survive listener destruction.",
+                scenario.Kind
+            );
             IMessageBus bus = MessageHandler.MessageBus;
 
             // The two default StringMessage handlers ALWAYS land on Targeted
@@ -579,12 +555,22 @@ namespace DxMessaging.Tests.Runtime.Core
                     + $"after destroy. {deltaDescription}"
             );
 
-            // Drop the orphaned registrations so they cannot bleed into the
-            // next test; UnityCleanup's WaitUntilMessageHandlerIsFresh would
-            // otherwise time out asserting bus staleness.
-            DxMessagingStaticState.Reset();
-
-            yield break;
+            UnityEngine.Object.Destroy(host);
+            _spawned.Remove(host);
+            yield return null;
+            Assert.That(
+                host == null,
+                Is.True,
+                "[{0}] Messaging owner must be destroyed.",
+                scenario.Kind
+            );
+            AssertRegistrationCounts(
+                bus,
+                untargeted: 0,
+                targeted: 0,
+                broadcast: 0,
+                context: $"OwnerCleanupAfterMissingBaseCalls[{scenario.Kind}]. {watcher.DescribeDelta()}"
+            );
         }
 
         /// <summary>
@@ -597,7 +583,7 @@ namespace DxMessaging.Tests.Runtime.Core
         /// <c>OnDisable</c> during the destroy lifecycle. This guards against
         /// a future regression where the framework only deregisters user
         /// handlers in some code path, leaving default handlers stranded
-        /// against a destroyed host.
+        /// against a destroyed listener.
         /// </summary>
         [UnityTest]
         public IEnumerator OnDisableDuringDestroyDeregistersDefaultStringHandlers()
@@ -618,9 +604,8 @@ namespace DxMessaging.Tests.Runtime.Core
                 host.GetComponent<MissingBaseOnDestroyOnlyComponent>();
             Assert.IsNotNull(GetToken(component), "Token must be created.");
 
-            // Capture the InstanceId BEFORE destroy so the post-destroy
-            // emission targets the same id without dereferencing a
-            // fake-null Unity wrapper.
+            // Retain the host route while destroying only the listener, so owner
+            // cleanup cannot make the inherited-OnDisable assertion pass.
             InstanceId hostId = host;
 
             // Sanity: spawning installs exactly the default handler count.
@@ -631,14 +616,19 @@ namespace DxMessaging.Tests.Runtime.Core
                 watcher.DescribeDelta()
             );
 
-            UnityEngine.Object.Destroy(host);
-            _spawned.Remove(host);
+            UnityEngine.Object.Destroy(component);
 
             if (Application.isPlaying)
             {
                 yield return null;
             }
 
+            Assert.That(component == null, Is.True, "Listener must be destroyed.");
+            Assert.That(
+                host != null,
+                Is.True,
+                "Messaging owner must survive this negative control."
+            );
             IMessageBus bus = MessageHandler.MessageBus;
             Assert.Zero(
                 bus.RegisteredTargeted,
@@ -668,7 +658,7 @@ namespace DxMessaging.Tests.Runtime.Core
                     StringMessage stringMessage = new("after-destroy");
                     bus.UntypedTargetedBroadcast(hostId, stringMessage);
                 },
-                "Targeted broadcast against the destroyed host's id must not "
+                "Targeted broadcast against the destroyed listener's host id must not "
                     + "throw and must dispatch to nobody."
             );
             Assert.DoesNotThrow(
@@ -677,7 +667,7 @@ namespace DxMessaging.Tests.Runtime.Core
                     GlobalStringMessage globalMessage = new("after-destroy-global");
                     globalMessage.EmitUntargeted();
                 },
-                "Emitting GlobalStringMessage after the host is destroyed must not throw."
+                "Emitting GlobalStringMessage after the listener is destroyed must not throw."
             );
 
             Assert.AreEqual(

--- a/Tests/Runtime/Core/DifferentialBusTraceTests.cs
+++ b/Tests/Runtime/Core/DifferentialBusTraceTests.cs
@@ -27,7 +27,7 @@ namespace DxMessaging.Tests.Runtime.Core
         public void TearDown() => _diagnostics.Dispose();
 
         [Test]
-        public void GeneratorVersionPinsKnownSeedPrefix([Values(1, 2, 3, 4, 5, 6)] int version)
+        public void GeneratorVersionPinsKnownSeedPrefix([Values(1, 2, 3, 4, 5, 6, 7)] int version)
         {
             BusTraceSequence sequence = DifferentialBusTrace.Generate(
                 MessageScenario.Untargeted(),
@@ -37,11 +37,19 @@ namespace DxMessaging.Tests.Runtime.Core
             );
             Assert.That(
                 BusTraceSequence.GeneratorVersion,
-                Is.EqualTo(6),
+                Is.EqualTo(7),
                 "Changing generation requires a new version and a reviewed replay fixture."
             );
             CollectionAssert.AreEqual(
-                version == 6
+                version == 7
+                        ? new[]
+                        {
+                            "Register(token=0,context=0,value=1409999377,priority=1)",
+                            "Emit(token=0,context=0,value=1481184789,priority=1)",
+                            "Emit(token=3,context=1,value=-541008231,priority=1)",
+                            "Remove(token=0,context=1,value=-1592061232,priority=1)",
+                        }
+                    : version == 6
                         ? new[]
                         {
                             "Register(token=0,context=0,value=1409999377,priority=1)",
@@ -82,6 +90,317 @@ namespace DxMessaging.Tests.Runtime.Core
                 sequence.Version,
                 Is.EqualTo(version),
                 $"version={version}: replay identity must preserve the requested generator."
+            );
+        }
+
+        [Test]
+        public void HandlerActivityReplayKeepsTokenEnabledAndAffectsCurrentDispatch(
+            [ValueSource(typeof(MessageScenarios), nameof(MessageScenarios.AllKinds))]
+                MessageScenario scenario
+        )
+        {
+            BusTraceOperation[] operations =
+            {
+                new(BusTraceOperationKind.Register, priority: -1),
+                new(BusTraceOperationKind.Register, token: 1, priority: 1),
+                new(BusTraceOperationKind.SetHandlerActive, token: 1),
+                new(BusTraceOperationKind.Emit, value: 17),
+                new(BusTraceOperationKind.Enable, token: 1),
+                new(BusTraceOperationKind.Emit, value: 19),
+                new(
+                    BusTraceOperationKind.EmitWithHandlerActive,
+                    value: 23,
+                    handlerToken: 1,
+                    handlerActive: true
+                ),
+                new(BusTraceOperationKind.EmitWithHandlerActive, value: 29, handlerToken: 1),
+                new(BusTraceOperationKind.Disable, token: 1),
+                new(BusTraceOperationKind.SetHandlerActive, token: 1, handlerActive: true),
+                new(BusTraceOperationKind.Emit, value: 31),
+                new(BusTraceOperationKind.Enable, token: 1),
+                new(BusTraceOperationKind.Emit, value: 37),
+            };
+            BusTraceSequence sequence = new(scenario, 509, operations);
+            IReadOnlyList<BusTraceObservation> observations = DifferentialBusTrace.Replay(
+                sequence,
+                kind => CreateAdapter(kind, false)
+            );
+            Assert.That(
+                observations.All(observation => observation.Exception == null),
+                Is.True,
+                $"[{scenario.Kind}] {string.Join(";", observations)}"
+            );
+            Assert.That(
+                Evaluate(sequence, false),
+                Is.Null,
+                $"[{scenario.Kind}] production replays must agree."
+            );
+            string report = $"[{scenario.Kind}] " + string.Join("\n", observations);
+            StringAssert.Contains("enabled=1111", observations[2].State, report);
+            StringAssert.Contains("handlerActive=1011", observations[2].State, report);
+            CollectionAssert.AreEqual(
+                new[] { "token=0,value=17" },
+                observations[3].Callbacks,
+                report
+            );
+            CollectionAssert.AreEqual(
+                new[] { "token=0,value=19" },
+                observations[5].Callbacks,
+                report
+            );
+            CollectionAssert.AreEqual(
+                new[] { "token=0,value=23", "token=1,value=23" },
+                observations[6].Callbacks,
+                report
+            );
+            CollectionAssert.AreEqual(
+                new[] { "token=0,value=29" },
+                observations[7].Callbacks,
+                report
+            );
+            StringAssert.Contains("enabled=1011", observations[9].State, report);
+            StringAssert.Contains("handlerActive=1111", observations[9].State, report);
+            CollectionAssert.AreEqual(
+                new[] { "token=0,value=31" },
+                observations[10].Callbacks,
+                report
+            );
+            CollectionAssert.AreEqual(
+                new[] { "token=0,value=37", "token=1,value=37" },
+                observations[12].Callbacks,
+                report
+            );
+        }
+
+        [Test]
+        public void IgnoredHandlerActivityIsDetectedAndShrunk(
+            [ValueSource(typeof(MessageScenarios), nameof(MessageScenarios.AllKinds))]
+                MessageScenario scenario,
+            [Values(false, true)] bool fromCallback
+        )
+        {
+            BusTraceSequence sequence = new(
+                scenario,
+                509,
+                new[]
+                {
+                    new BusTraceOperation(BusTraceOperationKind.Enable, token: 3),
+                    new BusTraceOperation(BusTraceOperationKind.Register, priority: -1),
+                    new BusTraceOperation(BusTraceOperationKind.Register, token: 1, priority: 1),
+                    fromCallback
+                        ? new BusTraceOperation(
+                            BusTraceOperationKind.EmitWithHandlerActive,
+                            value: 17,
+                            handlerToken: 1
+                        )
+                        : new BusTraceOperation(BusTraceOperationKind.SetHandlerActive, token: 1),
+                    new BusTraceOperation(BusTraceOperationKind.Emit, value: 19),
+                }
+            );
+            BusTraceMismatch mismatch = EvaluateMutant(sequence, "handler-active");
+            string report =
+                $"[{scenario.Kind}] fromCallback={fromCallback}: "
+                + mismatch?.BuildReport(sequence);
+            Assert.That(mismatch, Is.Not.Null, report);
+            Assert.That(
+                mismatch.Category,
+                Is.EqualTo(fromCallback ? "callbacks" : "state"),
+                report
+            );
+            BusTraceSequence minimal = DifferentialBusTrace.Shrink(
+                sequence,
+                replay => EvaluateMutant(replay, "handler-active")
+            );
+            Assert.That(DifferentialBusTrace.IsValid(minimal), Is.True, report);
+            Assert.That(
+                EvaluateMutant(minimal, "handler-active")?.Category,
+                Is.EqualTo(mismatch.Category),
+                report
+            );
+            Assert.That(minimal.Seed, Is.EqualTo(sequence.Seed), report);
+            Assert.That(minimal.Version, Is.EqualTo(sequence.Version), report);
+            CollectionAssert.AreEqual(
+                fromCallback
+                    ? new[]
+                    {
+                        BusTraceOperationKind.Register,
+                        BusTraceOperationKind.Register,
+                        BusTraceOperationKind.EmitWithHandlerActive,
+                    }
+                    : new[] { BusTraceOperationKind.SetHandlerActive },
+                minimal.Operations.Select(operation => operation.Kind),
+                report
+            );
+        }
+
+        [Test]
+        public void SkippedHandlerActivityCallbackDoesNotArmLaterEmission(
+            [ValueSource(typeof(MessageScenarios), nameof(MessageScenarios.AllKinds))]
+                MessageScenario scenario
+        )
+        {
+            BusTraceSequence sequence = new(
+                scenario,
+                509,
+                new[]
+                {
+                    new BusTraceOperation(BusTraceOperationKind.Register, priority: -1),
+                    new BusTraceOperation(BusTraceOperationKind.Register, token: 1, priority: 1),
+                    new BusTraceOperation(BusTraceOperationKind.SetHandlerActive),
+                    new BusTraceOperation(
+                        BusTraceOperationKind.EmitWithHandlerActive,
+                        value: 17,
+                        handlerToken: 1
+                    ),
+                    new BusTraceOperation(
+                        BusTraceOperationKind.SetHandlerActive,
+                        handlerActive: true
+                    ),
+                    new BusTraceOperation(BusTraceOperationKind.Emit, value: 19),
+                }
+            );
+            IReadOnlyList<BusTraceObservation> observations = DifferentialBusTrace.Replay(
+                sequence,
+                kind => CreateAdapter(kind, false)
+            );
+            string report = $"[{scenario.Kind}] " + string.Join(";", observations);
+            Assert.That(
+                observations.All(observation => observation.Exception == null),
+                Is.True,
+                report
+            );
+            CollectionAssert.AreEqual(
+                new[] { "token=1,value=17" },
+                observations[3].Callbacks,
+                report
+            );
+            CollectionAssert.AreEqual(
+                new[] { "token=0,value=19", "token=1,value=19" },
+                observations[5].Callbacks,
+                report
+            );
+            StringAssert.Contains("handlerActive=1111", observations[5].State, report);
+        }
+
+        [Test]
+        public void HandlerActivityValidityPreservesTriggerDependenciesAndVersion()
+        {
+            MessageScenario scenario = MessageScenario.Untargeted();
+            BusTraceOperation register = new(BusTraceOperationKind.Register);
+            BusTraceOperation toggle = new(BusTraceOperationKind.SetHandlerActive, token: 1);
+            BusTraceOperation callback = new(
+                BusTraceOperationKind.EmitWithHandlerActive,
+                handlerToken: 1
+            );
+            foreach (
+                BusTraceOperation[] operations in new[]
+                {
+                    new[] { toggle },
+                    new[] { register, callback },
+                    new[]
+                    {
+                        register,
+                        new BusTraceOperation(BusTraceOperationKind.Disable),
+                        callback,
+                    },
+                    new[]
+                    {
+                        register,
+                        new BusTraceOperation(BusTraceOperationKind.SetHandlerActive),
+                        callback,
+                    },
+                }
+            )
+            {
+                string report = string.Join(";", operations);
+                Assert.That(
+                    DifferentialBusTrace.IsValid(new BusTraceSequence(scenario, 509, operations)),
+                    Is.True,
+                    report
+                );
+                Assert.That(
+                    DifferentialBusTrace.IsValid(
+                        new BusTraceSequence(scenario, 509, operations, 6)
+                    ),
+                    Is.False,
+                    report
+                );
+            }
+            foreach (
+                BusTraceOperation[] operations in new[]
+                {
+                    new[] { callback },
+                    new[]
+                    {
+                        register,
+                        new BusTraceOperation(BusTraceOperationKind.Remove),
+                        callback,
+                    },
+                    new[]
+                    {
+                        register,
+                        new BusTraceOperation(
+                            BusTraceOperationKind.EmitWithHandlerActive,
+                            handlerToken: -1
+                        ),
+                    },
+                    new[]
+                    {
+                        register,
+                        new BusTraceOperation(
+                            BusTraceOperationKind.EmitWithHandlerActive,
+                            handlerToken: BusTraceSequence.TokenCount
+                        ),
+                    },
+                    new[]
+                    {
+                        new BusTraceOperation(
+                            BusTraceOperationKind.SetHandlerActive,
+                            handlerToken: 1
+                        ),
+                    },
+                    new[]
+                    {
+                        new BusTraceOperation(BusTraceOperationKind.Emit, handlerActive: true),
+                    },
+                }
+            )
+            {
+                Assert.That(
+                    DifferentialBusTrace.IsValid(new BusTraceSequence(scenario, 509, operations)),
+                    Is.False,
+                    string.Join(";", operations)
+                );
+            }
+            BusTraceSequence generated = DifferentialBusTrace.Generate(scenario, 17, 256, 7);
+            Assert.That(
+                DifferentialBusTrace.IsValid(generated),
+                Is.True,
+                "Version 7 seed 17 must preserve callback dependencies."
+            );
+            foreach (
+                BusTraceOperationKind kind in new[]
+                {
+                    BusTraceOperationKind.SetHandlerActive,
+                    BusTraceOperationKind.EmitWithHandlerActive,
+                }
+            )
+            {
+                foreach (bool active in new[] { false, true })
+                {
+                    Assert.That(
+                        generated.Operations.Any(operation =>
+                            operation.Kind == kind && operation.HandlerActive == active
+                        ),
+                        Is.True,
+                        $"Version 7 seed 17 must generate {kind} active={active}."
+                    );
+                }
+            }
+            StringAssert.Contains(
+                "handlerToken=1,handlerActive=False",
+                callback.ToString(),
+                "Replay reports must preserve handler identity and requested activity."
             );
         }
 
@@ -750,7 +1069,7 @@ namespace DxMessaging.Tests.Runtime.Core
             [ValueSource(typeof(MessageScenarios), nameof(MessageScenarios.AllKinds))]
                 MessageScenario scenario,
             [Values(17, 42)] int seed,
-            [Values(3, 4, 5, 6)] int version
+            [Values(3, 4, 5, 6, 7)] int version
         )
         {
             BusTraceSequence sequence = DifferentialBusTrace.Generate(
@@ -1122,7 +1441,7 @@ namespace DxMessaging.Tests.Runtime.Core
         }
 
         [TestCase(0)]
-        [TestCase(7)]
+        [TestCase(8)]
         public void UnsupportedGeneratorVersionsAreRejected(int version)
         {
             Assert.Throws<ArgumentOutOfRangeException>(
@@ -1581,7 +1900,7 @@ namespace DxMessaging.Tests.Runtime.Core
                     string.Join(";", operations)
                 );
             }
-            BusTraceSequence generated = DifferentialBusTrace.Generate(scenario, 17, 256);
+            BusTraceSequence generated = DifferentialBusTrace.Generate(scenario, 17, 256, 6);
             Assert.That(
                 DifferentialBusTrace.IsValid(generated),
                 Is.True,
@@ -1646,6 +1965,7 @@ namespace DxMessaging.Tests.Runtime.Core
                 "trim-force" => new IgnoredForceTrimAdapter(scenario, bus),
                 "nested" => new MissingNestedEmitAdapter(scenario, bus),
                 "callback-disable" => new IgnoredCallbackDisableAdapter(scenario, bus),
+                "handler-active" => new IgnoredHandlerActivityAdapter(scenario, bus),
                 _ => throw new ArgumentOutOfRangeException(nameof(fault)),
             };
         }
@@ -1684,6 +2004,14 @@ namespace DxMessaging.Tests.Runtime.Core
                 : base(scenario, bus, reset: bus.ResetState) { }
 
             protected override void EmitNested(BusTraceOperation operation) { }
+        }
+
+        private sealed class IgnoredHandlerActivityAdapter : MessageBusTraceAdapter
+        {
+            internal IgnoredHandlerActivityAdapter(MessageScenario scenario, MessageBus bus)
+                : base(scenario, bus, reset: bus.ResetState) { }
+
+            protected override void SetHandlerActive(int slot, bool active) { }
         }
 
         private sealed class IgnoredCallbackDisableAdapter : MessageBusTraceAdapter

--- a/Tests/Runtime/TestUtilities/DifferentialBusTrace.cs
+++ b/Tests/Runtime/TestUtilities/DifferentialBusTrace.cs
@@ -23,6 +23,8 @@ namespace DxMessaging.Tests.Runtime
         EmitNested,
         EmitWithDisable,
         RemoveForeign,
+        SetHandlerActive,
+        EmitWithHandlerActive,
     }
 
     /// <summary>Replay input with stable logical token identity, route, payload, and priority.</summary>
@@ -37,7 +39,9 @@ namespace DxMessaging.Tests.Runtime
             int kindOffset = 0,
             int nestedToken = 0,
             int depth = 0,
-            int handleToken = 0
+            int handleToken = 0,
+            int handlerToken = 0,
+            bool handlerActive = false
         )
         {
             Kind = kind;
@@ -49,6 +53,8 @@ namespace DxMessaging.Tests.Runtime
             NestedToken = nestedToken;
             Depth = depth;
             HandleToken = handleToken;
+            HandlerToken = handlerToken;
+            HandlerActive = handlerActive;
         }
 
         internal BusTraceOperationKind Kind { get; }
@@ -64,6 +70,9 @@ namespace DxMessaging.Tests.Runtime
         // RemoveForeign passes this owner's most recently issued handle to Token.
         internal int HandleToken { get; }
 
+        internal int HandlerToken { get; }
+        internal bool HandlerActive { get; }
+
         public override string ToString() =>
             $"{Kind}(token={Token},context={Context},value={Value},priority={Priority})"
             + (
@@ -75,13 +84,19 @@ namespace DxMessaging.Tests.Runtime
                 Kind == BusTraceOperationKind.RemoveForeign
                     ? $"[handleToken={HandleToken}]"
                     : string.Empty
+            )
+            + (
+                Kind == BusTraceOperationKind.SetHandlerActive
+                || Kind == BusTraceOperationKind.EmitWithHandlerActive
+                    ? $"[handlerToken={HandlerToken},handlerActive={HandlerActive}]"
+                    : string.Empty
             );
     }
 
     /// <summary>Immutable, versioned replay inputs; a seed identifies the original generator sequence.</summary>
     internal sealed class BusTraceSequence
     {
-        internal const int GeneratorVersion = 6;
+        internal const int GeneratorVersion = 7;
         internal const int TokenCount = 4;
         internal const int MaxOperations = 256;
 
@@ -229,7 +244,8 @@ namespace DxMessaging.Tests.Runtime
                         : generatorVersion == 3 ? 9U
                         : generatorVersion == 4 ? 10U
                         : generatorVersion == 5 ? 12U
-                        : 13U
+                        : generatorVersion == 6 ? 13U
+                        : 15U
                     )
                 );
                 if (index == 0)
@@ -256,6 +272,7 @@ namespace DxMessaging.Tests.Runtime
                         || kind == BusTraceOperationKind.EmitWithThrow
                         || kind == BusTraceOperationKind.EmitNested
                         || kind == BusTraceOperationKind.EmitWithDisable
+                        || kind == BusTraceOperationKind.EmitWithHandlerActive
                     ) && !registered[token]
                 )
                 {
@@ -301,6 +318,7 @@ namespace DxMessaging.Tests.Runtime
                     if (
                         kind == BusTraceOperationKind.EmitNested
                         || kind == BusTraceOperationKind.EmitWithDisable
+                        || kind == BusTraceOperationKind.EmitWithHandlerActive
                         || kind == BusTraceOperationKind.EmitWithReset
                         || kind == BusTraceOperationKind.EmitWithThrow
                     )
@@ -322,7 +340,15 @@ namespace DxMessaging.Tests.Runtime
                         kindOffset,
                         nestedToken: kind == BusTraceOperationKind.EmitNested ? nestedToken : 0,
                         depth: depth,
-                        handleToken: handleToken
+                        handleToken: handleToken,
+                        handlerToken: kind == BusTraceOperationKind.EmitWithHandlerActive
+                            ? nestedToken
+                            : 0,
+                        handlerActive: (
+                            kind == BusTraceOperationKind.SetHandlerActive
+                            || kind == BusTraceOperationKind.EmitWithHandlerActive
+                        )
+                            && (value & 1) != 0
                     )
                 );
                 if (kind == BusTraceOperationKind.Register)
@@ -380,6 +406,17 @@ namespace DxMessaging.Tests.Runtime
                     || (
                         operation.Kind != BusTraceOperationKind.RemoveForeign
                         && operation.HandleToken != 0
+                    )
+                    || operation.HandlerToken < 0
+                    || operation.HandlerToken >= registered.Length
+                    || (
+                        operation.Kind != BusTraceOperationKind.EmitWithHandlerActive
+                        && operation.HandlerToken != 0
+                    )
+                    || (
+                        operation.Kind != BusTraceOperationKind.SetHandlerActive
+                        && operation.Kind != BusTraceOperationKind.EmitWithHandlerActive
+                        && operation.HandlerActive
                     )
                     || operation.Depth < 0
                     || operation.Depth > 10
@@ -451,6 +488,20 @@ namespace DxMessaging.Tests.Runtime
                         {
                             return false;
                         }
+                        break;
+                    case BusTraceOperationKind.SetHandlerActive:
+                    case BusTraceOperationKind.EmitWithHandlerActive:
+                        if (
+                            sequence.Version < 7
+                            || (
+                                operation.Kind == BusTraceOperationKind.EmitWithHandlerActive
+                                && !registered[operation.Token]
+                            )
+                        )
+                        {
+                            return false;
+                        }
+                        // Handlers exist before registration; toggling does not consume a handle.
                         break;
                     case BusTraceOperationKind.Trim:
                         if (sequence.Version < 4 || operation.Value < 0 || operation.Value > 1)

--- a/Tests/Runtime/TestUtilities/MessageBusTraceAdapter.cs
+++ b/Tests/Runtime/TestUtilities/MessageBusTraceAdapter.cs
@@ -17,12 +17,16 @@ namespace DxMessaging.Tests.Runtime
         private int _resetOnCallbackToken = -1;
         private int _throwOnCallbackToken = -1;
         private int _disableOnCallbackToken = -1;
+        private BusTraceOperation? _handlerActiveOperation;
         private BusTraceOperation? _nestedOperation;
         private int _depth;
         private readonly BusTraceOperation[] _registrations = new BusTraceOperation[
             BusTraceSequence.TokenCount
         ];
         private readonly MessageRegistrationHandle[] _staleHandles = new MessageRegistrationHandle[
+            BusTraceSequence.TokenCount
+        ];
+        private readonly MessageHandler[] _handlers = new MessageHandler[
             BusTraceSequence.TokenCount
         ];
         private readonly MessageRegistrationToken[] _tokens = new MessageRegistrationToken[
@@ -58,6 +62,7 @@ namespace DxMessaging.Tests.Runtime
                     {
                         active = true,
                     };
+                    _handlers[slot] = handler;
                     _tokens[slot] = MessageRegistrationToken.Create(handler, bus);
                     _tokens[slot].DiagnosticMode = false;
                     _tokens[slot].Enable();
@@ -104,6 +109,21 @@ namespace DxMessaging.Tests.Runtime
                         break;
                     case BusTraceOperationKind.Disable:
                         _tokens[operation.Token].Disable();
+                        break;
+                    case BusTraceOperationKind.SetHandlerActive:
+                        SetHandlerActive(operation.Token, operation.HandlerActive);
+                        break;
+                    case BusTraceOperationKind.EmitWithHandlerActive:
+                        _handlerActiveOperation = operation;
+                        try
+                        {
+                            Emit(operation);
+                        }
+                        finally
+                        {
+                            // The trigger may be disabled, inactive, or on a different route.
+                            _handlerActiveOperation = null;
+                        }
                         break;
                     case BusTraceOperationKind.Emit:
                         Emit(operation);
@@ -180,6 +200,11 @@ namespace DxMessaging.Tests.Runtime
             {
                 enabled += token.Enabled ? "1" : "0";
             }
+            string handlerActive = string.Empty;
+            foreach (MessageHandler handler in _handlers)
+            {
+                handlerActive += handler.active ? "1" : "0";
+            }
             string diagnostics = string.Empty;
             string retainedMessages = string.Empty;
             foreach (MessageRegistrationToken token in _tokens)
@@ -201,7 +226,7 @@ namespace DxMessaging.Tests.Runtime
                 retainedMessages += $"{references},";
             }
             string state =
-                $"counts={_bus.RegisteredUntargeted},{_bus.RegisteredTargeted},{_bus.RegisteredBroadcast},{_bus.RegisteredInterceptors},{_bus.RegisteredPostProcessors},{_bus.RegisteredGlobalAcceptAll}; slots={_bus.OccupiedTypeSlots},{_bus.OccupiedTargetSlots}; enabled={enabled}; diagnostics={_bus.DiagnosticsMode}; tokenMetadataCallsHistory={diagnostics}; retainedMessages={retainedMessages}";
+                $"counts={_bus.RegisteredUntargeted},{_bus.RegisteredTargeted},{_bus.RegisteredBroadcast},{_bus.RegisteredInterceptors},{_bus.RegisteredPostProcessors},{_bus.RegisteredGlobalAcceptAll}; slots={_bus.OccupiedTypeSlots},{_bus.OccupiedTargetSlots}; enabled={enabled}; handlerActive={handlerActive}; diagnostics={_bus.DiagnosticsMode}; tokenMetadataCallsHistory={diagnostics}; retainedMessages={retainedMessages}";
             return new BusTraceObservation(
                 _callbacks,
                 state,
@@ -292,6 +317,9 @@ namespace DxMessaging.Tests.Runtime
         // Mutants change real callback behavior here; observation construction remains shared.
         protected virtual void OnCallback(int slot, IMessage message) { }
 
+        protected virtual void SetHandlerActive(int slot, bool active) =>
+            _handlers[slot].active = active;
+
         protected virtual void DisableFromCallback(int slot) => _tokens[slot].Disable();
 
         protected virtual void EmitNested(BusTraceOperation operation) => Emit(operation);
@@ -368,6 +396,12 @@ namespace DxMessaging.Tests.Runtime
         {
             _callbacks.Add($"token={token},value={value}");
             OnCallback(token, message);
+            if (_handlerActiveOperation.HasValue && token == _handlerActiveOperation.Value.Token)
+            {
+                BusTraceOperation operation = _handlerActiveOperation.Value;
+                _handlerActiveOperation = null;
+                SetHandlerActive(operation.HandlerToken, operation.HandlerActive);
+            }
             if (token == _disableOnCallbackToken)
             {
                 _disableOnCallbackToken = -1;

--- a/Tests/Runtime/Unity/MessagingComponentLifecycleTests.cs
+++ b/Tests/Runtime/Unity/MessagingComponentLifecycleTests.cs
@@ -2,6 +2,7 @@
 namespace DxMessaging.Tests.Runtime.Unity
 {
     using System;
+    using System.Text.RegularExpressions;
     using DxMessaging.Core;
     using DxMessaging.Core.Extensions;
     using DxMessaging.Core.MessageBus;
@@ -13,6 +14,7 @@ namespace DxMessaging.Tests.Runtime.Unity
     using DxMessaging.Unity;
     using NUnit.Framework;
     using UnityEngine;
+    using UnityEngine.TestTools;
 
     /// <summary>
     /// Covers <see cref="MessagingComponent"/> lifecycle surface not exercised elsewhere:
@@ -31,6 +33,425 @@ namespace DxMessaging.Tests.Runtime.Unity
     /// </remarks>
     public sealed class MessagingComponentLifecycleTests : MessagingTestBase
     {
+        [Test]
+        public void DestroyingMessagingOwnerDisposesManualTokens(
+            [ValueSource(typeof(MessageScenarios), nameof(MessageScenarios.AllKinds))]
+                MessageScenario scenario,
+            [Values(false, true)] bool emitWhenDisabled,
+            [Values(false, true)] bool destroyWholeHost
+        )
+        {
+            string context =
+                $"[{scenario.Kind}, emitWhenDisabled={emitWhenDisabled}, destroyWholeHost={destroyWholeHost}]";
+            GameObject host = new(
+                nameof(DestroyingMessagingOwnerDisposesManualTokens),
+                typeof(MessagingComponent),
+                typeof(ManualListenerComponent)
+            );
+            _spawned.Add(host);
+            MessagingComponent messaging = host.GetComponent<MessagingComponent>();
+            ManualListenerComponent listener = host.GetComponent<ManualListenerComponent>();
+            MessageBus bus = new();
+            messaging.Configure(bus, MessageBusRebindMode.RebindActive);
+            messaging.emitMessagesWhenDisabled = emitWhenDisabled;
+            InstanceId route = host;
+
+            using (LeakWatcher watcher = new(bus: bus, label: context))
+            {
+                MessageRegistrationToken token = listener.RequestToken(messaging);
+                try
+                {
+                    int calls = 0;
+                    _ = ScenarioCallbacks.RegisterCountingHandler(
+                        scenario,
+                        token,
+                        route,
+                        () => ++calls
+                    );
+                    token.Enable();
+                    ScenarioCallbacks.EmitForKind(scenario, bus, route);
+                    Assert.That(calls, Is.EqualTo(1), $"{context} Control must deliver once.");
+
+                    if (destroyWholeHost)
+                    {
+                        _spawned.Remove(host);
+                        UnityEngine.Object.DestroyImmediate(host);
+                    }
+                    else
+                    {
+                        UnityEngine.Object.DestroyImmediate(messaging);
+                    }
+
+                    Assert.That(
+                        messaging == null,
+                        Is.True,
+                        $"{context} Messaging owner must be destroyed."
+                    );
+                    ScenarioCallbacks.EmitForKind(scenario, bus, route);
+                    Assert.That(
+                        calls,
+                        Is.EqualTo(1),
+                        $"{context} Destroyed messaging owners must stop delivery."
+                    );
+                    Assert.That(
+                        token.Enabled,
+                        Is.False,
+                        $"{context} Destroying the owner must dispose its tokens."
+                    );
+                    Assert.That(
+                        watcher.LeakedRegistrations,
+                        Is.Zero,
+                        $"{context} Destruction must remove bus registrations."
+                    );
+                    Assert.That(
+                        messaging._registeredListeners.Count,
+                        Is.Zero,
+                        $"{context} Destruction must release retained listener references."
+                    );
+                }
+                finally
+                {
+                    token.Dispose();
+                }
+            }
+        }
+
+        [Test]
+        public void DestructionFailureRetainsRetryWithoutBlockingSiblingCleanup(
+            [ValueSource(typeof(MessageScenarios), nameof(MessageScenarios.AllKinds))]
+                MessageScenario scenario
+        )
+        {
+            AssertCleanupFailureRetainsRetryableListener(scenario, destroyOwner: true);
+        }
+
+#if UNITY_EDITOR
+        [Test]
+        public void EditorResetFailureRetainsRetryWithoutBlockingSiblingCleanup(
+            [ValueSource(typeof(MessageScenarios), nameof(MessageScenarios.AllKinds))]
+                MessageScenario scenario
+        )
+        {
+            AssertCleanupFailureRetainsRetryableListener(scenario, destroyOwner: false);
+        }
+#endif
+
+        private void AssertCleanupFailureRetainsRetryableListener(
+            MessageScenario scenario,
+            bool destroyOwner
+        )
+        {
+            string context = $"[{scenario.Kind}, destroyOwner={destroyOwner}]";
+            GameObject host = new(
+                nameof(AssertCleanupFailureRetainsRetryableListener),
+                typeof(MessagingComponent),
+                typeof(ManualListenerComponent)
+            );
+            _spawned.Add(host);
+            MessagingComponent messaging = host.GetComponent<MessagingComponent>();
+            ManualListenerComponent first = host.GetComponent<ManualListenerComponent>();
+            ManualListenerComponent sibling = host.AddComponent<ManualListenerComponent>();
+            MessageBus innerBus = new();
+            ThrowOnceDeregistrationBus bus = new(innerBus);
+            messaging.Configure(bus, MessageBusRebindMode.RebindActive);
+            messaging.emitMessagesWhenDisabled = true;
+            InstanceId route = host;
+
+            using (LeakWatcher watcher = new(bus: bus, label: context))
+            {
+                MessageRegistrationToken firstToken = first.RequestToken(messaging);
+                MessageRegistrationToken siblingToken = sibling.RequestToken(messaging);
+                try
+                {
+                    int calls = 0;
+                    firstToken.DiagnosticMode = true;
+                    siblingToken.DiagnosticMode = true;
+                    _ = ScenarioCallbacks.RegisterCountingHandler(
+                        scenario,
+                        firstToken,
+                        route,
+                        () => ++calls
+                    );
+                    _ = ScenarioCallbacks.RegisterCountingHandler(
+                        scenario,
+                        siblingToken,
+                        route,
+                        () => ++calls
+                    );
+                    firstToken.Enable();
+                    siblingToken.Enable();
+                    ScenarioCallbacks.EmitForKind(scenario, bus, route);
+                    Assert.That(
+                        calls,
+                        Is.EqualTo(2),
+                        $"{context} Both listeners must deliver before cleanup."
+                    );
+
+                    LogAssert.Expect(
+                        LogType.Warning,
+                        new Regex(
+                            @"\[DxMessaging\] Disposing listener token failed\. System.InvalidOperationException: Deregistration failure\."
+                        )
+                    );
+                    if (destroyOwner)
+                    {
+                        UnityEngine.Object.DestroyImmediate(messaging);
+                        messaging.ToggleMessageHandler(true);
+                        messaging.OnEnable();
+                        Assert.Throws<ObjectDisposedException>(
+                            () => messaging.Create(first),
+                            $"{context} A destroyed owner must reject new tokens."
+                        );
+                    }
+#if UNITY_EDITOR
+                    else
+                    {
+                        Assert.That(
+                            messaging.EditorResetRuntimeState(),
+                            Is.False,
+                            $"{context} A failed reset must not report success."
+                        );
+                    }
+#endif
+
+                    ScenarioCallbacks.EmitForKind(scenario, bus, route);
+                    Assert.That(
+                        calls,
+                        Is.EqualTo(2),
+                        $"{context} Failed cleanup must leave the old handler inactive."
+                    );
+                    Assert.That(
+                        firstToken.Enabled,
+                        Is.True,
+                        $"{context} Failed token must remain retryable."
+                    );
+                    Assert.That(
+                        siblingToken.Enabled,
+                        Is.False,
+                        $"{context} Failure must not block sibling disposal."
+                    );
+                    Assert.That(
+                        messaging._registeredListeners.Count,
+                        Is.EqualTo(1),
+                        $"{context} Only failed cleanup may retain a listener."
+                    );
+                    Assert.That(
+                        siblingToken._metadata.Count,
+                        Is.Zero,
+                        $"{context} Successful disposal must clear metadata."
+                    );
+                    Assert.That(
+                        siblingToken._callCounts.Count,
+                        Is.Zero,
+                        $"{context} Successful disposal must clear call counts."
+                    );
+                    Assert.That(
+                        siblingToken._emissionBuffer.Count,
+                        Is.Zero,
+                        $"{context} Successful disposal must clear history."
+                    );
+
+                    if (destroyOwner)
+                    {
+                        Assert.That(
+                            messaging.Release(first),
+                            Is.True,
+                            $"{context} Retained destroyed owner must support explicit cleanup retry."
+                        );
+                    }
+#if UNITY_EDITOR
+                    else
+                    {
+                        Assert.That(
+                            messaging.EditorResetRuntimeState(),
+                            Is.True,
+                            $"{context} Reset retry must complete cleanup."
+                        );
+                    }
+#endif
+
+                    Assert.That(
+                        firstToken.Enabled,
+                        Is.False,
+                        $"{context} Retry must dispose the retained token."
+                    );
+                    Assert.That(
+                        firstToken._metadata.Count,
+                        Is.Zero,
+                        $"{context} Retry must clear metadata."
+                    );
+                    Assert.That(
+                        firstToken._callCounts.Count,
+                        Is.Zero,
+                        $"{context} Retry must clear call counts."
+                    );
+                    Assert.That(
+                        firstToken._emissionBuffer.Count,
+                        Is.Zero,
+                        $"{context} Retry must clear history."
+                    );
+                    Assert.That(
+                        messaging._registeredListeners.Count,
+                        Is.Zero,
+                        $"{context} Retry must release listener references."
+                    );
+                    Assert.That(
+                        watcher.LeakedRegistrations,
+                        Is.Zero,
+                        $"{context} Retry must remove remaining registrations."
+                    );
+                }
+                finally
+                {
+                    firstToken.Dispose();
+                    siblingToken.Dispose();
+                }
+            }
+        }
+
+        [Test]
+        public void ExplicitReleaseCleansTokenAfterNeverActivatedHostDestruction(
+            [ValueSource(typeof(MessageScenarios), nameof(MessageScenarios.AllKinds))]
+                MessageScenario scenario
+        )
+        {
+            string context = $"[{scenario.Kind}]";
+            GameObject host = new(
+                nameof(ExplicitReleaseCleansTokenAfterNeverActivatedHostDestruction)
+            );
+            _spawned.Add(host);
+            host.SetActive(false);
+            MessagingComponent messaging = host.AddComponent<MessagingComponent>();
+            ManualListenerComponent listener = host.AddComponent<ManualListenerComponent>();
+            MessageBus bus = new();
+            messaging.Configure(bus, MessageBusRebindMode.RebindActive);
+            messaging.emitMessagesWhenDisabled = true;
+            InstanceId route = host;
+
+            using (LeakWatcher watcher = new(bus: bus, label: context))
+            {
+                MessageRegistrationToken token = listener.RequestToken(messaging);
+                try
+                {
+                    int calls = 0;
+                    _ = ScenarioCallbacks.RegisterCountingHandler(
+                        scenario,
+                        token,
+                        route,
+                        () => ++calls
+                    );
+                    token.Enable();
+                    ScenarioCallbacks.EmitForKind(scenario, bus, route);
+                    Assert.That(
+                        calls,
+                        Is.EqualTo(1),
+                        $"{context} Explicit opt-in must deliver before host activation."
+                    );
+
+                    _spawned.Remove(host);
+                    UnityEngine.Object.DestroyImmediate(host);
+                    Assert.That(
+                        host == null,
+                        Is.True,
+                        $"{context} Never-activated host must be destroyed."
+                    );
+                    messaging.Release(listener);
+
+                    ScenarioCallbacks.EmitForKind(scenario, bus, route);
+                    Assert.That(
+                        calls,
+                        Is.EqualTo(1),
+                        $"{context} Explicit release must stop delivery after destruction."
+                    );
+                    Assert.That(
+                        token.Enabled,
+                        Is.False,
+                        $"{context} Explicit release must dispose the token."
+                    );
+                    Assert.That(
+                        messaging._registeredListeners.Count,
+                        Is.Zero,
+                        $"{context} Explicit release must drop retained listeners."
+                    );
+                    Assert.That(
+                        watcher.LeakedRegistrations,
+                        Is.Zero,
+                        $"{context} Explicit release must remove bus registrations."
+                    );
+                }
+                finally
+                {
+                    token.Dispose();
+                }
+            }
+        }
+
+        [Test]
+        public void TokenCreatedBeforeHostActivationRespectsHandlerState(
+            [ValueSource(typeof(MessageScenarios), nameof(MessageScenarios.AllKinds))]
+                MessageScenario scenario,
+            [Values(false, true)] bool emitWhenDisabled,
+            [Values(false, true)] bool componentEnabled
+        )
+        {
+            string context =
+                $"[{scenario.Kind}, emitWhenDisabled={emitWhenDisabled}, componentEnabled={componentEnabled}]";
+            GameObject host = new(nameof(TokenCreatedBeforeHostActivationRespectsHandlerState));
+            _spawned.Add(host);
+            host.SetActive(false);
+            MessagingComponent messaging = host.AddComponent<MessagingComponent>();
+            ManualListenerComponent listener = host.AddComponent<ManualListenerComponent>();
+            messaging.enabled = componentEnabled;
+            messaging.emitMessagesWhenDisabled = emitWhenDisabled;
+            MessageBus bus = new();
+            messaging.Configure(bus, MessageBusRebindMode.RebindActive);
+            InstanceId route = host;
+
+            using (LeakWatcher watcher = new(bus: bus, label: context))
+            {
+                MessageRegistrationToken token = listener.RequestToken(messaging);
+                try
+                {
+                    int calls = 0;
+                    _ = ScenarioCallbacks.RegisterCountingHandler(
+                        scenario,
+                        token,
+                        route,
+                        () => ++calls
+                    );
+                    token.Enable();
+                    ScenarioCallbacks.EmitForKind(scenario, bus, route);
+                    int expectedCalls = emitWhenDisabled ? 1 : 0;
+                    Assert.That(
+                        calls,
+                        Is.EqualTo(expectedCalls),
+                        $"{context} A new handler must respect the inactive host."
+                    );
+
+                    host.SetActive(true);
+                    ScenarioCallbacks.EmitForKind(scenario, bus, route);
+                    expectedCalls += emitWhenDisabled || componentEnabled ? 1 : 0;
+                    Assert.That(
+                        calls,
+                        Is.EqualTo(expectedCalls),
+                        $"{context} Host activation must respect the component state."
+                    );
+
+                    messaging.enabled = true;
+                    ScenarioCallbacks.EmitForKind(scenario, bus, route);
+                    Assert.That(
+                        calls,
+                        Is.EqualTo(expectedCalls + 1),
+                        $"{context} Enabling the host and component must resume delivery."
+                    );
+                }
+                finally
+                {
+                    messaging.Release(listener);
+                }
+            }
+        }
+
         [Test]
         public void ToggleMessageHandlerFalseSuspendsDeliveryUntilToggledTrue()
         {
@@ -674,6 +1095,25 @@ namespace DxMessaging.Tests.Runtime.Unity
                     failingBus.AllowDeregistrations();
                     token.Dispose();
                 }
+            }
+        }
+
+        private sealed class ThrowOnceDeregistrationBus : DelegatingMessageBus
+        {
+            private bool _throwOnDeregistration = true;
+
+            internal ThrowOnceDeregistrationBus(IMessageBus inner)
+                : base(inner) { }
+
+            public override void Deregister<T>(in MessageBusRegistration registration)
+            {
+                if (_throwOnDeregistration)
+                {
+                    _throwOnDeregistration = false;
+                    throw new InvalidOperationException("Deregistration failure.");
+                }
+
+                base.Deregister<T>(in registration);
             }
         }
 

--- a/docs/guides/advanced.md
+++ b/docs/guides/advanced.md
@@ -124,13 +124,18 @@ messaging.ToggleMessageHandler(false); // suspends delivery despite the flag
 messaging.ToggleMessageHandler(true); // resumes delivery
 ```
 
-While `emitMessagesWhenDisabled` is true, the Unity lifecycle never toggles the
+While `emitMessagesWhenDisabled` is true, Unity enable/disable callbacks never toggle the
 handler: disabling the component keeps emission alive, and re-enabling does not
 revert an explicit `ToggleMessageHandler(false)`. Explicit toggle calls are the
 single source of truth until the flag is cleared. One ordering to know: if the
 lifecycle already deactivated the handler (component disabled with the flag
 clear) and you then set the flag while disabled, re-enabling does not
 reactivate it -- call `ToggleMessageHandler(true)` to resume.
+
+**Fixed in v4.0.0:** Initial handler activity follows the component and host enable state
+unless disabled delivery is opted in. Destroying an initialized messaging owner deactivates
+its shared handler and disposes its owned tokens. See [manual lifecycle cleanup](unity-integration.md#messagingcomponent)
+for cleanup failures and hosts that have never been active.
 
 Re-register after release (opt-in)
 

--- a/docs/guides/unity-integration.md
+++ b/docs/guides/unity-integration.md
@@ -9,6 +9,21 @@ Unity-centric helpers make registration lifecycles explicit and safe.
 - Call `Configure(IMessageBus, MessageBusRebindMode)` before `Create` if you want the component to use a custom bus (e.g., one resolved from a DI container). Passing `MessageBusRebindMode.RebindActive` migrates current registrations; `PreserveRegistrations` defers the swap until the next enable.
 - Optional: set `emitMessagesWhenDisabled` if you need to emit while disabled.
 
+**Fixed in v4.0.0:** A token created before host activation starts with delivery suspended
+unless `emitMessagesWhenDisabled` is enabled. Token enable state and handler activity are
+separate; enabling a token does not activate its GameObject.
+
+Destroying an initialized `MessagingComponent` deactivates its shared handler and disposes its
+owned tokens, including tokens created by plain `MonoBehaviour` listeners. This also applies when only the
+`MessagingComponent` is removed. If a custom bus throws during deregistration, cleanup continues
+for other listeners and logs the full exception. Retain the component and listener references
+and retry `Release(listener)` after the bus recovers. An interceptor whose removal fails remains
+registered until that retry succeeds.
+
+Unity [only sends `OnDestroy` to previously active GameObjects](https://docs.unity3d.com/2021.3/Documentation/ScriptReference/MonoBehaviour.OnDestroy.html).
+If you create tokens on a host that has never been active, call `Release(listener)` or dispose each token before discarding it. A manual
+listener removed while its messaging owner survives must also release its token.
+
 ## MessageAwareComponent
 
 - Derive for a batteries-included pattern; it manages a token for you.
@@ -54,8 +69,8 @@ public sealed class HealthComponent : MessageAwareComponent
 - If you need to opt out of string demos, prefer overriding `RegisterForStringMessages => false` rather than removing the base call.
 - **Don't hide Unity methods** with `new` (e.g., `new void OnEnable()`); always `override` and call `base.*`.
 
-!!! tip "Diagnostics & Analyzer"
-DxMessaging ships a Roslyn analyzer + Inspector overlay that catches missing base calls at compile time and surfaces them as a HelpBox at the top of the offending component's Inspector. See the [Inspector Overlay & Base-Call Warnings](inspector-overlay.md) guide for the day-to-day workflow, or the [Roslyn Analyzers & Diagnostics](../reference/analyzers.md) reference for every diagnostic id and the suppression-precedence ordering.
+> **Diagnostics and analyzer:**
+> DxMessaging ships a Roslyn analyzer + Inspector overlay that catches missing base calls at compile time and surfaces them as a HelpBox at the top of the offending component's Inspector. See the [Inspector Overlay & Base-Call Warnings](inspector-overlay.md) guide for the day-to-day workflow, or the [Roslyn Analyzers & Diagnostics](../reference/analyzers.md) reference for every diagnostic id and the suppression-precedence ordering.
 
 ## Registration timing
 
@@ -87,6 +102,7 @@ public sealed class InventoryUI : UnityEngine.MonoBehaviour
 
     private void OnEnable() => _token.Enable();
     private void OnDisable() => _token.Disable();
+    private void OnDestroy() => _messaging.Release(this);
 
     private void OnWorld(in WorldRegenerated m) { /* update UI */ }
     private void OnDamage(in ApplyDamage m) { /* apply damage */ }


### PR DESCRIPTION
## Why

Destroying a messaging owner can leave manual listener registrations alive. Tokens created before host activation can also deliver messages too early.

## What changed

- Owner destruction deactivates delivery and releases retained tokens. Failed cleanup remains available for retry without blocking other listeners.
- New handlers respect the initial component and GameObject state, including the disabled-delivery option.
- Differential traces cover handler activity and changes made during callbacks.
- The full-stack allocation test now verifies and measures two postprocessor priorities.
- Local Unity guidance requires safe Editor filters and completed framework cleanup.

## How we know

Native tests reproduce both lifecycle bugs before the fixes. The full runtime suite passes twice: 1,485 tests in 25.8 and 19.9 seconds.

The allocation setup assertion fails before its fix, reporting one priority instead of two. The corrected row passes ten native repetitions with the original zero-allocation threshold.

Documentation tests pass all 617 cases. Source-generator tests pass all 257 cases. Formatting, spelling, Markdown, and repository validation pass.

The full allocation assembly passes all 277 cases. Local Editor verification passes 942 cases in 36.9 seconds. The generated CI hosts pass all nine sample cases omitted locally; existing local imports are preserved.

Static CI, all four Unity versions, and both performance jobs pass. Internal benchmark execution remains 580 seconds; comparisons take 414 seconds versus 405 on main.

An earlier intermittent allocation failure remains open in #545. The unchanged test passed 50 isolated runs and the original scope repeated without assertion failures.

## Related Issue

Closes #542
Closes #543
Closes #546

Advances #509. Local test-bridge ownership remains tracked in #544.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)

## Checklist

- [x] Final supported local suites pass; omitted sample cases pass in CI
- [x] Code is properly formatted
- [x] I have added tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have updated the [CHANGELOG](../CHANGELOG.md)
- [x] My changes do not introduce breaking changes, or breaking changes are documented
