### PR TITLE
Bound Unity shutdown and preserve test results

### DIFF
--- a/.docs-tests/UnityMcpBridgeTests.cs
+++ b/.docs-tests/UnityMcpBridgeTests.cs
@@ -76,6 +76,40 @@ internal sealed class UnityMcpBridgeTests
         Assert.That(TestRunnerApi.Executions, Is.EqualTo(1));
     }
 
+    [TestCase(TestStatus.Passed)]
+    [TestCase(TestStatus.Skipped)]
+    public void MixedPassingAndSkippedResultsCompleteCleanup(TestStatus rootStatus)
+    {
+        Run();
+        // Unity propagates ignored children to a skipped suite with positive pass counts.
+        Result result = new()
+        {
+            IsSuite = true,
+            TestStatus = rootStatus,
+            PassCount = 1,
+            SkipCount = 1,
+            Children =
+            [
+                new Result(),
+                new Result
+                {
+                    TestStatus = TestStatus.Skipped,
+                    PassCount = 0,
+                    SkipCount = 1,
+                },
+            ],
+        };
+        TestRunnerApi.Callbacks.RunFinished(result);
+        TestRunnerApi.Active = false;
+        EditorApplication.Tick();
+        Assert.That(
+            File.ReadAllText(_path + ".cleanup.status"),
+            Is.EqualTo("done"),
+            rootStatus.ToString()
+        );
+        Assert.That(SessionState.Values, Is.Empty);
+    }
+
     [TestCase("observe")]
     [TestCase("error")]
     [TestCase("result")]
@@ -282,6 +316,7 @@ internal sealed class UnityMcpBridgeTests
     [TestCase("dirty")]
     [TestCase("scene-replaced")]
     [TestCase("zero-passes")]
+    [TestCase("all-skipped")]
     [TestCase("failed")]
     [TestCase("inconclusive")]
     [TestCase("suite-teardown-failed")]
@@ -301,6 +336,11 @@ internal sealed class UnityMcpBridgeTests
                 break;
             case "zero-passes":
                 result.PassCount = 0;
+                break;
+            case "all-skipped":
+                result.TestStatus = TestStatus.Skipped;
+                result.PassCount = 0;
+                result.SkipCount = 1;
                 break;
             case "failed":
                 result.FailCount = 1;
@@ -447,7 +487,7 @@ internal sealed class UnityMcpBridgeTests
         public bool IsSuite { get; set; }
         public int PassCount { get; set; } = 1;
         public int FailCount { get; set; }
-        public int SkipCount => 0;
+        public int SkipCount { get; set; }
         public int InconclusiveCount { get; set; }
         public double Duration => 0.125;
         public string FullName { get; set; } = "test";

--- a/.docs-tests/UnityMcpBridgeTests.cs
+++ b/.docs-tests/UnityMcpBridgeTests.cs
@@ -76,6 +76,76 @@ internal sealed class UnityMcpBridgeTests
         Assert.That(TestRunnerApi.Executions, Is.EqualTo(1));
     }
 
+    [TestCase("observe")]
+    [TestCase("error")]
+    [TestCase("result")]
+    public void UnmarkedLegacyOwnershipPreservesEvidence(string callback)
+    {
+        SessionState.SetString("DxMcpTestRunner.ResultPath", _path);
+        Dictionary<string, string> evidence = new()
+        {
+            [_path] = "legacy result",
+            [_path + ".status"] = "running",
+            [_path + ".errors.log"] = "legacy error",
+        };
+        foreach ((string path, string content) in evidence)
+        {
+            File.WriteAllText(path, content);
+        }
+        // Initialize callbacks while proving the unresolved legacy owner blocks Run.
+        Assert.Throws<InvalidOperationException>(() => Run());
+        switch (callback)
+        {
+            case "observe":
+                EditorApplication.Tick();
+                break;
+            case "error":
+                TestRunnerApi.Callbacks.OnError("unrelated framework error");
+                break;
+            case "result":
+                TestRunnerApi.Callbacks.RunFinished(new Result());
+                break;
+        }
+        foreach ((string path, string content) in evidence)
+        {
+            Assert.That(File.ReadAllText(path), Is.EqualTo(content), callback + ": " + path);
+        }
+        Assert.That(Directory.GetFiles(_directory), Is.EquivalentTo(evidence.Keys), callback);
+        Assert.That(
+            SessionState.GetString("DxMcpTestRunner.ResultPath", ""),
+            Is.EqualTo(_path),
+            callback
+        );
+        Assert.That(TestRunnerApi.Executions, Is.Zero);
+    }
+
+    [TestCase("ownedResultPath", false)]
+    [TestCase("ownedResultPath", true)]
+    [TestCase("legacyObserverResultPath", false)]
+    public void IncompleteOwnershipRemainsVisibleAndBlocksNewRuns(string field, bool hasRawPath)
+    {
+        string key =
+            field == "ownedResultPath"
+                ? "DxMcpTestRunner.OwnedResultPath"
+                : "DxMcpObservedTestRunner.ResultPath";
+        SessionState.SetString(key, _path);
+        if (hasRawPath)
+        {
+            SessionState.SetString("DxMcpTestRunner.ResultPath", _path + ".different");
+        }
+        Assert.Throws<InvalidOperationException>(() => Run());
+        EditorApplication.timeSinceStartup = double.MaxValue;
+        EditorApplication.Tick();
+        string snapshot = File.ReadAllText(
+            "Packages/com.wallstop-studios.dxmessaging/.artifacts/unity-mcp/editor-state.json"
+        );
+        Assert.That(snapshot, Does.Contain(field));
+        using JsonDocument state = JsonDocument.Parse(snapshot);
+        Assert.That(state.RootElement.GetProperty(field).GetString(), Is.EqualTo(_path));
+        Assert.That(SessionState.GetString(key, ""), Is.EqualTo(_path));
+        Assert.That(TestRunnerApi.Executions, Is.Zero);
+    }
+
     [TestCase("active")]
     [TestCase("compiling")]
     [TestCase("updating")]

--- a/.docs-tests/UnityMcpBridgeTests.cs
+++ b/.docs-tests/UnityMcpBridgeTests.cs
@@ -1,0 +1,393 @@
+using System.Text.Json;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEditor.SceneManagement;
+using UnityEditor.TestTools.TestRunner.Api;
+using UnityEngine.SceneManagement;
+
+namespace WallstopStudios.DxMessaging.Docs.Tests;
+
+[TestFixture]
+[NonParallelizable]
+internal sealed class UnityMcpBridgeTests
+{
+    private string _directory = "";
+    private string _path = "";
+    private string _previousDirectory = "";
+
+    [SetUp]
+    public void SetUp()
+    {
+        _directory = Path.Combine(Path.GetTempPath(), "dxm-mcp-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_directory);
+        _path = Path.Combine(_directory, "result.json");
+        _previousDirectory = Environment.CurrentDirectory;
+        Environment.CurrentDirectory = _directory;
+        SessionState.Values.Clear();
+        TestRunnerApi.Active = false;
+        TestRunnerApi.QueryThrows = false;
+        TestRunnerApi.ExecuteThrows = false;
+        TestRunnerApi.Executions = 0;
+        TestRunnerApi.DuringExecute = null;
+        TestRunnerApi.RunGuid = "owned-guid";
+        EditorApplication.isPlayingOrWillChangePlaymode = false;
+        EditorApplication.isCompiling = false;
+        EditorApplication.isUpdating = false;
+        EditorApplication.timeSinceStartup = -1;
+        StageUtility.CurrentStage = 0;
+        SceneManager.Scenes = [new Scene { path = "Assets/Original.unity", isLoaded = true }];
+        SceneManager.ActiveIndex = 0;
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        SessionState.Values.Clear();
+        Environment.CurrentDirectory = _previousDirectory;
+        Directory.Delete(_directory, true);
+    }
+
+    private string Run() =>
+        DxMcpTestRunner.Run("EditMode", "Assembly", "Fixture;Method", "!Perf", _path);
+
+    [Test]
+    public void RetainsIdentityAndOwnershipUntilPassiveCleanup()
+    {
+        Assert.That(Run(), Is.EqualTo("owned-guid"));
+        Assert.That(File.ReadAllText(_path + ".run.json"), Does.Contain("owned-guid"));
+        Assert.That(
+            TestRunnerApi.LastSettings!.Filter.testNames,
+            Is.EqualTo("Fixture;Method".Split(';'))
+        );
+        TestRunnerApi.Callbacks.RunFinished(new Result());
+        Assert.That(File.ReadAllText(_path + ".status"), Is.EqualTo("done"));
+        EditorApplication.Tick();
+        Assert.That(File.ReadAllText(_path + ".cleanup.status"), Is.EqualTo("running"));
+        Assert.Throws<InvalidOperationException>(() => Run());
+        Assert.That(
+            SessionState.GetString("DxMcpTestRunner.RunGuid", ""),
+            Is.EqualTo("owned-guid")
+        );
+        TestRunnerApi.Active = false;
+        EditorApplication.Tick();
+        Assert.That(File.ReadAllText(_path + ".cleanup.status"), Is.EqualTo("done"));
+        Assert.That(File.ReadAllText(_path + ".cleanup.json"), Does.Contain("owned-guid"));
+        Assert.That(SessionState.Values, Is.Empty);
+        Assert.That(TestRunnerApi.Executions, Is.EqualTo(1));
+    }
+
+    [TestCase("active")]
+    [TestCase("compiling")]
+    [TestCase("updating")]
+    [TestCase("playing")]
+    [TestCase("stage")]
+    [TestCase("dirty-secondary-scene")]
+    [TestCase("unsaved")]
+    [TestCase("query-error")]
+    [TestCase("legacy-owner")]
+    [TestCase("zero-scenes")]
+    public void RejectsUnsafeStartWithoutChangingEvidence(string condition)
+    {
+        switch (condition)
+        {
+            case "zero-scenes":
+                SceneManager.Scenes = [];
+                break;
+            case "active":
+                TestRunnerApi.Active = true;
+                break;
+            case "compiling":
+                EditorApplication.isCompiling = true;
+                break;
+            case "updating":
+                EditorApplication.isUpdating = true;
+                break;
+            case "playing":
+                EditorApplication.isPlayingOrWillChangePlaymode = true;
+                break;
+            case "stage":
+                StageUtility.CurrentStage = 1;
+                break;
+            case "dirty-secondary-scene":
+                SceneManager.Scenes =
+                [
+                    SceneManager.Scenes[0],
+                    new Scene { path = "Assets/Dirty.unity", isDirty = true },
+                ];
+                break;
+            case "unsaved":
+                SceneManager.Scenes[0].path = "";
+                break;
+            case "query-error":
+                TestRunnerApi.QueryThrows = true;
+                break;
+            case "legacy-owner":
+                SessionState.SetString("DxMcpObservedTestRunner.ResultPath", "owned");
+                break;
+        }
+        Assert.That(() => Run(), Throws.Exception, condition);
+        Assert.That(Directory.GetFiles(_directory), Is.Empty, condition);
+        Assert.That(TestRunnerApi.Executions, Is.Zero, condition);
+    }
+
+    [TestCase("")]
+    [TestCase(".status")]
+    [TestCase(".cleanup.status")]
+    [TestCase(".run.json")]
+    public void RefusesExistingEvidence(string suffix)
+    {
+        File.WriteAllText(_path + suffix, "preserve");
+        Assert.Throws<IOException>(() => Run());
+        Assert.That(File.ReadAllText(_path + suffix), Is.EqualTo("preserve"));
+        Assert.That(SessionState.Values, Is.Empty);
+        Assert.That(TestRunnerApi.Executions, Is.Zero);
+    }
+
+    [TestCase(false)]
+    [TestCase(true)]
+    public void CapturesFrameworkErrorBeforeOrAfterRawResult(bool resultFirst)
+    {
+        Run();
+        if (resultFirst)
+        {
+            TestRunnerApi.Callbacks.RunFinished(new Result());
+        }
+        TestRunnerApi.Callbacks.OnError("cleanup failed");
+        EditorApplication.Tick();
+        Assert.That(File.ReadAllText(_path + ".cleanup.status"), Is.EqualTo("running"));
+        TestRunnerApi.Active = false;
+        EditorApplication.Tick();
+        Assert.That(File.ReadAllText(_path + ".cleanup.status"), Does.StartWith("error:"));
+        Assert.That(File.ReadAllText(_path + ".errors.log"), Does.Contain("cleanup failed"));
+        Assert.That(SessionState.Values, Is.Empty);
+    }
+
+    [Test]
+    public void MissingResultIsTerminalOnlyAfterFrameworkBecomesInactive()
+    {
+        Run();
+        EditorApplication.Tick();
+        Assert.That(File.ReadAllText(_path + ".status"), Is.EqualTo("running"));
+        TestRunnerApi.Active = false;
+        EditorApplication.Tick();
+        Assert.That(
+            File.ReadAllText(_path + ".cleanup.status"),
+            Does.Contain("without a completed result")
+        );
+        Assert.That(File.ReadAllText(_path + ".status"), Does.StartWith("error:"));
+    }
+
+    [Test]
+    public void QueryFailureRetainsOwnershipAndRecoversOnNextPassiveObservation()
+    {
+        Run();
+        TestRunnerApi.Callbacks.RunFinished(new Result());
+        TestRunnerApi.Active = false;
+        TestRunnerApi.QueryThrows = true;
+        EditorApplication.Tick();
+        Assert.That(
+            File.ReadAllText(_path + ".cleanup.status"),
+            Does.StartWith("observation-error:")
+        );
+        Assert.Throws<InvalidOperationException>(() => Run());
+        TestRunnerApi.QueryThrows = false;
+        EditorApplication.Tick();
+        Assert.That(File.ReadAllText(_path + ".cleanup.status"), Is.EqualTo("done"));
+    }
+
+    [Test]
+    public void ExecuteFailureWithLiveJobRetainsOwnershipUntilCleanup()
+    {
+        TestRunnerApi.ExecuteThrows = true;
+        Assert.Throws<InvalidOperationException>(() => Run());
+        EditorApplication.Tick();
+        Assert.That(File.ReadAllText(_path + ".cleanup.status"), Is.EqualTo("running"));
+        Assert.Throws<InvalidOperationException>(() => Run());
+        TestRunnerApi.Active = false;
+        EditorApplication.Tick();
+        Assert.That(File.ReadAllText(_path + ".cleanup.status"), Does.StartWith("error:"));
+        Assert.That(TestRunnerApi.Executions, Is.EqualTo(1));
+    }
+
+    [TestCase("dirty")]
+    [TestCase("scene-replaced")]
+    [TestCase("zero-passes")]
+    [TestCase("failed")]
+    [TestCase("inconclusive")]
+    [TestCase("suite-teardown-failed")]
+    [TestCase("suite-inconclusive")]
+    [TestCase("child-failed")]
+    public void PassingRawCallbackDoesNotHideCleanupOrResultFailure(string condition)
+    {
+        Run();
+        Result result = new();
+        switch (condition)
+        {
+            case "dirty":
+                SceneManager.Scenes[0].isDirty = true;
+                break;
+            case "scene-replaced":
+                SceneManager.Scenes[0].path = "Assets/Temporary.unity";
+                break;
+            case "zero-passes":
+                result.PassCount = 0;
+                break;
+            case "failed":
+                result.FailCount = 1;
+                break;
+            case "inconclusive":
+                result.InconclusiveCount = 1;
+                break;
+            case "suite-teardown-failed":
+            case "suite-inconclusive":
+                // NUnit suite teardown changes status without incrementing failed-child counts.
+                result.IsSuite = true;
+                result.TestStatus =
+                    condition == "suite-teardown-failed"
+                        ? TestStatus.Failed
+                        : TestStatus.Inconclusive;
+                result.Children = [new Result()];
+                break;
+            case "child-failed":
+                result.IsSuite = true;
+                result.Children = [new Result { TestStatus = TestStatus.Failed }];
+                break;
+        }
+        TestRunnerApi.Callbacks.RunFinished(result);
+        TestRunnerApi.Active = false;
+        EditorApplication.Tick();
+        Assert.That(
+            File.ReadAllText(_path + ".cleanup.status"),
+            Does.StartWith("error:"),
+            condition
+        );
+    }
+
+    [Test]
+    public void RetainsTreeOutputAndEscapedFailures()
+    {
+        Run();
+        Result leaf = new()
+        {
+            FullName = "child",
+            TestStatus = TestStatus.Failed,
+            Message = "quoted \"value\"\nline",
+            Output = "output",
+        };
+        TestRunnerApi.Callbacks.RunFinished(new Result { IsSuite = true, Children = [leaf] });
+        using JsonDocument document = JsonDocument.Parse(File.ReadAllText(_path));
+        JsonElement root = document.RootElement;
+        Assert.That(root.GetProperty("nodes").GetArrayLength(), Is.EqualTo(2));
+        Assert.That(root.GetProperty("nodes")[1].GetProperty("parentIndex").GetInt32(), Is.Zero);
+        Assert.That(
+            root.GetProperty("failures")[0].GetProperty("message").GetString(),
+            Is.EqualTo(leaf.Message)
+        );
+        Assert.That(
+            root.GetProperty("nodes")[1].GetProperty("output").GetString(),
+            Is.EqualTo("output")
+        );
+    }
+
+    [Test]
+    public void SynchronousResultKeepsExecuteIdentityInCompanions()
+    {
+        TestRunnerApi.DuringExecute = () => TestRunnerApi.Callbacks.RunFinished(new Result());
+        Run();
+        Assert.That(File.ReadAllText(_path + ".status"), Is.EqualTo("done"));
+        Assert.That(File.ReadAllText(_path + ".run.json"), Does.Contain("owned-guid"));
+        TestRunnerApi.Active = false;
+        EditorApplication.Tick();
+        Assert.That(File.ReadAllText(_path + ".cleanup.json"), Does.Contain("owned-guid"));
+        Assert.That(File.ReadAllText(_path + ".cleanup.status"), Is.EqualTo("done"));
+    }
+
+    [Test]
+    public void CallbackStorageFailureStaysContainedAndPreservesOwnership()
+    {
+        Run();
+        Directory.CreateDirectory(_path);
+        Directory.CreateDirectory(_path + ".errors.log");
+        File.Delete(_path + ".status");
+        Directory.CreateDirectory(_path + ".status");
+        Assert.DoesNotThrow(() => TestRunnerApi.Callbacks.RunFinished(new Result()));
+        Assert.DoesNotThrow(() => TestRunnerApi.Callbacks.OnError("framework failed"));
+        File.Delete(_path + ".cleanup.status");
+        Directory.CreateDirectory(_path + ".cleanup.status");
+        TestRunnerApi.Active = false;
+        Assert.DoesNotThrow(() => EditorApplication.Tick());
+        Assert.That(SessionState.GetString("DxMcpTestRunner.ResultPath", ""), Is.EqualTo(_path));
+        Assert.That(
+            SessionState.GetString("DxMcpTestRunner.Errors", ""),
+            Does.Contain("framework failed")
+        );
+        string retainedErrors = SessionState.GetString("DxMcpTestRunner.Errors", "");
+        EditorApplication.Tick();
+        Assert.That(
+            SessionState.GetString("DxMcpTestRunner.Errors", ""),
+            Is.EqualTo(retainedErrors)
+        );
+        Directory.Delete(_path + ".cleanup.status");
+        Directory.Delete(_path + ".status");
+        EditorApplication.Tick();
+        using JsonDocument cleanup = JsonDocument.Parse(File.ReadAllText(_path + ".cleanup.json"));
+        Assert.That(
+            cleanup.RootElement.GetProperty("frameworkErrors").GetString(),
+            Does.Contain("framework failed")
+        );
+        Assert.That(File.ReadAllText(_path + ".cleanup.status"), Does.StartWith("error:"));
+        Assert.That(SessionState.Values, Is.Empty);
+    }
+
+    [Test]
+    public void PassiveIdleSnapshotCoversEverySceneAndUnknownFrameworkState()
+    {
+        // Initialize the maintained callback without starting a run.
+        Assert.Throws<ArgumentException>(() =>
+            DxMcpTestRunner.Run("invalid", null!, null!, null!, _path)
+        );
+        SceneManager.Scenes =
+        [
+            SceneManager.Scenes[0],
+            new Scene { path = "Assets/Second.unity", isLoaded = true },
+        ];
+        EditorApplication.timeSinceStartup = double.MaxValue;
+        EditorApplication.Tick();
+        string snapshot = Path.Combine(
+            _directory,
+            "Packages/com.wallstop-studios.dxmessaging/.artifacts/unity-mcp/editor-state.json"
+        );
+        using JsonDocument state = JsonDocument.Parse(File.ReadAllText(snapshot));
+        Assert.That(state.RootElement.GetProperty("scenes").GetArrayLength(), Is.EqualTo(2));
+        Assert.That(state.RootElement.GetProperty("frameworkActive").GetBoolean(), Is.False);
+        Assert.That(state.RootElement.GetProperty("mainStage").GetBoolean(), Is.True);
+        TestRunnerApi.QueryThrows = true;
+        EditorApplication.Tick();
+        using JsonDocument failed = JsonDocument.Parse(File.ReadAllText(snapshot));
+        Assert.That(
+            failed.RootElement.GetProperty("observationError").GetString(),
+            Does.Contain("query failed")
+        );
+        Assert.That(failed.RootElement.GetProperty("mainStage").GetBoolean(), Is.False);
+    }
+
+    private sealed class Result : ITestResultAdaptor, ITestAdaptor
+    {
+        public ITestAdaptor Test => this;
+        public bool IsSuite { get; set; }
+        public int PassCount { get; set; } = 1;
+        public int FailCount { get; set; }
+        public int SkipCount => 0;
+        public int InconclusiveCount { get; set; }
+        public double Duration => 0.125;
+        public string FullName { get; set; } = "test";
+        public TestStatus TestStatus { get; set; }
+        public string ResultState => TestStatus.ToString();
+        public string Message { get; set; } = "";
+        public string StackTrace => "stack";
+        public string Output { get; set; } = "";
+        public DateTime StartTime => new(2026, 9, 6);
+        public DateTime EndTime => StartTime.AddMilliseconds(125);
+        public IEnumerable<ITestResultAdaptor>? Children { get; set; }
+    }
+}

--- a/.docs-tests/UnityMcpTestDoubles.cs
+++ b/.docs-tests/UnityMcpTestDoubles.cs
@@ -1,0 +1,184 @@
+// Match Unity API shapes, including its event and method names.
+#pragma warning disable CA1003, CA1024, CA1724, CA1815, CA1822
+// Test doubles for the host-only bridge, linked verbatim from scripts/mcp.
+// Tests invoke the maintained bridge; these doubles only drive Unity's external boundaries.
+using System.Text.Json;
+
+namespace UnityEngine
+{
+    internal abstract class ScriptableObject
+    {
+        public static T CreateInstance<T>()
+            where T : new() => new T();
+    }
+
+    internal static class JsonUtility
+    {
+        private static readonly JsonSerializerOptions Options = new() { IncludeFields = true };
+
+        public static string ToJson(object value, bool prettyPrint = false) =>
+            JsonSerializer.Serialize(value, Options);
+
+        public static T FromJson<T>(string value) => JsonSerializer.Deserialize<T>(value, Options)!;
+    }
+}
+
+namespace UnityEditor
+{
+    [AttributeUsage(AttributeTargets.Class)]
+    internal sealed class InitializeOnLoadAttribute : Attribute { }
+
+    internal static class SessionState
+    {
+        internal static readonly Dictionary<string, string> Values = new();
+
+        public static string GetString(string key, string fallback) =>
+            Values.GetValueOrDefault(key, fallback);
+
+        public static void SetString(string key, string value) => Values[key] = value;
+
+        public static void EraseString(string key) => Values.Remove(key);
+    }
+
+    internal static class EditorApplication
+    {
+        internal static bool isPlayingOrWillChangePlaymode;
+        internal static bool isCompiling;
+        internal static bool isUpdating;
+        internal static double timeSinceStartup = -1;
+        public static event Action? update;
+
+        public static void Tick() => update?.Invoke();
+    }
+}
+
+namespace UnityEditor.SceneManagement
+{
+    internal static class StageUtility
+    {
+        internal static int CurrentStage;
+
+        internal static int GetCurrentStageHandle() => CurrentStage;
+
+        internal static int GetMainStageHandle() => 0;
+    }
+}
+
+namespace UnityEngine.SceneManagement
+{
+    internal struct Scene
+    {
+        public string path;
+        public bool isDirty;
+        public bool isLoaded;
+    }
+
+    internal static class SceneManager
+    {
+        internal static Scene[] Scenes = [];
+        internal static int ActiveIndex;
+        internal static int sceneCount => Scenes.Length;
+
+        public static Scene GetSceneAt(int index) => Scenes[index];
+
+        public static Scene GetActiveScene() => Scenes.Length == 0 ? default : Scenes[ActiveIndex];
+    }
+}
+
+namespace UnityEditor.TestTools.TestRunner.Api
+{
+    internal enum TestMode
+    {
+        EditMode,
+        PlayMode,
+    }
+
+    internal enum TestStatus
+    {
+        Passed,
+        Failed,
+        Skipped,
+        Inconclusive,
+    }
+
+    internal sealed class Filter
+    {
+        public TestMode testMode;
+        public string[]? assemblyNames;
+        public string[]? testNames;
+        public string[]? categoryNames;
+    }
+
+    internal sealed class ExecutionSettings(Filter filter)
+    {
+        public Filter Filter = filter;
+    }
+
+    internal interface ITestAdaptor
+    {
+        bool IsSuite { get; }
+    }
+
+    internal interface ITestResultAdaptor
+    {
+        ITestAdaptor Test { get; }
+        int PassCount { get; }
+        int FailCount { get; }
+        int SkipCount { get; }
+        int InconclusiveCount { get; }
+        double Duration { get; }
+        string FullName { get; }
+        TestStatus TestStatus { get; }
+        string ResultState { get; }
+        string Message { get; }
+        string StackTrace { get; }
+        string Output { get; }
+        DateTime StartTime { get; }
+        DateTime EndTime { get; }
+        IEnumerable<ITestResultAdaptor>? Children { get; }
+    }
+
+    internal interface ICallbacks
+    {
+        void RunStarted(ITestAdaptor test);
+        void RunFinished(ITestResultAdaptor result);
+        void TestStarted(ITestAdaptor test);
+        void TestFinished(ITestResultAdaptor result);
+    }
+
+    internal interface IErrorCallbacks : ICallbacks
+    {
+        void OnError(string message);
+    }
+
+    internal sealed class TestRunnerApi
+    {
+        internal static IErrorCallbacks Callbacks = null!;
+        internal static bool Active;
+        internal static bool QueryThrows;
+        internal static bool ExecuteThrows;
+        internal static int Executions;
+        internal static Action? DuringExecute;
+        internal static string RunGuid = "owned-guid";
+        internal static ExecutionSettings? LastSettings;
+
+        public void RegisterCallbacks(ICallbacks callbacks) =>
+            Callbacks = (IErrorCallbacks)callbacks;
+
+        public string Execute(ExecutionSettings settings)
+        {
+            Executions++;
+            LastSettings = settings;
+            Active = true;
+            if (ExecuteThrows)
+            {
+                throw new InvalidOperationException("launch failed with live job");
+            }
+            DuringExecute?.Invoke();
+            return RunGuid;
+        }
+
+        internal static bool IsRunActive() =>
+            QueryThrows ? throw new InvalidOperationException("query failed") : Active;
+    }
+}

--- a/.docs-tests/WallstopStudios.DxMessaging.Docs.Tests.csproj
+++ b/.docs-tests/WallstopStudios.DxMessaging.Docs.Tests.csproj
@@ -6,6 +6,7 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="../scripts/mcp/DxMcpTestRunner.cs.txt" Link="DxMcpTestRunner.cs" />
     <ProjectReference
       Include="../SourceGenerators/WallstopStudios.DxMessaging.SourceGenerators/WallstopStudios.DxMessaging.SourceGenerators.csproj"
       AdditionalProperties="CopyAnalyzerPayload=false"

--- a/.llm/context.md
+++ b/.llm/context.md
@@ -97,17 +97,21 @@ editor), NOT inside the devcontainer. The container ships no local Unity build. 
 
 - The devcontainer workspace IS the embedded package inside the host Unity project,
   so edits in-container are instantly visible to the editor.
-- Preflight: prove framework idleness, idle editor flags, the main stage, and every open scene's
-  clean state through non-refreshing queries or an installed passive observer. `Unity_RunCommand`
-  refreshes assets before executing its snippet, so it cannot establish safety. Once safe, compile
-  through `Unity_ManageMenuItem` with `Assets/Refresh`. Never raise a save prompt in the shared editor.
+- Preflight: prefer passive `GetState`, `GetPrefabStage`, `GetActive`, and a fresh observer snapshot.
+  If the observer is absent or incomplete, available flags are idle/clean, and no test is known
+  active, use a minimal `Unity_RunCommand` inspection for framework activity and every open
+  scene. It refreshes before the snippet; this bootstrap does not prove the prior refresh safe.
+  Follow the [bootstrap procedure](./skills/unity-mcp-test-loop/references/mcp-test-loop.md#bootstrap-without-a-complete-passive-observer);
+  missing fields alone do not require confirmation. Respect tool approval gates. Once idle with
+  clean scenes, compile through `Unity_ManageMenuItem` with `Assets/Refresh`.
 - Poll active tests through files only. Require passive framework cleanup and error checks after
   the raw result reports `done`; never restart solely because observation timed out. See the
   [framework cleanup gate](./skills/unity-mcp-test-loop/references/mcp-test-loop.md#framework-cleanup-gate).
 - Run tests: call the host bridge `DxMcpTestRunner.Run(testMode, assemblies, tests, categories, resultPath)` via `Unity_RunCommand`, then poll the `.status` sidecar from the container. `resultPath` resolves against the HOST project root, so it MUST be prefixed `Packages/com.wallstop-studios.dxmessaging/.artifacts/unity-mcp/<name>.json`; a bare `.artifacts/unity-mcp/<name>.json` lands where the container cannot see it and the poll waits forever next to stale files.
 - EditMode assemblies: `WallstopStudios.DxMessaging.Tests.Editor`, `...Tests.Editor.Allocations`, `...Tests.00.Editor.Benchmarks`. PlayMode: `...Tests.Runtime`, `...Tests.00.Runtime.Benchmarks` (category `PerfBench`), `...Tests.00.Runtime.Comparisons`, DI integrations (Reflex/VContainer/Zenject).
 - Perf baselines: the benchmark CSV defaults to `.artifacts/perf-baseline.csv` (override env `DX_PERF_BASELINE`; `DX_PERF_COMMIT` stamps the commit column).
-- Sandbox restriction: `using System.Reflection;` is rejected in `Unity_RunCommand` snippets -- fully qualify (`System.Reflection.Assembly`) instead.
+- Sandbox restriction: `using System.Reflection;` is rejected in `Unity_RunCommand` snippets;
+  qualify allowed types (`System.Reflection.Assembly`). Qualification does not bypass member restrictions.
 - The published IL2CPP-Release headline comes from the CI leg (self-hosted Windows, `scripts/unity/run-ci-tests.ps1`), not the local MCP loop; the MCP loop is the local Mono/editor signal. CI keeps short, scope-isolated host projects under `$RUNNER_WORKSPACE/dxm-u/{t,b,p}/<version>-<mode>/` so each fixed runner can reuse its own `Library` without transferring it over the network -- see [UPM Test Harness](./skills/unity-test-execution/references/upm-test-harness.md).
 - License (CI only): see [Unity License Bootstrap](./skills/unity-licensing/references/unity-license-bootstrap.md). CI activates Unity with a classic serial (`UNITY_SERIAL` + `UNITY_EMAIL` + `UNITY_PASSWORD`) and guarantees a `-returnlicense` on every exit path.
 - For source-generator tests (no Unity), use

--- a/.llm/skills/unity-mcp-test-loop/SKILL.md
+++ b/.llm/skills/unity-mcp-test-loop/SKILL.md
@@ -71,13 +71,13 @@ The devcontainer workspace is the same directory as the embedded package inside 
 ### The loop
 
 1. **Edit** files in the container.
-1. **Preflight before any refresh-capable command or test.** Establish framework idleness, idle editor
-   flags, the main stage, and clean state for every open scene using dedicated queries whose
-   installed implementation does not refresh assets, or an already-installed passive observer.
-   `GetState`, `GetPrefabStage`, and `GetActive` suffice only when their responses cover every
-   required field; an active-scene response cannot prove other scenes are clean. Never use
-   `Unity_RunCommand` to establish safety: it refreshes assets before checking the snippet's
-   guard. If evidence is missing or unsafe, wait or report it without refreshing or changing scenes.
+1. **Preflight.** Prefer passive `GetState`, `GetPrefabStage`, `GetActive`, and a fresh observer
+   snapshot for framework activity, editor flags, stage, and every open scene's dirty flag.
+   If the observer is absent or incomplete, available flags are idle/clean, and no test is known
+   active, use a minimal `Unity_RunCommand` inspection to fill the gaps. It refreshes before
+   the snippet; this bootstrap cannot prove the prior refresh safe. Missing fields alone do not
+   require user confirmation. Follow the [bootstrap procedure](./references/mcp-test-loop.md#bootstrap-without-a-complete-passive-observer)
+   and preserve tool approval gates. Wait for active tests or editor work; stop for dirty scenes.
 1. **Compile** with `Unity_ValidateScript` for changed C# under `Assets/`, then execute the
    `Assets/Refresh` menu item through `Unity_ManageMenuItem`. The validator rejects embedded
    `Packages/` paths, so package edits must use the refresh plus fresh-assembly proof. Wait for
@@ -124,7 +124,8 @@ PNG writer when testing the whole Editor assembly. See
 
 ### Sandbox restrictions
 
-- `using System.Reflection;` is REJECTED in `Unity_RunCommand` snippets. Fully qualify instead: `System.Reflection.Assembly`, `System.Reflection.BindingFlags`.
+- `using System.Reflection;` is rejected in `Unity_RunCommand`. Qualify allowed reflection types;
+  qualification does not bypass member restrictions. Prefer public APIs when `BindingFlags` is rejected.
 - Inside `DxMessaging.*` namespaces the bare identifier `Unity` binds to `DxMessaging.Unity`. Use a `global::`-qualified alias when that ambiguity bites.
 
 ### If the bridge is missing
@@ -133,9 +134,10 @@ The maintained source is `scripts/mcp/DxMcpTestRunner.cs.txt`. Its installed cop
 the host's `Assets/Editor/DxMcpTestRunner.cs`, so cleaning the host can remove it.
 After the safe-state preflight, follow the
 [maintained runner installation flow](../../../scripts/mcp/README.md#maintain-the-local-unity-test-runner).
-Copy that source verbatim, preserve unreviewed host changes, and refresh through
-`Unity_ManageMenuItem`. Do not generate a replacement implementation. If the missing
-observer also leaves preflight evidence unavailable, report it before installation.
+Copy that source verbatim through supported MCP editing, back up existing source and metadata
+outside `Assets`, preserve unreviewed host changes, and refresh through `Unity_ManageMenuItem`.
+Verify the loaded assembly and fresh passive snapshots. Use the bootstrap procedure when the
+missing observer leaves preflight fields unavailable; do not generate a replacement runner.
 
 ### Measuring suite speed
 

--- a/.llm/skills/unity-mcp-test-loop/SKILL.md
+++ b/.llm/skills/unity-mcp-test-loop/SKILL.md
@@ -84,7 +84,12 @@ The devcontainer workspace is the same directory as the embedded package inside 
    compilation to settle before trusting tests. Do not use `AssetDatabase.Refresh()` through
    `Unity_RunCommand`; a modal prompt blocks the editor and only the developer can dismiss it.
 1. **Run** `DxMcpTestRunner.Run(testMode, assemblyNames, testNames, categoryNames, resultPath)` through `Unity_RunCommand`, locating the type by scanning `AppDomain` assemblies. Arguments are semicolon-separated lists and `null` means no filter. `testMode` is `EditMode` or `PlayMode`. `testNames` accepts a full fixture type name such as `DxMessaging.Tests.Runtime.Core.TestAttributeContractTests` for a single-fixture red-green loop.
-1. **Poll** the `.status` sidecar next to `resultPath` from bash. It moves `running` to `done` or `error: <message>`. The JSON result carries `{ passCount, failCount, skipCount, inconclusiveCount, durationSeconds, failures[] }`.
+1. **Poll** the `.status` and `.cleanup.status` sidecars next to `resultPath` from bash.
+   The first records raw result capture; only the second establishes passive cleanup.
+   Retain the returned Execute GUID and its `.run.json` identity record. The JSON result
+   includes counts, duration, and the full `nodes[]` tree with output and failures.
+   Require both sidecars to report `done`, positive passes, no failed/inconclusive nodes,
+   and matching GUID/path in the cleanup record before accepting a run.
 1. **Wait for framework cleanup before another run or scene mutation.** `RunFinished` can write
    `done` before Unity restores its temporary scenes. Check the installed Test Framework's active
    job state and run-scoped framework errors through a passive host observer; do not poll
@@ -124,7 +129,13 @@ PNG writer when testing the whole Editor assembly. See
 
 ### If the bridge is missing
 
-`DxMcpTestRunner` lives in the host project under its `Assets/Editor/`, not in this repo, so cleaning the host project drops it. After the safe-state preflight, regenerate it through `Unity_RunCommand` with `System.IO.File.WriteAllText` of the bridge source, then execute `Assets/Refresh` through `Unity_ManageMenuItem`. It wraps `TestRunnerApi` and writes the JSON result plus the `.status` sidecar.
+The maintained source is `scripts/mcp/DxMcpTestRunner.cs.txt`. Its installed copy lives at
+the host's `Assets/Editor/DxMcpTestRunner.cs`, so cleaning the host can remove it.
+After the safe-state preflight, follow the
+[maintained runner installation flow](../../../scripts/mcp/README.md#maintain-the-local-unity-test-runner).
+Copy that source verbatim, preserve unreviewed host changes, and refresh through
+`Unity_ManageMenuItem`. Do not generate a replacement implementation. If the missing
+observer also leaves preflight evidence unavailable, report it before installation.
 
 ### Measuring suite speed
 

--- a/.llm/skills/unity-mcp-test-loop/references/mcp-test-loop.md
+++ b/.llm/skills/unity-mcp-test-loop/references/mcp-test-loop.md
@@ -29,16 +29,12 @@ the host editor; the container only edits files and drives the editor over MCP.
 ## The Loop
 
 1. **Edit** files in the container as usual.
-1. **Preflight before any refresh-capable command or test.** Use dedicated query actions
-   whose installed implementation does not refresh assets, or an already-installed passive
-   observer, to establish framework idleness, editor flags, current stage, loaded-scene count,
-   and every scene's path and dirty flag. `Unity_ManageEditor GetState` and `GetPrefabStage`
-   plus `Unity_ManageScene GetActive` suffice only when their responses provide all that
-   evidence. With multiple loaded scenes, an active-scene result alone is insufficient.
-   Do not use `Unity_RunCommand` to fill missing fields: its implicit refresh runs before any
-   guard in the supplied code. Report missing evidence or an unsafe state without refreshing,
-   installing a new observer, or changing scenes. A tool's read-only name does not prove its
-   implementation has no import side effects.
+1. **Preflight.** Prefer passive `Unity_ManageEditor GetState` and `GetPrefabStage`,
+   `Unity_ManageScene GetActive`, and a fresh observer snapshot. Establish framework idleness,
+   idle editor flags, the main stage, loaded-scene count, and every scene's path and dirty flag.
+   An active-scene response alone cannot prove other scenes are clean. When the observer is
+   absent or incomplete, use the [bootstrap procedure](#bootstrap-without-a-complete-passive-observer)
+   below. A tool's read-only name does not prove its implementation has no import side effects.
 1. **Compile**: validate changed C# under `Assets/` with `Unity_ValidateScript`, then
    execute the `Assets/Refresh` menu item through `Unity_ManageMenuItem`. The validator
    rejects embedded `Packages/` paths, so package edits rely on the refresh plus the
@@ -92,6 +88,35 @@ testNames, categoryNames, resultPath)` via `Unity_RunCommand`. Locate the type b
 The maintained bridge survives domain reloads through `[InitializeOnLoad]` and `SessionState`.
 Its source, installation, artifact contract, and preflight snapshot are documented in
 [Maintain the local Unity test runner](../../../../scripts/mcp/README.md#maintain-the-local-unity-test-runner).
+
+## Bootstrap without a complete passive observer
+
+Missing observer fields alone do not require user confirmation or prevent local verification.
+First read the passive editor, stage, and active-scene queries and any existing snapshot. If the
+available flags show idle editor state, the main stage, and a clean scene, and no test is known
+active, use a minimal `Unity_RunCommand` inspection to read `TestRunnerApi.IsRunActive`, current
+editor flags and stage, every open scene's path/loading/dirty state through
+`SceneManager.sceneCount` and `GetSceneAt`, and the runner SessionState ownership keys listed in
+the installation guide. Do not mutate scenes, launch tests, or install source in that inspection.
+Use the installed framework's available API; `IsRunActive` may be nonpublic and unavailable to a
+direct snippet call. Resolve API compatibility failures with a minimal inspection sequence using
+supported public metadata or installed runner APIs. A compile or lookup failure does not prove
+framework inactivity.
+
+`Unity_RunCommand` refreshes assets before executing the snippet. State that limitation honestly:
+the inspection bootstraps missing evidence; its result cannot prove that preceding refresh was
+safe. Preserve tool approval gates. If a tool rejects the inspection or installation, report its
+reason and do not switch transports or tools to bypass the rejection. Wait for actual framework
+activity, compilation, imports, or play-mode transitions. Stop for dirty or unnamed scenes or a
+non-main stage; never save, discard, or switch the developer's scenes to force progress.
+
+Once the inspection shows inactive framework/editor state and saved, clean scenes, install or
+update the maintained source through supported MCP editing, following the
+[backup and installation flow](../../../../scripts/mcp/README.md#maintain-the-local-unity-test-runner).
+Validate, refresh through `Unity_ManageMenuItem`, and verify the loaded assembly and fresh passive
+snapshots before testing. If supported inspection cannot resolve the required state, report the
+specific failure. During a known or owned test, poll its files and passive snapshots only,
+including after an observation timeout; never use bootstrap inspection as a polling loop.
 
 ## Framework cleanup gate
 
@@ -192,8 +217,10 @@ benchmark run, since the editor process is already up. See
 
 `Unity_RunCommand` snippets run in a restricted compile sandbox:
 
-- `using System.Reflection;` is REJECTED. Fully qualify instead
-  (`System.Reflection.Assembly`, `System.Reflection.BindingFlags`, ...).
+- `using System.Reflection;` is rejected. Qualify allowed types such as
+  `System.Reflection.Assembly`; qualification does not bypass member restrictions. Some installed
+  sandboxes also reject `System.Reflection.BindingFlags` members. Prefer public APIs or supported
+  script editing within existing tool permissions; do not bypass a tool rejection.
 - Inside `DxMessaging.*` namespaces the bare identifier `Unity` binds to
   `DxMessaging.Unity`, not `UnityEngine`-adjacent types; use a `global::`-qualified
   alias when that ambiguity bites.
@@ -203,7 +230,8 @@ benchmark run, since the editor process is already up. See
 The installed bridge lives under the host's `Assets/Editor/`, outside this package. Regenerate it
 from the maintained `scripts/mcp/DxMcpTestRunner.cs.txt`, following the
 [installation and preflight contract](../../../../scripts/mcp/README.md#maintain-the-local-unity-test-runner).
-Do not invent a replacement bridge or use a refresh-capable command to establish its own safety.
+Use the bootstrap procedure above if passive evidence is incomplete. Do not invent a replacement
+bridge or describe the bootstrap's implicit refresh as proven safe.
 
 ## CI vs Local
 

--- a/.llm/skills/unity-mcp-test-loop/references/mcp-test-loop.md
+++ b/.llm/skills/unity-mcp-test-loop/references/mcp-test-loop.md
@@ -84,49 +84,43 @@ testNames, categoryNames, resultPath)` via `Unity_RunCommand`. Locate the type b
    - `testNames` accepts a fixture's full type name (for example
      `DxMessaging.Tests.Runtime.Core.TestAttributeContractTests`) to run just that
      fixture -- handy for a fast red-green loop on a single contract test.
-1. **Poll**: read the `.status` sidecar next to `resultPath` from bash in the
-   container. It moves `running` -> `done` (or `error: <message>`). The JSON result
-   carries `{ passCount, failCount, skipCount, inconclusiveCount, durationSeconds,
-failures[] }`.
+1. **Poll** through files only. With the maintained bridge, `.status` describes raw result
+   availability and `.cleanup.status` describes passive framework completion. Require `done` in
+   both files, positive passes, zero failed/inconclusive cases, and matching GUID/path companions.
+   Keep expected skips visible. Read the complete tree in the result JSON for individual outcomes.
 
-The bridge survives domain reloads via `[InitializeOnLoad]` + `SessionState`, so a
-recompile mid-run does not lose the result.
+The maintained bridge survives domain reloads through `[InitializeOnLoad]` and `SessionState`.
+Its source, installation, artifact contract, and preflight snapshot are documented in
+[Maintain the local Unity test runner](../../../../scripts/mcp/README.md#maintain-the-local-unity-test-runner).
 
 ## Framework cleanup gate
 
-`DxMcpTestRunner` writes its result during `RunFinished`. Unity Test Framework can still be
-restoring scenes after that callback, even when `EditorApplication.isPlaying` is false. Starting
-another run in that interval can capture a temporary scene that the previous run then deletes.
-Session 266 observed `Invalid SceneManagerSetup` followed by `ReloadScene cannot be used with a
-scene without a SceneAsset` during repeated local runs.
+`RunFinished` makes a result available before Unity Test Framework necessarily finishes restoring
+scenes. Session 266 observed `Invalid SceneManagerSetup` and a missing temporary scene after a new
+run started during that cleanup interval. A raw passing result is not cleanup evidence.
 
-Do not poll `Unity_RunCommand` during a test run. The inspected MCP implementation calls
-`AssetDatabase.Refresh` before executing the supplied code, including read-only snippets. During
-local runtime tests that refresh imported malformed host assets and produced unrelated test
-failures. Use filesystem polling for the active run.
+The maintained `DxMcpTestRunner` retains the Execute GUID, owns a fresh result path, records
+`IErrorCallbacks.OnError`, and observes framework inactivity from `EditorApplication.update`.
+It writes `.cleanup.json` and `.cleanup.status` after verifying the original scene setup. Missing
+results and late framework errors produce terminal errors; failed observations retain ownership.
+An observation timeout never authorizes cancellation or a replacement launch.
 
-Before repeated runs, prepare a host-side observer while the editor is safe. It must retain the
-current result path across reloads, capture `IErrorCallbacks.OnError` for that run, and use
-`EditorApplication.update` to observe framework cleanup without refreshing assets. On the
-inspected framework the active-job query is the internal static `TestRunnerApi.IsRunActive`.
-Inspect the installed source if that API changes; missing state is not proof of idleness.
+Do not poll `Unity_RunCommand` during a test run. Its installed implementation refreshes assets
+before executing even read-only snippets. Use filesystem polling and the bridge's passive
+`editor-state.json` for subsequent preflight, requiring current timestamps and complete safe-state
+fields. Missing, stale, or temporarily malformed files prove no state; continue observing the same
+job without refreshing assets.
 
-The observer must write a separate terminal marker only after the framework reports inactive.
-Capture errors through that point: cleanup can fail after `RunFinished` has already written a
-passing result. Require both successful framework completion and a result with a positive pass
-count, zero failures, and zero inconclusive cases. Keep expected skips visible. Check editor flags
-and every scene's dirtiness again before the next refresh, run, or scene change.
+For a host that still has the earlier simple bridge, retain its reviewed
+`DxMcpObservedTestRunner` until migration is safe. That observer writes `.observer.status`;
+require its terminal `done` alongside the raw result. An old terminal file is historical evidence,
+not a fresh editor preflight. The simple bridge alone can leave `running` without a result after
+framework setup fails. Prove inactivity before classifying that as terminal or recovering scenes.
+Never discard an unnamed or dirty user scene.
 
-The simple bridge implements only `ICallbacks`, so a framework-level `RunFailed` can leave its
-sidecar at `running` without a result. Inactive framework state with no result is a terminal
-framework failure, not a live test or a pass. Preserve that failed attempt and inspect the error
-before recovery. Restore the original saved scene only after verifying that the editor is idle
-and all scenes are clean. Never restart solely because polling timed out, cancel a run to resolve
-an observation timeout, or discard an unnamed scene containing unreviewed work.
-
-This is local orchestration. Add no delays, retries, or extra test launches to CI. Durable bridge
-ownership and regeneration are tracked in
-[issue #544](https://github.com/Ambiguous-Interactive/DxMessaging/issues/544).
+This is local orchestration. It adds no delays, retries, or test launches to CI.
+[Issue #544](https://github.com/Ambiguous-Interactive/DxMessaging/issues/544) tracks native acceptance
+of maintained bridge ownership and regeneration.
 
 ## Shared Editor Safety
 
@@ -206,11 +200,10 @@ benchmark run, since the editor process is already up. See
 
 ## If the Bridge Is Missing
 
-The `DxMcpTestRunner` bridge lives in the host project (under its `Assets/Editor/`),
-NOT in this package repo, so a clean of the host project drops it. Regenerate it via
-`Unity_RunCommand` (`System.IO.File.WriteAllText` of the bridge source), then run the
-safe-state preflight and execute `Assets/Refresh` through `Unity_ManageMenuItem`. It
-wraps `TestRunnerApi` and writes the JSON result plus the `.status` sidecar.
+The installed bridge lives under the host's `Assets/Editor/`, outside this package. Regenerate it
+from the maintained `scripts/mcp/DxMcpTestRunner.cs.txt`, following the
+[installation and preflight contract](../../../../scripts/mcp/README.md#maintain-the-local-unity-test-runner).
+Do not invent a replacement bridge or use a refresh-capable command to establish its own safety.
 
 ## CI vs Local
 

--- a/Tests/Editor/Allocations/AllocationProbeContractTests.cs
+++ b/Tests/Editor/Allocations/AllocationProbeContractTests.cs
@@ -4,6 +4,7 @@ namespace DxMessaging.Tests.Editor.Allocations
     using System;
     using System.Collections.Generic;
     using System.Reflection;
+    using DxMessaging.Tests.Runtime;
     using DxMessaging.Tests.Runtime.Benchmarks;
     using NUnit.Framework;
     using UnityEngine.Profiling;
@@ -41,6 +42,77 @@ namespace DxMessaging.Tests.Editor.Allocations
             // Defensive hygiene: never let a failing test leak an enabled recorder into the
             // next test. Assertions run BEFORE teardown, so this never masks a real leak.
             Recorder.Get(GcAllocMarker).enabled = false;
+        }
+
+        [TestCase(1)]
+        [TestCase(3)]
+        public void ZeroAllocationFailureReportsMeasuredCountWithoutRepeating(int iterations)
+        {
+            if (!AllocationProbe.IsFunctional)
+            {
+                Assert.Ignore("GC.Alloc recorder is non-functional on this backend.");
+            }
+
+            const string label = "Deliberate allocation diagnostic";
+            int calls = 0;
+            byte[] sink = null;
+            Action allocate = () =>
+            {
+                ++calls;
+                sink = new byte[16];
+            };
+
+            AssertionException failure = Assert.Throws<AssertionException>(() =>
+                AllocationAssertions.AssertNoAllocations(label, allocate, 0, iterations)
+            );
+            StringAssert.Contains(label, failure.Message, $"iterations={iterations}");
+            System.Text.RegularExpressions.Match count = System.Text.RegularExpressions.Regex.Match(
+                failure.Message,
+                @"made (\d+) GC allocation\(s\)"
+            );
+            Assert.IsTrue(count.Success, $"iterations={iterations}: {failure.Message}");
+            Assert.GreaterOrEqual(
+                long.Parse(
+                    count.Groups[1].Value,
+                    System.Globalization.CultureInfo.InvariantCulture
+                ),
+                iterations,
+                $"iterations={iterations}: diagnostic must retain the positive allocation count."
+            );
+            StringAssert.Contains(
+                $"across {iterations} iterations",
+                failure.Message,
+                $"iterations={iterations}"
+            );
+            Assert.AreEqual(
+                iterations * 2,
+                calls,
+                $"iterations={iterations}: one wrapper warmup and one measured window; no retry."
+            );
+            Assert.IsFalse(RecorderEnabled, $"iterations={iterations}: recorder must be disabled.");
+            GC.KeepAlive(sink);
+        }
+
+        [TestCase(0, 1)]
+        [TestCase(2, 3)]
+        public void ZeroAllocationSuccessPreservesWarmupAndMeasurementCounts(
+            int warmup,
+            int iterations
+        )
+        {
+            int calls = 0;
+            AllocationAssertions.AssertNoAllocations(
+                "Nonallocating control",
+                () => ++calls,
+                warmup,
+                iterations
+            );
+            Assert.AreEqual(
+                warmup + iterations * 2,
+                calls,
+                $"warmup={warmup}, iterations={iterations}: the diagnostic must not remeasure."
+            );
+            Assert.IsFalse(RecorderEnabled, $"warmup={warmup}, iterations={iterations}");
         }
 
         [Test]

--- a/Tests/Runtime/Core/DifferentialHostTraceTests.cs
+++ b/Tests/Runtime/Core/DifferentialHostTraceTests.cs
@@ -1,0 +1,405 @@
+#if UNITY_2021_3_OR_NEWER
+namespace DxMessaging.Tests.Runtime.Core
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using DxMessaging.Core;
+    using DxMessaging.Core.MessageBus;
+    using DxMessaging.Unity;
+    using NUnit.Framework;
+    using UnityEngine;
+
+    /// <summary>Replays version-seven activity inputs through native host activation and production owner tokens.</summary>
+    public sealed class DifferentialHostTraceTests : UnityFixtureBase
+    {
+        private DiagnosticsScope _diagnostics;
+
+        [SetUp]
+        public void SetUp() =>
+            _diagnostics = new DiagnosticsScope(
+                DiagnosticsTarget.Off,
+                messageBufferSize: 16,
+                diagnosticsStackTraces: false
+            );
+
+        [TearDown]
+        public void RestoreDiagnostics() => _diagnostics.Dispose();
+
+        [Test]
+        public void NativeHostActivityPreservesOwnerTokensAndControlsCurrentDispatch(
+            [ValueSource(typeof(MessageScenarios), nameof(MessageScenarios.AllKinds))]
+                MessageScenario scenario
+        )
+        {
+            BusTraceSequence sequence = new(
+                scenario,
+                509,
+                new[]
+                {
+                    new BusTraceOperation(BusTraceOperationKind.Register, priority: -1),
+                    new BusTraceOperation(BusTraceOperationKind.Register, token: 1, priority: 1),
+                    new BusTraceOperation(BusTraceOperationKind.SetHandlerActive, token: 1),
+                    new BusTraceOperation(BusTraceOperationKind.Emit, value: 11),
+                    new BusTraceOperation(BusTraceOperationKind.Enable, token: 1),
+                    new BusTraceOperation(BusTraceOperationKind.Emit, value: 13),
+                    new BusTraceOperation(
+                        BusTraceOperationKind.EmitWithHandlerActive,
+                        value: 17,
+                        handlerToken: 1,
+                        handlerActive: true
+                    ),
+                    new BusTraceOperation(
+                        BusTraceOperationKind.EmitWithHandlerActive,
+                        value: 19,
+                        handlerToken: 1
+                    ),
+                    new BusTraceOperation(BusTraceOperationKind.Disable, token: 1),
+                    new BusTraceOperation(
+                        BusTraceOperationKind.SetHandlerActive,
+                        token: 1,
+                        handlerActive: true
+                    ),
+                    new BusTraceOperation(BusTraceOperationKind.Emit, value: 23),
+                    new BusTraceOperation(BusTraceOperationKind.Enable, token: 1),
+                    new BusTraceOperation(BusTraceOperationKind.Emit, value: 29),
+                    new BusTraceOperation(BusTraceOperationKind.Remove, token: 1),
+                    new BusTraceOperation(BusTraceOperationKind.SetHandlerActive, token: 1),
+                    new BusTraceOperation(
+                        BusTraceOperationKind.SetHandlerActive,
+                        token: 1,
+                        handlerActive: true
+                    ),
+                    new BusTraceOperation(BusTraceOperationKind.Emit, value: 31),
+                }
+            );
+            IReadOnlyList<BusTraceObservation> observations = Replay(sequence);
+            string report = Report(sequence, observations);
+            Assert.That(observations.All(item => item.Exception == null), Is.True, report);
+            Assert.That(
+                DifferentialBusTrace.Compare(observations, Replay(sequence)),
+                Is.Null,
+                report
+            );
+            foreach (int index in new[] { 3, 5, 7, 10, 16 })
+            {
+                CollectionAssert.AreEqual(
+                    new[] { $"token=0,value={sequence.Operations[index].Value}" },
+                    observations[index].Callbacks,
+                    report
+                );
+            }
+            foreach (int index in new[] { 6, 12 })
+            {
+                int value = sequence.Operations[index].Value;
+                CollectionAssert.AreEqual(
+                    new[] { $"token=0,value={value}", $"token=1,value={value}" },
+                    observations[index].Callbacks,
+                    report
+                );
+            }
+            StringAssert.Contains("enabled=1111", observations[2].State, report);
+            StringAssert.Contains("host[1]=0/0/0/1", observations[2].State, report);
+            StringAssert.Contains("enabled=1011", observations[9].State, report);
+            StringAssert.Contains("host[1]=1/1/1/1", observations[9].State, report);
+            StringAssert.Contains("host[1]=1/1/1/1", observations[16].State, report);
+        }
+
+        [Test]
+        public void InitiallyInactiveHostHonorsReceiveWhileDisabled(
+            [ValueSource(typeof(MessageScenarios), nameof(MessageScenarios.AllKinds))]
+                MessageScenario scenario,
+            [Values(false, true)] bool receiveWhileDisabled
+        )
+        {
+            BusTraceSequence sequence = new(
+                scenario,
+                509,
+                new[]
+                {
+                    new BusTraceOperation(BusTraceOperationKind.Register),
+                    new BusTraceOperation(BusTraceOperationKind.Emit, value: 11),
+                    new BusTraceOperation(
+                        BusTraceOperationKind.SetHandlerActive,
+                        handlerActive: true
+                    ),
+                    new BusTraceOperation(BusTraceOperationKind.Emit, value: 13),
+                    new BusTraceOperation(BusTraceOperationKind.SetHandlerActive),
+                    new BusTraceOperation(BusTraceOperationKind.Emit, value: 17),
+                }
+            );
+            IReadOnlyList<BusTraceObservation> observations = DifferentialBusTrace.Replay(
+                sequence,
+                kind =>
+                    CreateAdapter(
+                        kind,
+                        startsActive: false,
+                        receiveWhileDisabled: receiveWhileDisabled
+                    )
+            );
+            string report =
+                $"receiveWhileDisabled={receiveWhileDisabled}; " + Report(sequence, observations);
+            Assert.That(observations.All(item => item.Exception == null), Is.True, report);
+            foreach (int index in new[] { 1, 5 })
+            {
+                CollectionAssert.AreEqual(
+                    receiveWhileDisabled
+                        ? new[] { $"token=0,value={sequence.Operations[index].Value}" }
+                        : Array.Empty<string>(),
+                    observations[index].Callbacks,
+                    report
+                );
+                StringAssert.Contains("host[0]=0/0/0/1", observations[index].State, report);
+                StringAssert.Contains("enabled=1111", observations[index].State, report);
+            }
+            CollectionAssert.AreEqual(
+                new[] { "token=0,value=13" },
+                observations[3].Callbacks,
+                report
+            );
+        }
+
+        [Test]
+        public void NativeHostDisableMutationIsDetectedAndShrunkWithCallbackDependencies(
+            [ValueSource(typeof(MessageScenarios), nameof(MessageScenarios.AllKinds))]
+                MessageScenario scenario,
+            [Values(false, true)] bool fromCallback
+        )
+        {
+            BusTraceSequence sequence = new(
+                scenario,
+                509,
+                new[]
+                {
+                    new BusTraceOperation(BusTraceOperationKind.Enable, token: 3),
+                    new BusTraceOperation(BusTraceOperationKind.Register, priority: -1),
+                    new BusTraceOperation(BusTraceOperationKind.Register, token: 1, priority: 1),
+                    fromCallback
+                        ? new BusTraceOperation(
+                            BusTraceOperationKind.EmitWithHandlerActive,
+                            value: 11,
+                            handlerToken: 1
+                        )
+                        : new BusTraceOperation(BusTraceOperationKind.SetHandlerActive, token: 1),
+                    new BusTraceOperation(BusTraceOperationKind.Emit, value: 13),
+                    new BusTraceOperation(BusTraceOperationKind.Remove, token: 1),
+                }
+            );
+            BusTraceMismatch mismatch = EvaluateMutation(sequence);
+            Assert.That(mismatch, Is.Not.Null, $"[{scenario.Kind}] fromCallback={fromCallback}");
+            string report = mismatch.BuildReport(sequence);
+            Assert.That(mismatch.Category, Is.EqualTo("callbacks"), report);
+            Assert.That(mismatch.Index, Is.EqualTo(fromCallback ? 3 : 4), report);
+            Assert.That(mismatch.Control.State, Is.EqualTo(mismatch.Candidate.State), report);
+            BusTraceSequence minimal = DifferentialBusTrace.Shrink(sequence, EvaluateMutation);
+            CollectionAssert.AreEqual(
+                fromCallback
+                    ? new[]
+                    {
+                        BusTraceOperationKind.Register,
+                        BusTraceOperationKind.Register,
+                        BusTraceOperationKind.EmitWithHandlerActive,
+                    }
+                    : new[]
+                    {
+                        BusTraceOperationKind.Register,
+                        BusTraceOperationKind.SetHandlerActive,
+                        BusTraceOperationKind.Emit,
+                    },
+                minimal.Operations.Select(operation => operation.Kind),
+                report
+            );
+            Assert.That(DifferentialBusTrace.IsValid(minimal), Is.True, report);
+            Assert.That(EvaluateMutation(minimal)?.Category, Is.EqualTo("callbacks"), report);
+        }
+
+        [Test]
+        public void GeneratedActivityReplayMatchesThroughNativeOwners(
+            [ValueSource(typeof(MessageScenarios), nameof(MessageScenarios.AllKinds))]
+                MessageScenario scenario
+        )
+        {
+            // One bounded native seed supplements the larger managed replay matrix.
+            BusTraceSequence sequence = DifferentialBusTrace.Generate(scenario, 17, 32, 7);
+            IReadOnlyList<BusTraceObservation> control = Replay(sequence);
+            IReadOnlyList<BusTraceObservation> candidate = Replay(sequence);
+            BusTraceMismatch mismatch = DifferentialBusTrace.Compare(control, candidate);
+            string report = mismatch?.BuildReport(sequence) ?? Report(sequence, control);
+            Assert.That(mismatch, Is.Null, report);
+            for (int index = 0; index < control.Count; ++index)
+            {
+                if (control[index].Exception != null)
+                {
+                    Assert.That(
+                        sequence.Operations[index].Kind,
+                        Is.EqualTo(BusTraceOperationKind.EmitWithThrow),
+                        report
+                    );
+                    StringAssert.Contains(
+                        "intentional trace callback failure",
+                        control[index].Exception,
+                        report
+                    );
+                }
+            }
+        }
+
+        private IReadOnlyList<BusTraceObservation> Replay(BusTraceSequence sequence) =>
+            DifferentialBusTrace.Replay(sequence, kind => CreateAdapter(kind));
+
+        private BusTraceMismatch EvaluateMutation(BusTraceSequence sequence) =>
+            DifferentialBusTrace.Compare(
+                Replay(sequence),
+                DifferentialBusTrace.Replay(
+                    sequence,
+                    kind => CreateAdapter(kind, ignoreDisable: true)
+                )
+            );
+
+        private NativeHostAdapter CreateAdapter(
+            MessageScenario scenario,
+            bool ignoreDisable = false,
+            bool startsActive = true,
+            bool receiveWhileDisabled = false
+        )
+        {
+            MessageBus bus = MessageBus.CreateForInternalUse(
+                new FakeClock(),
+                idleEvictionTicks: 0,
+                idleEvictionEnabled: false,
+                trimApiEnabled: true
+            );
+            bus.DiagnosticsMode = false;
+            NativeOwners owners = new(
+                bus,
+                slot => Track(new GameObject($"DifferentialHost-{scenario.Kind}-{slot}")),
+                startsActive,
+                receiveWhileDisabled
+            );
+            return new NativeHostAdapter(scenario, bus, owners, ignoreDisable);
+        }
+
+        private static string Report(
+            BusTraceSequence sequence,
+            IReadOnlyList<BusTraceObservation> observations
+        ) =>
+            $"adapter=UnityHostSetActive; generator={sequence.Version}; seed={sequence.Seed}; kind={sequence.Scenario.Kind}\n"
+            + string.Join(
+                "\n",
+                observations.Select(
+                    (item, index) => $"[{index}] {sequence.Operations[index]}: {item}"
+                )
+            );
+
+        private sealed class NativeOwners
+        {
+            internal readonly MessagingComponent[] Components = new MessagingComponent[
+                BusTraceSequence.TokenCount
+            ];
+
+            internal NativeOwners(
+                IMessageBus bus,
+                Func<int, GameObject> createHost,
+                bool startsActive,
+                bool receiveWhileDisabled
+            )
+            {
+                for (int slot = 0; slot < Components.Length; ++slot)
+                {
+                    GameObject host = createHost(slot);
+                    host.SetActive(startsActive);
+                    MessagingComponent owner = host.AddComponent<MessagingComponent>();
+                    owner.emitMessagesWhenDisabled = receiveWhileDisabled;
+                    owner.Configure(bus, MessageBusRebindMode.RebindActive);
+                    Components[slot] = owner;
+                }
+            }
+
+            internal MessageRegistrationToken CreateToken(int slot) =>
+                Components[slot].Create(Components[slot]);
+        }
+
+        private sealed class NativeHostAdapter : MessageBusTraceAdapter
+        {
+            private readonly NativeOwners _owners;
+            private readonly bool _ignoreDisable;
+
+            internal NativeHostAdapter(
+                MessageScenario scenario,
+                MessageBus bus,
+                NativeOwners owners,
+                bool ignoreDisable
+            )
+                : base(scenario, bus, reset: bus.ResetState, tokenFactory: owners.CreateToken)
+            {
+                _owners = owners;
+                _ignoreDisable = ignoreDisable;
+            }
+
+            protected override void SetHandlerActive(int slot, bool active)
+            {
+                MessagingComponent owner = _owners.Components[slot];
+                owner.gameObject.SetActive(active);
+                if (_ignoreDisable && !active)
+                {
+                    // Mutate the production handler after the real native OnDisable callback.
+                    // Native host observations stay identical; only actual delivery reveals drift.
+                    owner.ToggleMessageHandler(true);
+                }
+            }
+
+            // The owner hides its handler. Report observable native state below instead of inferring its flag.
+            protected override string DescribeHandlerActivity() => "native-owner";
+
+            protected override string DescribeAdapterState()
+            {
+                StringBuilder state = new("; adapter=UnityHostSetActive");
+                for (int slot = 0; slot < _owners.Components.Length; ++slot)
+                {
+                    MessagingComponent owner = _owners.Components[slot];
+                    GameObject host = owner.gameObject;
+                    state.Append(
+                        $"; host[{slot}]={(host.activeSelf ? 1 : 0)}/{(host.activeInHierarchy ? 1 : 0)}/{(owner.isActiveAndEnabled ? 1 : 0)}/{owner._registeredListeners.Count}"
+                    );
+                    state.Append(
+                        $"; receiveWhileDisabled[{slot}]={owner.emitMessagesWhenDisabled}"
+                    );
+                }
+                return state.ToString();
+            }
+
+            protected override void DisposeToken(int slot)
+            {
+                if (_owners == null)
+                {
+                    base.DisposeToken(slot);
+                    return;
+                }
+                try
+                {
+                    MessagingComponent owner = _owners.Components[slot];
+                    owner.Release(owner);
+                    Assert.That(
+                        owner._registeredListeners,
+                        Is.Empty,
+                        $"Native owner {slot} must release its token."
+                    );
+                    Assert.That(
+                        Token(slot).Enabled,
+                        Is.False,
+                        $"Native owner {slot} must disable its released token."
+                    );
+                    // The base adapter checks metadata and bus leaks after this returns.
+                    // Do not repair a failed owner release before those observations.
+                }
+                catch
+                {
+                    base.DisposeToken(slot);
+                    throw;
+                }
+            }
+        }
+    }
+}
+#endif

--- a/Tests/Runtime/Core/DifferentialHostTraceTests.cs.meta
+++ b/Tests/Runtime/Core/DifferentialHostTraceTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e1052a4d06a84a9eabec71000c0bb9ab
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests/Runtime/TestUtilities/AllocationAssertions.cs
+++ b/Tests/Runtime/TestUtilities/AllocationAssertions.cs
@@ -3,6 +3,8 @@ namespace DxMessaging.Tests.Runtime
 {
     using System;
     using NUnit.Framework;
+    using NUnit.Framework.Constraints;
+    using NUnit.Framework.Internal;
     using UnityEngine.TestTools.Constraints;
     using Is = NUnit.Framework.Is;
 
@@ -20,7 +22,7 @@ namespace DxMessaging.Tests.Runtime
         /// <summary>
         /// Runs <paramref name="action"/> a handful of times to JIT it, then
         /// asserts that running it <paramref name="measuredIterations"/> more
-        /// times allocates zero managed bytes. Both the inner action and the
+        /// times makes zero managed allocations. Both the inner action and the
         /// outer assertion lambda are warmed before measurement so first-call
         /// JIT overhead does not pollute the result.
         /// </summary>
@@ -61,10 +63,24 @@ namespace DxMessaging.Tests.Runtime
 
             // Warm the wrapper lambda itself once so the first invocation's
             // delegate-creation / JIT cost does not show up inside the
-            // Is.Not.AllocatingGCMemory measurement below.
+            // AllocatingGCMemoryConstraint measurement below.
             lambdaUnderTest();
 
-            Assert.That(lambdaUnderTest, Is.Not.AllocatingGCMemory(), label);
+            ConstraintResult measurement = new AllocatingGCMemoryConstraint().ApplyTo(
+                lambdaUnderTest
+            );
+            if (measurement.IsSuccess)
+            {
+                // Negating the constraint hides its allocation count in NUnit's failure
+                // message. Render the original result after the recorder has stopped.
+                TextMessageWriter writer = new TextMessageWriter();
+                measurement.WriteMessageTo(writer);
+                Assert.Fail(
+                    $"{label}: expected zero GC allocations across {measuredIterations} iterations.\n{writer}"
+                );
+            }
+
+            Assert.That(measurement.IsSuccess, Is.False, label);
         }
     }
 }

--- a/Tests/Runtime/TestUtilities/MessageBusTraceAdapter.cs
+++ b/Tests/Runtime/TestUtilities/MessageBusTraceAdapter.cs
@@ -42,7 +42,8 @@ namespace DxMessaging.Tests.Runtime
             MessageScenario scenario,
             IMessageBus bus,
             IMessageBus emitter = null,
-            Action reset = null
+            Action reset = null,
+            Func<int, MessageRegistrationToken> tokenFactory = null
         )
         {
             _scenario = scenario ?? throw new ArgumentNullException(nameof(scenario));
@@ -58,12 +59,19 @@ namespace DxMessaging.Tests.Runtime
             {
                 for (int slot = 0; slot < _tokens.Length; ++slot)
                 {
-                    MessageHandler handler = new(new InstanceId(1000 + slot), bus)
+                    if (tokenFactory == null)
                     {
-                        active = true,
-                    };
-                    _handlers[slot] = handler;
-                    _tokens[slot] = MessageRegistrationToken.Create(handler, bus);
+                        MessageHandler handler = new(new InstanceId(1000 + slot), bus)
+                        {
+                            active = true,
+                        };
+                        _handlers[slot] = handler;
+                        _tokens[slot] = MessageRegistrationToken.Create(handler, bus);
+                    }
+                    else
+                    {
+                        _tokens[slot] = tokenFactory(slot);
+                    }
                     _tokens[slot].DiagnosticMode = false;
                     _tokens[slot].Enable();
                 }
@@ -200,11 +208,7 @@ namespace DxMessaging.Tests.Runtime
             {
                 enabled += token.Enabled ? "1" : "0";
             }
-            string handlerActive = string.Empty;
-            foreach (MessageHandler handler in _handlers)
-            {
-                handlerActive += handler.active ? "1" : "0";
-            }
+            string handlerActive = DescribeHandlerActivity();
             string diagnostics = string.Empty;
             string retainedMessages = string.Empty;
             foreach (MessageRegistrationToken token in _tokens)
@@ -226,7 +230,8 @@ namespace DxMessaging.Tests.Runtime
                 retainedMessages += $"{references},";
             }
             string state =
-                $"counts={_bus.RegisteredUntargeted},{_bus.RegisteredTargeted},{_bus.RegisteredBroadcast},{_bus.RegisteredInterceptors},{_bus.RegisteredPostProcessors},{_bus.RegisteredGlobalAcceptAll}; slots={_bus.OccupiedTypeSlots},{_bus.OccupiedTargetSlots}; enabled={enabled}; handlerActive={handlerActive}; diagnostics={_bus.DiagnosticsMode}; tokenMetadataCallsHistory={diagnostics}; retainedMessages={retainedMessages}";
+                $"counts={_bus.RegisteredUntargeted},{_bus.RegisteredTargeted},{_bus.RegisteredBroadcast},{_bus.RegisteredInterceptors},{_bus.RegisteredPostProcessors},{_bus.RegisteredGlobalAcceptAll}; slots={_bus.OccupiedTypeSlots},{_bus.OccupiedTargetSlots}; enabled={enabled}; handlerActive={handlerActive}; diagnostics={_bus.DiagnosticsMode}; tokenMetadataCallsHistory={diagnostics}; retainedMessages={retainedMessages}"
+                + DescribeAdapterState();
             return new BusTraceObservation(
                 _callbacks,
                 state,
@@ -241,15 +246,16 @@ namespace DxMessaging.Tests.Runtime
         public void Dispose()
         {
             List<Exception> errors = new();
-            foreach (MessageRegistrationToken token in _tokens)
+            for (int slot = 0; slot < _tokens.Length; ++slot)
             {
+                MessageRegistrationToken token = _tokens[slot];
                 try
                 {
                     if (token == null)
                     {
                         continue;
                     }
-                    token.Dispose();
+                    DisposeToken(slot);
                     if (
                         token._metadata.Count != 0
                         || token._callCounts.Count != 0
@@ -287,6 +293,20 @@ namespace DxMessaging.Tests.Runtime
                 throw new AggregateException("Differential replay cleanup failed.", errors);
             }
         }
+
+        protected virtual void DisposeToken(int slot) => _tokens[slot].Dispose();
+
+        protected virtual string DescribeHandlerActivity()
+        {
+            string activity = string.Empty;
+            foreach (MessageHandler handler in _handlers)
+            {
+                activity += handler.active ? "1" : "0";
+            }
+            return activity;
+        }
+
+        protected virtual string DescribeAdapterState() => string.Empty;
 
         protected MessageRegistrationToken Token(int slot) => _tokens[slot];
 

--- a/scripts/__tests__/run-ci-tests-enter-play-mode.test.js
+++ b/scripts/__tests__/run-ci-tests-enter-play-mode.test.js
@@ -8,6 +8,10 @@ const path = require("node:path");
 const { spawnSync } = require("node:child_process");
 const { stripVTControlCharacters } = require("node:util");
 
+const { extractRows, deriveScope: extractorDeriveScope } = require("../unity/extract-perf-baseline.js");
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+const STANDALONE_PLATFORM = "Standalone IL2CPP x64 Release (WindowsPlayer; Unity 6000.3.16f1)";
+const EDITOR_PLAYMODE_PLATFORM = "Editor PlayMode Mono x64 Release (WindowsEditor; Unity 6000.3.16f1)";
 const RUN_CI_SCRIPT_PATH = path.join(__dirname, "..", "unity", "run-ci-tests.ps1");
 // prettier-ignore
 const ROSLYNATOR_ANALYZER_FILES = ["Roslynator.CSharp.Analyzers.dll", "Roslynator_Analyzers_Roslynator.Common.dll", "Roslynator_Analyzers_Roslynator.Core.dll", "Roslynator_Analyzers_Roslynator.CSharp.dll"];
@@ -252,5 +256,86 @@ test("run-ci-tests -GenerateOnly rejects an unowned CachePath without modifying 
     assert.equal(fs.existsSync(path.join(cachePath, ".dxmessaging-ci-cache")), false);
   } finally {
     fs.rmSync(stagingRoot, { recursive: true, force: true });
+  }
+});
+
+test("PowerShell performance harness regression tests pass", () => {
+  // prettier-ignore
+  for (const script of ["il2cpp-profile.test.ps1", "require-comparison-rows.test.ps1", "same-player-repeat-evidence.test.ps1", "editor-process-watchdog.test.ps1", "shipping-fidelity.test.ps1"]) {
+    const testScript = path.join(REPO_ROOT, "scripts", "unity", "__tests__", script);
+    const result = spawnSync("pwsh", ["-NoLogo", "-NoProfile", "-File", testScript], {
+      encoding: "utf8"
+    });
+    assert.ifError(result.error);
+    assert.equal(result.status, 0, `${script}\n${result.stdout}\n${result.stderr}`);
+  }
+  const result = spawnSync("pwsh", ["-NoProfile", "-File", "scripts/unity/capture-dispatch-codegen.ps1", "-SelfTestOnly"], {
+    cwd: REPO_ROOT, encoding: "utf8"
+  });
+  assert.ifError(result.error);
+  assert.equal(result.status, 0, result.stderr);
+});
+
+test("render-perf-deltas CLI failures preserve non-gating diagnostic output", () => {
+  const script = path.join(REPO_ROOT, "scripts", "unity", "render-perf-deltas.js");
+  const result = spawnSync(process.execPath, [script, "--bogus"], {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"]
+  });
+
+  assert.ifError(result.error);
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout, "changed=false\nregressed=false\n");
+  assert.match(result.stderr, /Unknown argument: --bogus/);
+  assert.match(result.stderr, /workflow decides whether the regressed= signal fails CI/);
+});
+
+test("extract-perf-baseline --scope filters rows to one execution scope", () => {
+  const mixed = [
+    `UntargetedFlood_OneHandler,${STANDALONE_PLATFORM},abc1234,-1,37500000,-1,5000`,
+    `UntargetedFlood_OneHandler,${EDITOR_PLAYMODE_PLATFORM},abc1234,-1,20000000,0,5000`,
+    `TargetedFlood_OneListener,Unity 6000.3.16f1 EditMode Mono,abc1234,-1,9000000,0,5000`
+  ].join("\n");
+  const all = extractRows(mixed);
+  const standaloneOnly = all.filter((r) => extractorDeriveScope(r.platform) === "Standalone");
+  assert.equal(all.length, 3);
+  assert.deepEqual(
+    standaloneOnly.map((r) => r.platform),
+    [STANDALONE_PLATFORM]
+  );
+
+  const script = path.join(REPO_ROOT, "scripts", "unity", "extract-perf-baseline.js");
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "dxm-scope-"));
+  try {
+    const mixedPath = path.join(dir, "mixed.log");
+    const editorOnlyPath = path.join(dir, "editor.log");
+    fs.writeFileSync(mixedPath, mixed);
+    fs.writeFileSync(
+      editorOnlyPath,
+      `UntargetedFlood_OneHandler,${EDITOR_PLAYMODE_PLATFORM},abc1234,-1,20000000,0,5000`
+    );
+
+    const kept = spawnSync(
+      process.execPath,
+      [script, "--input", mixedPath, "--scope", "Standalone"],
+      { cwd: REPO_ROOT, encoding: "utf8" }
+    );
+    assert.equal(kept.status, 0, kept.stderr);
+    const keptRows = extractRows(kept.stdout);
+    assert.deepEqual(
+      keptRows.map((r) => r.platform),
+      [STANDALONE_PLATFORM]
+    );
+
+    const empty = spawnSync(
+      process.execPath,
+      [script, "--input", editorOnlyPath, "--scope", "Standalone"],
+      { cwd: REPO_ROOT, encoding: "utf8" }
+    );
+    assert.notEqual(empty.status, 0);
+    assert.match(empty.stderr, /No DispatchThroughputBenchmarks rows found/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
   }
 });

--- a/scripts/__tests__/run-ci-tests-enter-play-mode.test.js
+++ b/scripts/__tests__/run-ci-tests-enter-play-mode.test.js
@@ -58,7 +58,9 @@ function runGenerateOnly(stagingRoot, repoRoot, artifactsPath, options = {}) {
   if (options.cachePath) args.push("-CachePath", options.cachePath);
   args.push("-GenerateOnly");
 
-  return spawnSync("pwsh", args, { cwd: stagingRoot, encoding: "utf8", timeout: 120000 });
+  const result = spawnSync("pwsh", args, { cwd: stagingRoot, encoding: "utf8", timeout: 120000 });
+  assert.ifError(result.error);
+  return result;
 }
 
 test("run-ci-tests emits EnterPlayModeOptions reload-disable for CI projects", () => {
@@ -76,7 +78,7 @@ test("Unity native-exit, diagnostic, and retry-cleanup guards stay fail-closed",
   for (const text of [runCiTests, exportUnityPackage]) {
     assert.match(
       text,
-      /(?=[\s\S]*function Clear-NonFatalNativeExitCode[\s\S]*\$global:LASTEXITCODE = 0)(?=[\s\S]*\$exitCode = \$LASTEXITCODE\s+Clear-NonFatalNativeExitCode -Context \$Label)(?=[\s\S]*finally \{\s+Clear-NonFatalNativeExitCode -Context 'Unity license return cleanup'\s+\})/
+      /^(?=[\s\S]*function Clear-NonFatalNativeExitCode[\s\S]*\$global:LASTEXITCODE = 0)(?=[\s\S]*\$exitCode = \$(?:LASTEXITCODE|processResult\.ExitCode)\s+Clear-NonFatalNativeExitCode -Context \$Label)(?=[\s\S]*finally \{\s+Clear-NonFatalNativeExitCode -Context 'Unity license return cleanup'\s+\})/
     );
   }
   // prettier-ignore
@@ -84,7 +86,7 @@ test("Unity native-exit, diagnostic, and retry-cleanup guards stay fail-closed",
   // prettier-ignore
   assert.match(runCiTests, /function Write-CacheOwnershipMarker \{(?:(?!\n\})[\s\S])*Test-IsReparsePoint -Path \$markerPath/);
   // prettier-ignore
-  assert.match(runCiTests, /(?=[\s\S]*function Test-IsReparsePoint \{(?!(?:(?!\n\})[\s\S])*Test-Path)(?:(?!\n\})[\s\S])*Get-Item -LiteralPath \$Path -Force(?:(?!\n\})[\s\S])*catch \[System\.Management\.Automation\.ItemNotFoundException\])(?=[\s\S]*foreach \(\$projectRetryPath in \$projectRetryPaths\)[\s\S]*Assert-UnityProjectRetryPathSafe)(?=[\s\S]*foreach \(\$retryCachePath in \$retryCachePaths\)[\s\S]*Assert-UnityCacheRetryPathSafe)(?=[\s\S]*\$paths = \$projectRetryPaths \+ \$retryCachePaths[\s\S]*Remove-Item -LiteralPath \$path -Recurse)/);
+  assert.match(runCiTests, /^(?=[\s\S]*function Test-IsReparsePoint \{(?!(?:(?!\n\})[\s\S])*Test-Path)(?:(?!\n\})[\s\S])*Get-Item -LiteralPath \$Path -Force(?:(?!\n\})[\s\S])*catch \[System\.Management\.Automation\.ItemNotFoundException\])(?=[\s\S]*foreach \(\$projectRetryPath in \$projectRetryPaths\)[\s\S]*Assert-UnityProjectRetryPathSafe)(?=[\s\S]*foreach \(\$retryCachePath in \$retryCachePaths\)[\s\S]*Assert-UnityCacheRetryPathSafe)(?=[\s\S]*\$paths = \$projectRetryPaths \+ \$retryCachePaths[\s\S]*Remove-Item -LiteralPath \$path -Recurse)/);
 });
 
 test("run-ci-tests -GenerateOnly defaults to managed artifact project and cache paths", (t) => {

--- a/scripts/__tests__/unity-perf.test.js
+++ b/scripts/__tests__/unity-perf.test.js
@@ -2,7 +2,6 @@
 
 const { test } = require("node:test");
 const assert = require("node:assert/strict");
-const { spawnSync } = require("node:child_process");
 const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
@@ -176,18 +175,6 @@ test("scenario filters keep only dispatch and DxMessaging comparison rows", () =
   ];
   for (const [predicate, scenario, expected] of cases) {
     assert.equal(predicate(scenario), expected, `${scenario}`);
-  }
-});
-
-test("PowerShell performance harness regression tests pass", () => {
-  // prettier-ignore
-  for (const script of ["il2cpp-profile.test.ps1", "require-comparison-rows.test.ps1", "same-player-repeat-evidence.test.ps1", "editor-process-watchdog.test.ps1", "shipping-fidelity.test.ps1"]) {
-    const testScript = path.join(REPO_ROOT, "scripts", "unity", "__tests__", script);
-    const result = spawnSync("pwsh", ["-NoLogo", "-NoProfile", "-File", testScript], {
-      encoding: "utf8"
-    });
-    assert.ifError(result.error);
-    assert.equal(result.status, 0, `${script}\n${result.stdout}\n${result.stderr}`);
   }
 });
 
@@ -465,26 +452,7 @@ test("readBaselineRows degrades gracefully when the baseline is absent", () => {
   assert.equal(readBaselineRows("/nonexistent/baseline.csv"), null);
 });
 
-test("render-perf-deltas CLI failures preserve non-gating diagnostic output", () => {
-  const script = path.join(REPO_ROOT, "scripts", "unity", "render-perf-deltas.js");
-  const result = spawnSync(process.execPath, [script, "--bogus"], {
-    cwd: REPO_ROOT,
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "pipe"]
-  });
-
-  assert.ifError(result.error);
-  assert.equal(result.status, 0, result.stderr);
-  assert.equal(result.stdout, "changed=false\nregressed=false\n");
-  assert.match(result.stderr, /Unknown argument: --bogus/);
-  assert.match(result.stderr, /workflow decides whether the regressed= signal fails CI/);
-});
 test("performance workflow publishes exact player-size and codegen evidence", () => {
-  const selfTest = spawnSync(
-    "pwsh -NoProfile -File scripts/unity/capture-dispatch-codegen.ps1 -SelfTestOnly",
-    { cwd: REPO_ROOT, shell: true }
-  );
-  assert.equal(selfTest.status, 0, selfTest.stderr?.toString());
   const workflow = fs.readFileSync(
     path.join(REPO_ROOT, ".github", "workflows", "perf-numbers.yml"),
     "utf8"
@@ -724,55 +692,6 @@ test("comparison count+bytes matrices are omitted when no leg measured them", ()
   assert.ok(!joined.includes("GC allocations per 10k ops"), joined);
   assert.ok(!joined.includes("GC allocated bytes per 10k ops"), joined);
   assert.ok(!/\bn\/a\b/.test(joined), joined);
-});
-
-test("extract-perf-baseline --scope filters rows to one execution scope", () => {
-  const mixed = [
-    `UntargetedFlood_OneHandler,${STANDALONE_PLATFORM},abc1234,-1,37500000,-1,5000`,
-    `UntargetedFlood_OneHandler,${EDITOR_PLAYMODE_PLATFORM},abc1234,-1,20000000,0,5000`,
-    `TargetedFlood_OneListener,Unity 6000.3.16f1 EditMode Mono,abc1234,-1,9000000,0,5000`
-  ].join("\n");
-  const all = extractRows(mixed);
-  const standaloneOnly = all.filter((r) => extractorDeriveScope(r.platform) === "Standalone");
-  assert.equal(all.length, 3);
-  assert.deepEqual(
-    standaloneOnly.map((r) => r.platform),
-    [STANDALONE_PLATFORM]
-  );
-
-  const script = path.join(REPO_ROOT, "scripts", "unity", "extract-perf-baseline.js");
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "dxm-scope-"));
-  try {
-    const mixedPath = path.join(dir, "mixed.log");
-    const editorOnlyPath = path.join(dir, "editor.log");
-    fs.writeFileSync(mixedPath, mixed);
-    fs.writeFileSync(
-      editorOnlyPath,
-      `UntargetedFlood_OneHandler,${EDITOR_PLAYMODE_PLATFORM},abc1234,-1,20000000,0,5000`
-    );
-
-    const kept = spawnSync(
-      process.execPath,
-      [script, "--input", mixedPath, "--scope", "Standalone"],
-      { cwd: REPO_ROOT, encoding: "utf8" }
-    );
-    assert.equal(kept.status, 0, kept.stderr);
-    const keptRows = extractRows(kept.stdout);
-    assert.deepEqual(
-      keptRows.map((r) => r.platform),
-      [STANDALONE_PLATFORM]
-    );
-
-    const empty = spawnSync(
-      process.execPath,
-      [script, "--input", editorOnlyPath, "--scope", "Standalone"],
-      { cwd: REPO_ROOT, encoding: "utf8" }
-    );
-    assert.notEqual(empty.status, 0);
-    assert.match(empty.stderr, /No DispatchThroughputBenchmarks rows found/);
-  } finally {
-    fs.rmSync(dir, { recursive: true, force: true });
-  }
 });
 
 test("a winner flip within tolerance does not defeat table idempotence", () => {

--- a/scripts/__tests__/unity-perf.test.js
+++ b/scripts/__tests__/unity-perf.test.js
@@ -181,7 +181,7 @@ test("scenario filters keep only dispatch and DxMessaging comparison rows", () =
 
 test("PowerShell performance harness regression tests pass", () => {
   // prettier-ignore
-  for (const script of ["il2cpp-profile.test.ps1", "require-comparison-rows.test.ps1", "same-player-repeat-evidence.test.ps1", "shipping-fidelity.test.ps1"]) {
+  for (const script of ["il2cpp-profile.test.ps1", "require-comparison-rows.test.ps1", "same-player-repeat-evidence.test.ps1", "editor-process-watchdog.test.ps1", "shipping-fidelity.test.ps1"]) {
     const testScript = path.join(REPO_ROOT, "scripts", "unity", "__tests__", script);
     const result = spawnSync("pwsh", ["-NoLogo", "-NoProfile", "-File", testScript], {
       encoding: "utf8"

--- a/scripts/mcp/DxMcpTestRunner.cs.txt
+++ b/scripts/mcp/DxMcpTestRunner.cs.txt
@@ -1,0 +1,522 @@
+#nullable disable
+// Unity loads this global entry point and requires exception containment in editor callbacks.
+#pragma warning disable CA1050, CA1515, CA1031
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using UnityEditor;
+using UnityEditor.SceneManagement;
+using UnityEditor.TestTools.TestRunner.Api;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+// Copy this maintained source to the host's Assets/Editor/DxMcpTestRunner.cs.
+// It is local tooling; the .txt suffix prevents compilation inside the package.
+[InitializeOnLoad]
+public static class DxMcpTestRunner
+{
+    private const string Prefix = "DxMcpTestRunner.";
+    private const string StatePath =
+        "Packages/com.wallstop-studios.dxmessaging/.artifacts/unity-mcp/editor-state.json";
+    private static readonly TestRunnerApi Api;
+    private static readonly MethodInfo ActiveMethod = typeof(TestRunnerApi).GetMethod(
+        "IsRunActive",
+        BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic
+    );
+    private static double nextSnapshot;
+
+    static DxMcpTestRunner()
+    {
+        Api = ScriptableObject.CreateInstance<TestRunnerApi>();
+        Api.RegisterCallbacks(new ResultWriter());
+        EditorApplication.update += Observe;
+    }
+
+    public static string Run(
+        string testMode,
+        string assemblyNames,
+        string testNames,
+        string categoryNames,
+        string resultPath
+    )
+    {
+        if (
+            !string.IsNullOrEmpty(Get("ResultPath"))
+            || !string.IsNullOrEmpty(
+                SessionState.GetString("DxMcpObservedTestRunner.ResultPath", "")
+            )
+        )
+        {
+            throw new InvalidOperationException("A previous run still owns its cleanup scope.");
+        }
+        EditorState state = ReadEditorState();
+        RequireSafeEditor(state);
+        if (testMode != "EditMode" && testMode != "PlayMode")
+        {
+            throw new ArgumentException("Expected EditMode or PlayMode.", nameof(testMode));
+        }
+        if (string.IsNullOrWhiteSpace(resultPath))
+        {
+            throw new ArgumentException("A fresh result path is required.", nameof(resultPath));
+        }
+        string path = Path.GetFullPath(resultPath);
+        foreach (
+            string suffix in new[]
+            {
+                "",
+                ".status",
+                ".run.json",
+                ".cleanup.json",
+                ".cleanup.status",
+                ".errors.log",
+            }
+        )
+        {
+            if (File.Exists(path + suffix) || Directory.Exists(path + suffix))
+            {
+                throw new IOException("Refusing existing run evidence: " + path + suffix);
+            }
+        }
+        Directory.CreateDirectory(Path.GetDirectoryName(path));
+        // Claim the path before Execute: callbacks can fire before Execute returns its GUID.
+        Set("ResultPath", path);
+        Set("InitialScenes", JsonUtility.ToJson(state));
+        Set("Errors", "");
+        Set("RunGuid", "");
+        Set("ResultWritten", "");
+        try
+        {
+            File.WriteAllText(path + ".status", "running");
+            File.WriteAllText(path + ".cleanup.status", "running");
+            Filter filter = new Filter
+            {
+                testMode = testMode == "PlayMode" ? TestMode.PlayMode : TestMode.EditMode,
+                assemblyNames = Split(assemblyNames),
+                testNames = Split(testNames),
+                categoryNames = Split(categoryNames),
+            };
+            string guid = Api.Execute(new ExecutionSettings(filter));
+            Set("RunGuid", guid);
+            if (string.IsNullOrEmpty(guid))
+            {
+                throw new InvalidOperationException("Execute returned no run GUID.");
+            }
+            File.WriteAllText(
+                path + ".run.json",
+                JsonUtility.ToJson(new RunIdentity { runGuid = guid, resultPath = path }, true)
+            );
+            return guid;
+        }
+        catch (Exception error)
+        {
+            RecordError("Starting the run failed: " + error);
+            // Execute may have created a job before throwing. Keep ownership until passive cleanup.
+            throw;
+        }
+    }
+
+    private static string[] Split(string value) =>
+        string.IsNullOrEmpty(value) ? null : value.Split(';');
+
+    private static string Get(string key) => SessionState.GetString(Prefix + key, "");
+
+    private static void Set(string key, string value) =>
+        SessionState.SetString(Prefix + key, value);
+
+    private static EditorState ReadEditorState()
+    {
+        if (ActiveMethod == null)
+        {
+            throw new MissingMethodException(
+                "TestRunnerApi.IsRunActive is unavailable; idleness is unproven."
+            );
+        }
+        SceneState[] scenes = new SceneState[SceneManager.sceneCount];
+        for (int index = 0; index < scenes.Length; ++index)
+        {
+            Scene scene = SceneManager.GetSceneAt(index);
+            scenes[index] = new SceneState
+            {
+                path = scene.path,
+                dirty = scene.isDirty,
+                loaded = scene.isLoaded,
+            };
+        }
+        return new EditorState
+        {
+            observedUtc = DateTime.UtcNow.ToString("O"),
+            frameworkActive = (bool)ActiveMethod.Invoke(null, null),
+            playing = EditorApplication.isPlayingOrWillChangePlaymode,
+            compiling = EditorApplication.isCompiling,
+            updating = EditorApplication.isUpdating,
+            mainStage = StageUtility
+                .GetCurrentStageHandle()
+                .Equals(StageUtility.GetMainStageHandle()),
+            activeScene = SceneManager.GetActiveScene().path,
+            scenes = scenes,
+            runGuid = Get("RunGuid"),
+            resultPath = Get("ResultPath"),
+            frameworkErrors = Get("Errors"),
+        };
+    }
+
+    private static void RequireSafeEditor(EditorState state)
+    {
+        if (
+            state.frameworkActive
+            || state.playing
+            || state.compiling
+            || state.updating
+            || !state.mainStage
+        )
+        {
+            throw new InvalidOperationException("The shared editor is not idle in its main stage.");
+        }
+        if (state.scenes.Length == 0 || string.IsNullOrEmpty(state.activeScene))
+        {
+            throw new InvalidOperationException("A saved active scene is required.");
+        }
+        foreach (SceneState scene in state.scenes)
+        {
+            if (scene.dirty || (scene.loaded && string.IsNullOrEmpty(scene.path)))
+            {
+                throw new InvalidOperationException(
+                    "The shared editor has a dirty or unsaved scene."
+                );
+            }
+        }
+    }
+
+    private static void Observe()
+    {
+        string path = Get("ResultPath");
+        try
+        {
+            // No refresh, scene mutation, cancellation, retry, or new test launch.
+            // The bounded idle snapshot makes the next preflight possible without Unity_RunCommand.
+            if (string.IsNullOrEmpty(path) && EditorApplication.timeSinceStartup < nextSnapshot)
+            {
+                return;
+            }
+            EditorState state = ReadEditorState();
+            if (EditorApplication.timeSinceStartup >= nextSnapshot)
+            {
+                Directory.CreateDirectory(Path.GetDirectoryName(StatePath));
+                File.WriteAllText(StatePath, JsonUtility.ToJson(state, true));
+                SessionState.EraseString(Prefix + "ObservationError");
+                nextSnapshot = EditorApplication.timeSinceStartup + 1;
+            }
+            if (
+                string.IsNullOrEmpty(path)
+                || state.frameworkActive
+                || state.playing
+                || state.compiling
+                || state.updating
+            )
+            {
+                return;
+            }
+            string errors = Get("Errors");
+            string terminal;
+            if (!string.IsNullOrEmpty(errors))
+            {
+                terminal = "error: framework or result writer failed; see .errors.log";
+            }
+            else if (Get("ResultWritten") != "yes")
+            {
+                terminal = "error: framework inactive without a completed result";
+            }
+            else
+            {
+                ResultSummary result = JsonUtility.FromJson<ResultSummary>(File.ReadAllText(path));
+                terminal =
+                    result.passCount > 0
+                    && result.failCount == 0
+                    && result.inconclusiveCount == 0
+                    && result.nodes != null
+                    && result.nodes.Length > 0
+                    && result.nodes[0].status == nameof(TestStatus.Passed)
+                    && Array.TrueForAll(
+                        result.nodes,
+                        node =>
+                            node != null
+                            && (
+                                node.status == nameof(TestStatus.Passed)
+                                || node.status == nameof(TestStatus.Skipped)
+                            )
+                    )
+                        ? "done"
+                        : "error: result has no passes or contains failed/inconclusive nodes";
+            }
+            try
+            {
+                RequireSafeEditor(state);
+                EditorState initial = JsonUtility.FromJson<EditorState>(Get("InitialScenes"));
+                if (
+                    initial.activeScene != state.activeScene
+                    || initial.scenes.Length != state.scenes.Length
+                )
+                {
+                    throw new InvalidOperationException(
+                        "The initial scene setup was not restored."
+                    );
+                }
+                for (int index = 0; index < initial.scenes.Length; ++index)
+                {
+                    if (
+                        initial.scenes[index].path != state.scenes[index].path
+                        || initial.scenes[index].loaded != state.scenes[index].loaded
+                    )
+                    {
+                        throw new InvalidOperationException(
+                            "The initial scene setup was not restored."
+                        );
+                    }
+                }
+            }
+            catch (Exception error)
+            {
+                terminal = "error: " + error.Message;
+            }
+            File.WriteAllText(path + ".cleanup.json", JsonUtility.ToJson(state, true));
+            File.WriteAllText(path + ".cleanup.status", terminal);
+            if (Get("ResultWritten") != "yes")
+            {
+                File.WriteAllText(path + ".status", terminal);
+            }
+            // A terminal cleanup record keeps identity and errors after SessionState ownership clears.
+            foreach (
+                string key in new[]
+                {
+                    "ResultPath",
+                    "RunGuid",
+                    "InitialScenes",
+                    "Errors",
+                    "ResultWritten",
+                    "ObservationError",
+                }
+            )
+            {
+                SessionState.EraseString(Prefix + key);
+            }
+        }
+        catch (Exception error)
+        {
+            // A missing/failed query is never evidence of cleanup. Keep ownership and keep observing.
+            Set("ObservationError", error.ToString());
+            if (!string.IsNullOrEmpty(path))
+            {
+                TryWriteFailure(path + ".cleanup.status", "observation-error: " + error);
+            }
+            // Mark an unavailable query unsafe; if storage fails, the previous snapshot goes stale.
+            TryWriteFailure(
+                StatePath,
+                JsonUtility.ToJson(
+                    new EditorState
+                    {
+                        observedUtc = DateTime.UtcNow.ToString("O"),
+                        observationError = error.ToString(),
+                    },
+                    true
+                )
+            );
+        }
+    }
+
+    private static void RecordError(string message)
+    {
+        string path = Get("ResultPath");
+        if (string.IsNullOrEmpty(path))
+        {
+            return;
+        }
+        if (string.IsNullOrEmpty(message))
+        {
+            message = "The framework reported an empty error.";
+        }
+        string entry = DateTime.UtcNow.ToString("O") + " " + message + Environment.NewLine;
+        string previous = Get("Errors");
+        // Repeated passive storage failures must not grow SessionState every editor frame.
+        if (previous.Contains(message, StringComparison.Ordinal))
+        {
+            return;
+        }
+        Set("Errors", previous + entry);
+        try
+        {
+            File.AppendAllText(path + ".errors.log", entry);
+        }
+        catch (Exception error)
+        {
+            // SessionState retains the error even when the filesystem cannot retain a log.
+            Set("Errors", Get("Errors") + "Writing the error log failed: " + error);
+        }
+    }
+
+    private static void TryWriteFailure(string path, string content)
+    {
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(path));
+            File.WriteAllText(path, content);
+        }
+        catch (Exception error)
+        {
+            Set("ObservationError", "Writing failure evidence failed: " + error);
+            RecordError("Writing failure evidence failed: " + error);
+        }
+    }
+
+    private sealed class ResultWriter : IErrorCallbacks
+    {
+        public void OnError(string message) => RecordError(message);
+
+        public void RunStarted(ITestAdaptor testsToRun) { }
+
+        public void TestStarted(ITestAdaptor test) { }
+
+        public void TestFinished(ITestResultAdaptor result) { }
+
+        public void RunFinished(ITestResultAdaptor result)
+        {
+            string path = Get("ResultPath");
+            if (string.IsNullOrEmpty(path))
+            {
+                return;
+            }
+            try
+            {
+                if (Get("ResultWritten") == "yes")
+                {
+                    throw new InvalidOperationException("Multiple run results reached one owner.");
+                }
+                List<ResultNode> nodes = new List<ResultNode>();
+                List<ResultNode> failures = new List<ResultNode>();
+                AppendResultTree(result, -1, nodes, failures);
+                ResultSummary summary = new ResultSummary
+                {
+                    passCount = result.PassCount,
+                    failCount = result.FailCount,
+                    skipCount = result.SkipCount,
+                    inconclusiveCount = result.InconclusiveCount,
+                    durationSeconds = result.Duration,
+                    nodes = nodes.ToArray(),
+                    failures = failures.ToArray(),
+                };
+                File.WriteAllText(path, JsonUtility.ToJson(summary, true));
+                File.WriteAllText(path + ".status", "done");
+                Set("ResultWritten", "yes");
+            }
+            catch (Exception error)
+            {
+                RecordError("Saving the result failed: " + error);
+                TryWriteFailure(path + ".status", "error: " + error);
+            }
+        }
+    }
+
+    private static void AppendResultTree(
+        ITestResultAdaptor result,
+        int parentIndex,
+        List<ResultNode> nodes,
+        List<ResultNode> failures
+    )
+    {
+        int index = nodes.Count;
+        ResultNode node = new ResultNode
+        {
+            parentIndex = parentIndex,
+            name = result.FullName,
+            isSuite = result.Test.IsSuite,
+            status = result.TestStatus.ToString(),
+            resultState = result.ResultState,
+            durationSeconds = result.Duration,
+            message = result.Message,
+            stack = result.StackTrace,
+            output = result.Output,
+            startTime = result.StartTime.ToString("O"),
+            endTime = result.EndTime.ToString("O"),
+            passCount = result.PassCount,
+            failCount = result.FailCount,
+            skipCount = result.SkipCount,
+            inconclusiveCount = result.InconclusiveCount,
+        };
+        nodes.Add(node);
+        if (result.TestStatus == TestStatus.Failed)
+        {
+            failures.Add(node);
+        }
+        if (result.Children != null)
+        {
+            foreach (ITestResultAdaptor child in result.Children)
+            {
+                AppendResultTree(child, index, nodes, failures);
+            }
+        }
+    }
+
+    [Serializable]
+    private sealed class RunIdentity
+    {
+        public string runGuid = "";
+        public string resultPath = "";
+    }
+
+    [Serializable]
+    private sealed class SceneState
+    {
+        public string path = "";
+        public bool dirty;
+        public bool loaded;
+    }
+
+    [Serializable]
+    private sealed class EditorState
+    {
+        public string observedUtc = "";
+        public string observationError = "";
+        public bool frameworkActive;
+        public bool playing;
+        public bool compiling;
+        public bool updating;
+        public bool mainStage;
+        public string activeScene = "";
+        public SceneState[] scenes = Array.Empty<SceneState>();
+        public string runGuid = "";
+        public string resultPath = "";
+        public string frameworkErrors = "";
+    }
+
+    [Serializable]
+    private sealed class ResultSummary
+    {
+        public int passCount = -1;
+        public int failCount = -1;
+        public int skipCount;
+        public int inconclusiveCount = -1;
+        public double durationSeconds;
+        public ResultNode[] nodes = Array.Empty<ResultNode>();
+        public ResultNode[] failures = Array.Empty<ResultNode>();
+    }
+
+    [Serializable]
+    private sealed class ResultNode
+    {
+        public int parentIndex;
+        public string name = "";
+        public bool isSuite;
+        public string status = "";
+        public string resultState = "";
+        public double durationSeconds;
+        public string message = "";
+        public string stack = "";
+        public string output = "";
+        public string startTime = "";
+        public string endTime = "";
+        public int passCount;
+        public int failCount;
+        public int skipCount;
+        public int inconclusiveCount;
+    }
+}

--- a/scripts/mcp/DxMcpTestRunner.cs.txt
+++ b/scripts/mcp/DxMcpTestRunner.cs.txt
@@ -248,7 +248,6 @@ public static class DxMcpTestRunner
                     && result.inconclusiveCount == 0
                     && result.nodes != null
                     && result.nodes.Length > 0
-                    && result.nodes[0].status == nameof(TestStatus.Passed)
                     && Array.TrueForAll(
                         result.nodes,
                         node =>

--- a/scripts/mcp/DxMcpTestRunner.cs.txt
+++ b/scripts/mcp/DxMcpTestRunner.cs.txt
@@ -17,6 +17,7 @@ using UnityEngine.SceneManagement;
 public static class DxMcpTestRunner
 {
     private const string Prefix = "DxMcpTestRunner.";
+    private const string LegacyObserverKey = "DxMcpObservedTestRunner.ResultPath";
     private const string StatePath =
         "Packages/com.wallstop-studios.dxmessaging/.artifacts/unity-mcp/editor-state.json";
     private static readonly TestRunnerApi Api;
@@ -43,8 +44,9 @@ public static class DxMcpTestRunner
     {
         if (
             !string.IsNullOrEmpty(Get("ResultPath"))
+            || !string.IsNullOrEmpty(Get("OwnedResultPath"))
             || !string.IsNullOrEmpty(
-                SessionState.GetString("DxMcpObservedTestRunner.ResultPath", "")
+                SessionState.GetString(LegacyObserverKey, "")
             )
         )
         {
@@ -81,6 +83,7 @@ public static class DxMcpTestRunner
         Directory.CreateDirectory(Path.GetDirectoryName(path));
         // Claim the path before Execute: callbacks can fire before Execute returns its GUID.
         Set("ResultPath", path);
+        Set("OwnedResultPath", path);
         Set("InitialScenes", JsonUtility.ToJson(state));
         Set("Errors", "");
         Set("RunGuid", "");
@@ -121,6 +124,13 @@ public static class DxMcpTestRunner
 
     private static string Get(string key) => SessionState.GetString(Prefix + key, "");
 
+    private static string GetOwnedResultPath()
+    {
+        // Legacy runners used ResultPath alone. Never claim their unfinished evidence.
+        string path = Get("ResultPath");
+        return !string.IsNullOrEmpty(path) && path == Get("OwnedResultPath") ? path : "";
+    }
+
     private static void Set(string key, string value) =>
         SessionState.SetString(Prefix + key, value);
 
@@ -157,6 +167,8 @@ public static class DxMcpTestRunner
             scenes = scenes,
             runGuid = Get("RunGuid"),
             resultPath = Get("ResultPath"),
+            ownedResultPath = Get("OwnedResultPath"),
+            legacyObserverResultPath = SessionState.GetString(LegacyObserverKey, ""),
             frameworkErrors = Get("Errors"),
         };
     }
@@ -190,7 +202,7 @@ public static class DxMcpTestRunner
 
     private static void Observe()
     {
-        string path = Get("ResultPath");
+        string path = GetOwnedResultPath();
         try
         {
             // No refresh, scene mutation, cancellation, retry, or new test launch.
@@ -290,6 +302,7 @@ public static class DxMcpTestRunner
                 string key in new[]
                 {
                     "ResultPath",
+                    "OwnedResultPath",
                     "RunGuid",
                     "InitialScenes",
                     "Errors",
@@ -326,7 +339,7 @@ public static class DxMcpTestRunner
 
     private static void RecordError(string message)
     {
-        string path = Get("ResultPath");
+        string path = GetOwnedResultPath();
         if (string.IsNullOrEmpty(path))
         {
             return;
@@ -380,7 +393,7 @@ public static class DxMcpTestRunner
 
         public void RunFinished(ITestResultAdaptor result)
         {
-            string path = Get("ResultPath");
+            string path = GetOwnedResultPath();
             if (string.IsNullOrEmpty(path))
             {
                 return;
@@ -485,6 +498,8 @@ public static class DxMcpTestRunner
         public SceneState[] scenes = Array.Empty<SceneState>();
         public string runGuid = "";
         public string resultPath = "";
+        public string ownedResultPath = "";
+        public string legacyObserverResultPath = "";
         public string frameworkErrors = "";
     }
 

--- a/scripts/mcp/DxMcpTestRunner.cs.txt.meta
+++ b/scripts/mcp/DxMcpTestRunner.cs.txt.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0397955a08c748aba54a576def8f9ead
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/scripts/mcp/README.md
+++ b/scripts/mcp/README.md
@@ -199,7 +199,9 @@ files are refused. The runner owns that path until passive framework cleanup end
 
 A raw `.status` of `done` means results are available. Accept success only when `.cleanup.status`
 is also `done`, GUID/path companions agree, and the result has positive passes with zero failures
-and inconclusive cases. Keep skips visible. Cleanup checks that the original scene paths, loaded
+and inconclusive cases. Keep skips visible. Unity can mark a suite `Skipped` when it contains
+both passing and ignored tests; failed or inconclusive suites still prevent acceptance.
+Cleanup checks that the original scene paths, loaded
 states and active scene were restored. A framework failure without RunFinished becomes an `error:`
 outcome after framework inactivity is proven. An `observation-error:` keeps ownership pending;
 continue observing the same job. Storage failures retain errors in SessionState and later copy

--- a/scripts/mcp/README.md
+++ b/scripts/mcp/README.md
@@ -150,6 +150,55 @@ every committed file back to its previous content and permissions. Rollback is i
 which matters on Windows where `rename` returns `EPERM` while an editor holds a config file open: a
 failed restore is collected and attached to the original error rather than replacing it.
 
+## Maintain the local Unity test runner
+
+The HTTP relay above transports requests. The maintained Editor test runner is
+[DxMcpTestRunner.cs.txt](./DxMcpTestRunner.cs.txt). Copy that file verbatim to the host project's
+`Assets/Editor/DxMcpTestRunner.cs`; the `.txt` source stays outside package compilation and CI
+test execution. The same source is compiled and exercised by `.docs-tests/UnityMcpBridgeTests.cs`.
+
+Before installing or replacing it, prove framework inactivity, idle editor flags, the main stage,
+and every loaded scene's saved, clean state through passive queries or a maintainer's inspection.
+`Unity_RunCommand` refreshes assets before executing code, so it cannot establish that preflight.
+Preserve any existing runner source and metadata outside `Assets` before replacement, and review
+local changes before overwriting them. Use an approved host Editor/filesystem flow when MCP cannot
+serve the required interaction; do not bypass its approval gate. Keep existing `.meta` identity
+when replacing an owned script. Refresh through `Assets/Refresh` only after the preflight, then
+verify the new assembly and unchanged scenes. Remove an old `DxMcpObservedTestRunner` only through
+the same reviewed flow after its ownership scope is empty.
+
+The runner writes a passive snapshot once per second to
+`Packages/com.wallstop-studios.dxmessaging/.artifacts/unity-mcp/editor-state.json`. Require a fresh
+`observedUtc`, no `observationError`, inactive framework/editor flags, `mainStage: true`, an empty
+`resultPath`, and saved, clean scenes before the next refresh or run. Compare the host clock when
+checking freshness. A missing, stale, or temporarily malformed snapshot proves no state. Read it
+again without invoking an asset-refreshing tool; never launch another test because observation
+timed out.
+
+`DxMcpTestRunner.Run(mode, assemblies, tests, categories, resultPath)` returns the exact GUID from
+`TestRunnerApi.Execute`. Filters use semicolon-separated strings. Use a fresh result path under
+`Packages/com.wallstop-studios.dxmessaging/.artifacts/unity-mcp/`; existing result or companion
+files are refused. The runner owns that path until passive framework cleanup ends.
+
+| Artifact                                        | Meaning                                                                             |
+| ----------------------------------------------- | ----------------------------------------------------------------------------------- |
+| `resultPath.run.json`                           | Exact Execute GUID and absolute result path; joins every companion to one job       |
+| `resultPath` and `.status`                      | Raw RunFinished result, including every result-tree node, output, failure and count |
+| `resultPath.errors.log`                         | Framework and result-writer errors, including errors after RunFinished              |
+| `resultPath.cleanup.json` and `.cleanup.status` | Passive terminal outcome, GUID, retained errors and restored-scene evidence         |
+
+A raw `.status` of `done` means results are available. Accept success only when `.cleanup.status`
+is also `done`, GUID/path companions agree, and the result has positive passes with zero failures
+and inconclusive cases. Keep skips visible. Cleanup checks that the original scene paths, loaded
+states and active scene were restored. A framework failure without RunFinished becomes an `error:`
+outcome after framework inactivity is proven. An `observation-error:` keeps ownership pending;
+continue observing the same job. Storage failures retain errors in SessionState and later copy
+them into the cleanup record when storage recovers.
+
+Validate an installation with consecutive focused runs and a deliberately failed framework setup.
+Retain each GUID, complete result and terminal cleanup record, and verify the original scene setup
+after each attempt. No waits, retries or extra Unity launches are added to CI by this local runner.
+
 ## Local overrides
 
 Set any of these in `.env.local` at the repository root, or pass the matching flag:

--- a/scripts/mcp/README.md
+++ b/scripts/mcp/README.md
@@ -167,10 +167,20 @@ when replacing an owned script. Refresh through `Assets/Refresh` only after the 
 verify the new assembly and unchanged scenes. Remove an old `DxMcpObservedTestRunner` only through
 the same reviewed flow after its ownership scope is empty.
 
+Inspect the existing `DxMcpTestRunner.ResultPath`, `DxMcpTestRunner.OwnedResultPath`, and
+`DxMcpObservedTestRunner.ResultPath` SessionState keys before replacement. Let an active run
+finish through its installed runner. If a legacy run is terminal and cannot clear its ownership,
+preserve its artifacts and record passive framework inactivity plus saved, clean scene state.
+Retire only the identified legacy key through the reviewed host recovery flow after checking
+that evidence; never erase a key merely to force a new run. The maintained callbacks require
+matching result and owner paths, so they cannot overwrite evidence left by an older runner or
+inconsistent ownership metadata.
+
 The runner writes a passive snapshot once per second to
 `Packages/com.wallstop-studios.dxmessaging/.artifacts/unity-mcp/editor-state.json`. Require a fresh
 `observedUtc`, no `observationError`, inactive framework/editor flags, `mainStage: true`, an empty
-`resultPath`, and saved, clean scenes before the next refresh or run. Compare the host clock when
+`resultPath`, `ownedResultPath`, and `legacyObserverResultPath`, and saved, clean scenes before
+the next refresh or run. Compare the host clock when
 checking freshness. A missing, stale, or temporarily malformed snapshot proves no state. Read it
 again without invoking an asset-refreshing tool; never launch another test because observation
 timed out.

--- a/scripts/mcp/README.md
+++ b/scripts/mcp/README.md
@@ -157,15 +157,21 @@ The HTTP relay above transports requests. The maintained Editor test runner is
 `Assets/Editor/DxMcpTestRunner.cs`; the `.txt` source stays outside package compilation and CI
 test execution. The same source is compiled and exercised by `.docs-tests/UnityMcpBridgeTests.cs`.
 
-Before installing or replacing it, prove framework inactivity, idle editor flags, the main stage,
-and every loaded scene's saved, clean state through passive queries or a maintainer's inspection.
-`Unity_RunCommand` refreshes assets before executing code, so it cannot establish that preflight.
-Preserve any existing runner source and metadata outside `Assets` before replacement, and review
-local changes before overwriting them. Use an approved host Editor/filesystem flow when MCP cannot
-serve the required interaction; do not bypass its approval gate. Keep existing `.meta` identity
-when replacing an owned script. Refresh through `Assets/Refresh` only after the preflight, then
-verify the new assembly and unchanged scenes. Remove an old `DxMcpObservedTestRunner` only through
-the same reviewed flow after its ownership scope is empty.
+Before installing or replacing it, prefer passive `GetState`, `GetPrefabStage`, `GetActive`, and
+a fresh observer snapshot for framework inactivity, idle editor flags, the main stage, and every
+loaded scene's saved, clean state. If the observer is absent or incomplete, available flags are
+idle/clean, and no test is known active, use a minimal `Unity_RunCommand` inspection for
+`TestRunnerApi.IsRunActive`, every open scene, and ownership keys. It refreshes before the snippet;
+this bootstrap cannot prove the prior refresh safe. Missing fields alone do not require user
+confirmation. Follow the [bootstrap procedure](../../.llm/skills/unity-mcp-test-loop/references/mcp-test-loop.md#bootstrap-without-a-complete-passive-observer).
+
+After inspection confirms inactivity and saved, clean scenes, preserve any existing runner source
+and metadata outside `Assets`, review local changes, and copy the maintained source through
+supported MCP editing. Keep existing `.meta` identity when replacing an owned script. Validate
+with `Unity_ValidateScript`, refresh through `Unity_ManageMenuItem` with `Assets/Refresh`, then
+verify the loaded assembly, fresh passive snapshots, and unchanged scenes. Respect tool approval
+gates; do not bypass a rejected operation through another transport. Remove an old
+`DxMcpObservedTestRunner` only after its ownership scope is empty and its source is backed up.
 
 Inspect the existing `DxMcpTestRunner.ResultPath`, `DxMcpTestRunner.OwnedResultPath`, and
 `DxMcpObservedTestRunner.ResultPath` SessionState keys before replacement. Let an active run
@@ -181,9 +187,10 @@ The runner writes a passive snapshot once per second to
 `observedUtc`, no `observationError`, inactive framework/editor flags, `mainStage: true`, an empty
 `resultPath`, `ownedResultPath`, and `legacyObserverResultPath`, and saved, clean scenes before
 the next refresh or run. Compare the host clock when
-checking freshness. A missing, stale, or temporarily malformed snapshot proves no state. Read it
-again without invoking an asset-refreshing tool; never launch another test because observation
-timed out.
+checking freshness. A missing, stale, or temporarily malformed snapshot proves no state. During
+a known or owned run, keep polling its files without invoking an asset-refreshing tool; never
+launch another test because observation timed out. Outside an active run, use the bootstrap
+procedure above if the observer is absent or incomplete.
 
 `DxMcpTestRunner.Run(mode, assemblies, tests, categories, resultPath)` returns the exact GUID from
 `TestRunnerApi.Execute`. Filters use semicolon-separated strings. Use a fresh result path under

--- a/scripts/unity/__tests__/editor-process-watchdog.test.ps1
+++ b/scripts/unity/__tests__/editor-process-watchdog.test.ps1
@@ -1,0 +1,187 @@
+#!/usr/bin/env pwsh
+# Exercise the maintained process owner with real portable child executables.
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$runner = Join-Path (Split-Path -Parent $PSScriptRoot) 'run-ci-tests.ps1'
+$tokens = $null
+$errors = $null
+$ast = [System.Management.Automation.Language.Parser]::ParseFile($runner, [ref]$tokens, [ref]$errors)
+if (@($errors).Count) { throw ($errors.Message -join '; ') }
+foreach ($definition in $ast.EndBlock.Statements) {
+    if ($definition -is [System.Management.Automation.Language.FunctionDefinitionAst]) {
+        Invoke-Expression $definition.Extent.Text
+    }
+}
+# These fixtures contain no compiler diagnostics or native crash codes.
+$script:CatastrophicPatterns = @()
+$script:NativeExitCodeDescriptions = @{}
+$fixture = Join-Path ([System.IO.Path]::GetTempPath()) ("dxm-editor-watchdog-" + [guid]::NewGuid().ToString('N'))
+$pwsh = (Get-Process -Id $PID).Path
+$terminal = 'Test run completed. Exiting with code 0 (Ok). Run completed.'
+try {
+    New-Item -ItemType Directory -Path $fixture | Out-Null
+    foreach ($case in @('normal', 'shutdown', 'stderr-shutdown', 'lookalike', 'failed-exit')) {
+        $scriptPath = Join-Path $fixture "$case.ps1"
+        $logPath = Join-Path $fixture "$case.log"
+        $body = switch ($case) {
+            'normal' { "1..64 | ForEach-Object { [Console]::Out.WriteLine(('o' * 2048)); [Console]::Error.WriteLine(('e' * 2048)) }; [Console]::Out.WriteLine('$terminal'); [Console]::Error.WriteLine('stderr retained'); Write-Output 'stdout retained'; exit 0" }
+            'shutdown' { "Write-Output '$terminal'; Wait-Event -Timeout 30 | Out-Null" }
+            'stderr-shutdown' { "[Console]::Error.WriteLine('$terminal'); Wait-Event -Timeout 30 | Out-Null" }
+            'lookalike' { "Write-Output 'prefix $terminal'; Wait-Event -Timeout 2 | Out-Null; exit 7" }
+            'failed-exit' { "Write-Output '$terminal'; exit 7" }
+        }
+        [System.IO.File]::WriteAllText($scriptPath, $body)
+        $timer = [System.Diagnostics.Stopwatch]::StartNew()
+        $exitCode = Invoke-UnityEditor -EditorPath $pwsh `
+            -Arguments @('-NoLogo', '-NoProfile', '-File', $scriptPath) `
+            -Label $case -LogPath $logPath -TimeoutSeconds 15 -ShutdownTimeoutSeconds 1
+        $timer.Stop()
+        $expected = switch ($case) { 'normal' { 0 } 'shutdown' { 124 } 'stderr-shutdown' { 124 } default { 7 } }
+        if ($exitCode -ne $expected) { throw "$case returned $exitCode instead of $expected" }
+        if ($case -in @('shutdown', 'stderr-shutdown') -and $timer.Elapsed.TotalSeconds -ge 10) {
+            throw 'Completed work waited for the total timeout instead of the shutdown deadline.'
+        }
+        $log = Get-Content -LiteralPath $logPath -Raw
+        if ($case -eq 'normal' -and ($log -notmatch 'stderr retained' -or $log -notmatch 'stdout retained')) {
+            throw 'The process owner lost a redirected stream.'
+        }
+    }
+
+    $childScript = Join-Path $fixture 'child-tree.ps1'
+    $treePidPath = Join-Path $fixture 'tree-child.pid'
+    [System.IO.File]::WriteAllText($childScript, @'
+param([string]$PidPath)
+$start = [System.Diagnostics.ProcessStartInfo]::new()
+$start.FileName = (Get-Process -Id $PID).Path
+$start.Arguments = '-NoLogo -NoProfile -Command "Wait-Event -Timeout 30 | Out-Null"'
+$start.UseShellExecute = $false
+$child = [System.Diagnostics.Process]::Start($start)
+[IO.File]::WriteAllText($PidPath, [string]$child.Id)
+Write-Output "child-pid=$($child.Id)"
+Write-Output 'Test run completed. Exiting with code 0 (Ok). Run completed.'
+Wait-Event -Timeout 30 | Out-Null
+'@)
+    $treeLog = Join-Path $fixture 'child-tree.log'
+    try {
+        $treeExit = Invoke-UnityEditor -EditorPath $pwsh `
+            -Arguments @('-NoLogo', '-NoProfile', '-File', $childScript, '-PidPath', $treePidPath) `
+            -Label 'shutdown process tree' -LogPath $treeLog -TimeoutSeconds 15 -ShutdownTimeoutSeconds 1
+        $treeText = Get-Content -LiteralPath $treeLog -Raw
+        if ($treeExit -ne 124 -or $treeText -notmatch 'child-pid=(\d+)') { throw 'Child-tree fixture did not run.' }
+        $childProcess = Get-Process -Id ([int]$Matches[1]) -ErrorAction SilentlyContinue
+        if ($childProcess) {
+            try {
+                if (-not $childProcess.HasExited) { throw 'Shutdown left its child process alive.' }
+            } finally { $childProcess.Dispose() }
+        }
+    } finally {
+        if (Test-Path -LiteralPath $treePidPath) {
+            $childProcess = Get-Process -Id ([int][IO.File]::ReadAllText($treePidPath)) -ErrorAction SilentlyContinue
+            if ($childProcess) {
+                try {
+                    if (-not $childProcess.HasExited) { $childProcess.Kill($true) }
+                    if (-not $childProcess.WaitForExit(5000)) { throw 'Child-tree fixture cleanup did not exit.' }
+                } finally { $childProcess.Dispose() }
+            }
+        }
+    }
+
+    # A parent that exits before its pipe-holding child cannot be tree-killed by
+    # walking the exited parent. Match ensure-editor's existing nonretryable policy.
+    $orphanScript = Join-Path $fixture 'orphan-parent.ps1'
+    $orphanPidPath = Join-Path $fixture 'orphan-child.pid'
+    $orphanSource = @'
+param([string]$PidPath)
+$start = [System.Diagnostics.ProcessStartInfo]::new()
+$start.FileName = (Get-Process -Id $PID).Path
+$start.Arguments = '-NoLogo -NoProfile -Command "Wait-Event -Timeout 30 | Out-Null"'
+$start.UseShellExecute = $false
+$child = [System.Diagnostics.Process]::Start($start)
+[IO.File]::WriteAllText($PidPath, [string]$child.Id)
+Write-Output 'Test run completed. Exiting with code 0 (Ok). Run completed.'
+exit 0
+'@
+    [System.IO.File]::WriteAllText($orphanScript, $orphanSource)
+    $orphanLog = Join-Path $fixture 'orphan.log'
+    $safetyFailure = $null
+    $orphanExit = $null
+    $orphanClock = [Diagnostics.Stopwatch]::StartNew()
+    try {
+        $orphanExit = Invoke-UnityEditor -EditorPath $pwsh `
+            -Arguments @('-NoLogo', '-NoProfile', '-File', $orphanScript, '-PidPath', $orphanPidPath) `
+            -Label 'exited parent with inherited pipe' -LogPath $orphanLog `
+            -TimeoutSeconds 15 -ShutdownTimeoutSeconds 1
+    } catch {
+        $safetyFailure = $_.Exception
+    } finally {
+        $orphanClock.Stop()
+        # Only this fixture owns this child; production must not discover unrelated
+        # editor processes by name or broaden termination beyond its known tree.
+        if (Test-Path -LiteralPath $orphanPidPath) {
+            $orphanProcess = Get-Process -Id ([int][IO.File]::ReadAllText($orphanPidPath)) -ErrorAction SilentlyContinue
+            if ($orphanProcess) {
+                try {
+                    if (-not $orphanProcess.HasExited) { $orphanProcess.Kill($true) }
+                    if (-not $orphanProcess.WaitForExit(5000)) { throw 'Orphan fixture cleanup did not exit.' }
+                } finally { $orphanProcess.Dispose() }
+            }
+        }
+    }
+    if ($orphanClock.Elapsed.TotalSeconds -ge 12) { throw 'Inherited-pipe cleanup exceeded its bounded deadline.' }
+    if ($null -ne $safetyFailure) {
+        if ($safetyFailure.Message -notmatch 'safe process-tree termination could not be confirmed' -or
+            -not $safetyFailure.Data['DxMessagingNonRetryable']) {
+            throw "Inherited-pipe failure lost its nonretryable classification: $safetyFailure"
+        }
+        if (-not (Test-Path -LiteralPath $orphanLog)) { throw 'Inherited-pipe failure lost its diagnostic log.' }
+    } elseif (-not $IsWindows -or $orphanExit -ne 0) {
+        throw 'Inherited-pipe orphan was accepted as confirmed tree cleanup.'
+    }
+    # Windows may create independent console handles instead of inheriting the
+    # parent's redirected pipes, as in the existing provisioning heartbeat fixture.
+
+    # EOF is independent of process exit. Close both OS descriptors and continue
+    # past the old five-second reap window; the total deadline still owns the run.
+    $node = (Get-Command node -ErrorAction Stop).Source
+    $closedStreams = Invoke-ProcessWithTreeKillTimeout -FilePath $node `
+        -Arguments @('-e', "const fs = require('node:fs'); fs.closeSync(1); fs.closeSync(2); setTimeout(() => process.exit(7), 6000)") `
+        -Label 'closed output with live process' -LogPath (Join-Path $fixture 'closed-streams.log') -TimeoutSeconds 15
+    if ($closedStreams.TimedOut -or $closedStreams.ExitCode -ne 7) {
+        throw 'Closing output streams caused premature process termination.'
+    }
+
+    # No terminal signal: use the total deadline, preserving the incomplete-run failure.
+    $result = Invoke-ProcessWithTreeKillTimeout -FilePath $pwsh `
+        -Arguments @('-NoLogo', '-NoProfile', '-Command', 'Wait-Event -Timeout 30 | Out-Null') `
+        -Label 'incomplete work' -LogPath (Join-Path $fixture 'incomplete.log') -TimeoutSeconds 1
+    if (-not $result.TimedOut -or $result.CompletionObserved -or $result.ExitCode -ne 124) {
+        throw 'Incomplete work must remain a timed-out failure without a completion signal.'
+    }
+    if (Get-Process -Id $result.ProcessId -ErrorAction SilentlyContinue) {
+        throw 'The timed-out process is still alive.'
+    }
+
+    # A forced exit never manufactures a passing result; exercise the real validator.
+    $resultsPath = Join-Path $fixture 'results.xml'
+    foreach ($case in @('missing', 'malformed', 'empty', 'failed', 'passed')) {
+        if (Test-Path -LiteralPath $resultsPath) { Remove-Item -LiteralPath $resultsPath }
+        $xml = switch ($case) {
+            'malformed' { '<test-run' }
+            'empty' { '<test-run total="0" passed="0" failed="0" skipped="0" />' }
+            'failed' { '<test-run total="1" passed="0" failed="1" skipped="0" />' }
+            'passed' { '<test-run total="1" passed="1" failed="0" skipped="0" />' }
+        }
+        if ($null -ne $xml) { [System.IO.File]::WriteAllText($resultsPath, [string]$xml) }
+        $rejected = $false
+        try {
+            Test-NUnitResults -Path $resultsPath -Label $case -UnityExitCode 124
+        } catch {
+            $rejected = $true
+            if ($case -eq 'passed') { throw }
+        }
+        if ($rejected -ne ($case -ne 'passed')) { throw "$case had the wrong artifact verdict." }
+    }
+    Write-Host 'Editor watchdog and result-validation cases passed.'
+} finally {
+    Remove-Item -LiteralPath $fixture -Recurse -Force
+}

--- a/scripts/unity/__tests__/editor-process-watchdog.test.ps1.meta
+++ b/scripts/unity/__tests__/editor-process-watchdog.test.ps1.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: dda374d556194e0bb7636c5d7a1af390
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/scripts/unity/run-ci-tests.ps1
+++ b/scripts/unity/run-ci-tests.ps1
@@ -4560,10 +4560,10 @@ function Invoke-ProcessWithTreeKillTimeout {
     # System.Diagnostics.Process + ProcessStartInfo, drains BOTH stdout and stderr
     # from a MAIN-THREAD ReadLineAsync poll loop (live echo via Write-Host + Tee to
     # $LogPath), enforces an absolute UTC deadline, and on a breach $proc.Kill($true)
-    # tree-kills the whole process tree (the Unity editor build spawns child
-    # processes -- IL2CPP/bee -- and the player may too, so a bare Kill() would orphan
-    # them). The process is held in a try/finally that kills it on ANY throw between
-    # launch and reap, so a pwsh cancellation cannot leave an orphaned editor/player.
+    # requests termination of the process tree (Unity builds spawn IL2CPP/bee).
+    # A parent that already exited cannot own a reparented descendant: fail closed
+    # in that case instead of treating a passing result as proof of safe cleanup.
+    # The try/finally also requests termination on exceptions before reap.
     #
     # WHY a Process and NOT `& <exe>`: the call operator cannot be interrupted -- a
     # hung child runs until the whole job is killed. WHY the main-thread poll loop:
@@ -4584,6 +4584,8 @@ function Invoke-ProcessWithTreeKillTimeout {
         [int]$TimeoutSeconds = 1800,
         [Parameter(Mandatory = $true)][string]$LogPath,
         [Parameter(Mandatory = $true)][string]$Label,
+        [string]$CompletionPattern,
+        [ValidateRange(1, 300)][int]$ShutdownTimeoutSeconds = 30,
         [ValidateRange(0, [long]::MaxValue)][long]$ProcessorAffinityMask = 0,
         [ValidateSet('Normal', 'AboveNormal', 'High')][string]$PriorityClass = 'Normal'
     )
@@ -4623,6 +4625,9 @@ function Invoke-ProcessWithTreeKillTimeout {
     $proc = $null
     $exit = -1
     $timedOut = $false
+    $terminationUnconfirmed = $false
+    $completionObserved = $false
+    $shutdownDeadline = [DateTime]::MaxValue
     $reaped = $false
     $processId = $null
     $observedProcessorAffinityMask = $null
@@ -4699,7 +4704,9 @@ function Invoke-ProcessWithTreeKillTimeout {
 
         $oDone = $false
         $eDone = $false
-        while (-not ($oDone -and $eDone)) {
+        # EOF alone is not process completion: an editor can close both streams
+        # before finishing its work. Keep its original deadlines until it exits.
+        while (-not ($oDone -and $eDone) -or -not $proc.HasExited) {
             $progressed = $false
 
             if (-not $oDone -and $oTask.Wait(0)) {
@@ -4709,6 +4716,10 @@ function Invoke-ProcessWithTreeKillTimeout {
                 } else {
                     Write-Host $line
                     $buffer.Add([string]$line)
+                    if (-not $completionObserved -and $CompletionPattern -and $line -cmatch $CompletionPattern) {
+                        $completionObserved = $true
+                        $shutdownDeadline = [DateTime]::UtcNow.AddSeconds($ShutdownTimeoutSeconds)
+                    }
                     $oTask = $outReader.ReadLineAsync()
                 }
                 $progressed = $true
@@ -4721,18 +4732,32 @@ function Invoke-ProcessWithTreeKillTimeout {
                 } else {
                     Write-Host $line
                     $buffer.Add([string]$line)
+                    if (-not $completionObserved -and $CompletionPattern -and $line -cmatch $CompletionPattern) {
+                        $completionObserved = $true
+                        $shutdownDeadline = [DateTime]::UtcNow.AddSeconds($ShutdownTimeoutSeconds)
+                    }
                     $eTask = $errReader.ReadLineAsync()
                 }
                 $progressed = $true
             }
 
-            if ([DateTime]::UtcNow -ge $deadline) {
-                # HUNG (or a quick-exit child whose grandchild still holds the pipe
-                # open, so EOF never arrives): tree-kill the WHOLE process tree.
+            # Completion observed on this iteration wins an expired deadline.
+            # Otherwise the final EOFs could falsely classify an exited root as orphaned.
+            if ($oDone -and $eDone -and $proc.HasExited) { break }
+
+            if ([DateTime]::UtcNow -ge $deadline -or [DateTime]::UtcNow -ge $shutdownDeadline) {
+                # A quick-exit parent cannot identify a reparented descendant that
+                # still holds a pipe. Mirror ensure-editor.ps1: preserve diagnostics
+                # but never report this as confirmed tree cleanup or allow retry.
                 $timedOut = $true
+                $terminationUnconfirmed = [bool]$proc.HasExited
+                if ($completionObserved -and $shutdownDeadline -le $deadline) {
+                    Write-Host "::warning::$Label did not close its process/output streams within $ShutdownTimeoutSeconds seconds of its terminal message; requesting process-tree termination. Results can be accepted only after confirmed cleanup."
+                }
                 try {
                     $proc.Kill($true)
                 } catch {
+                    $terminationUnconfirmed = $true
                     try { $proc.Kill() } catch { }
                 }
                 break
@@ -4745,19 +4770,33 @@ function Invoke-ProcessWithTreeKillTimeout {
 
         # Reap so ExitCode is valid; bounded so a stuck reap cannot hang the harness.
         $reaped = $proc.WaitForExit(5000)
+        if (-not $reaped) { $terminationUnconfirmed = $true }
 
-        # Drain any reads that completed during/after the kill so no pre-kill output
-        # is dropped.
-        foreach ($pending in @($oTask, $eTask)) {
+        # Drain buffered output to EOF within one bounded window per stream.
+        # A parent can exit between HasExited and Kill(true); pipes still open
+        # after the reap expose that race instead of falsely confirming cleanup.
+        foreach ($stream in @(
+            @{ Reader = $outReader; Pending = $oTask; Done = $oDone },
+            @{ Reader = $errReader; Pending = $eTask; Done = $eDone }
+        )) {
+            $drainDeadline = [DateTime]::UtcNow.AddSeconds(2)
             try {
-                if ($pending.Wait(2000) -and $null -ne $pending.Result) {
-                    $line = $pending.Result
-                    Write-Host $line
-                    $buffer.Add([string]$line)
+                while (-not $stream.Done) {
+                    $remaining = [int][Math]::Ceiling(($drainDeadline - [DateTime]::UtcNow).TotalMilliseconds)
+                    if ($remaining -le 0 -or -not $stream.Pending.Wait($remaining)) { break }
+                    $line = $stream.Pending.Result
+                    if ($null -eq $line) {
+                        $stream.Done = $true
+                    } else {
+                        Write-Host $line
+                        $buffer.Add([string]$line)
+                        $stream.Pending = $stream.Reader.ReadLineAsync()
+                    }
                 }
             } catch {
-                # A faulted/cancelled read on a killed pipe carries nothing to add.
+                # Faulted reads cannot prove that inherited handles closed.
             }
+            if (-not $stream.Done) { $terminationUnconfirmed = $true }
         }
 
         if ($timedOut) {
@@ -4777,10 +4816,15 @@ function Invoke-ProcessWithTreeKillTimeout {
         $buffer.Add($message)
         $exit = -1
     } finally {
-        # If we are unwinding on a throw/cancellation and the process is still alive,
-        # tree-kill it so a cancelled step never orphans the editor/player.
-        if ($proc -and -not $proc.HasExited) {
-            try { $proc.Kill($true) } catch { }
+        # Bound exception-path cleanup too. A failed tree request or reap must not
+        # be hidden by a valid results file or start another UPM attempt.
+        if ($proc -and $null -ne $processId -and -not $proc.HasExited) {
+            try {
+                $proc.Kill($true)
+                if (-not $proc.WaitForExit(5000)) { $terminationUnconfirmed = $true }
+            } catch {
+                $terminationUnconfirmed = $true
+            }
         }
         if ($proc) { $proc.Dispose() }
     }
@@ -4794,9 +4838,18 @@ function Invoke-ProcessWithTreeKillTimeout {
         Write-Host "::warning::Could not persist '$Label' log to ${LogPath}: $($_.Exception.Message)"
     }
 
+    if ($terminationUnconfirmed) {
+        $message = "Process watchdog '$Label': safe process-tree termination could not be confirmed. A parent may have exited while a descendant retained its output pipe, or termination/reap failed. Preserved log: $LogPath. Do not retry while a process may still own the project."
+        Write-Host "::error::$message"
+        $exception = [System.InvalidOperationException]::new($message)
+        $exception.Data['DxMessagingNonRetryable'] = $true
+        throw $exception
+    }
+
     return @{
         ExitCode = $exit
         TimedOut = [bool]$timedOut
+        CompletionObserved = [bool]$completionObserved
         ProcessId = $processId
         ProcessorAffinityMask = $observedProcessorAffinityMask
         ProcessorAffinityError = $processorAffinityError
@@ -4937,33 +4990,30 @@ function Invoke-UnityEditor {
         [Parameter(Mandatory = $true)][string]$EditorPath,
         [Parameter(Mandatory = $true)][string[]]$Arguments,
         [Parameter(Mandatory = $true)][string]$Label,
-        [Parameter(Mandatory = $true)][string]$LogPath
+        [Parameter(Mandatory = $true)][string]$LogPath,
+        # The shortest caller has a 30-minute step and at most two UPM attempts.
+        # Ten minutes per attempt leaves ten minutes for setup and license cleanup.
+        [ValidateRange(0, [int]::MaxValue)][int]$TimeoutSeconds = 600,
+        [ValidateRange(1, 300)][int]$ShutdownTimeoutSeconds = 30
     )
 
-    # Unity.exe is a Windows GUI-subsystem binary. PowerShell's `&` launches such
-    # executables ASYNCHRONOUSLY: it does NOT wait for them and does NOT set
-    # $LASTEXITCODE. Callers therefore pass `-logFile -` (Unity logs to stdout) so
-    # that consuming the process's stdout via the pipeline forces PowerShell to
-    # BLOCK until the process exits AND reliably sets $LASTEXITCODE. Tee-Object both
-    # streams the log live to the CI console and persists it to $LogPath.
-    $logDir = Split-Path -Parent $LogPath
-    if ($logDir -and -not (Test-Path -LiteralPath $logDir -PathType Container)) {
-        New-Item -ItemType Directory -Force -Path $logDir | Out-Null
-    }
-
-    Write-Host "::group::$Label"
-    Write-Host "`"$EditorPath`" $($Arguments -join ' ')"
-    # Stream Unity's output LIVE to the console AND persist it to $LogPath, but route
-    # it to the HOST (Out-Host) so it never enters this function's success stream:
-    # the function RETURNS the exit code, and a bare `| Tee-Object` would otherwise
-    # collect every streamed log line into the caller's `$x = Invoke-UnityEditor`
-    # capture (turning the return value into an Object[] of log lines + the code).
-    # Consuming the process's stdout via the pipeline still forces PowerShell to
-    # BLOCK until the GUI-subsystem Unity.exe exits and to set $LASTEXITCODE.
-    & $EditorPath @Arguments 2>&1 | Tee-Object -FilePath $LogPath | Out-Host
-    $exitCode = $LASTEXITCODE
+    # A native pipeline can remain blocked in shutdown (or on a descendant's
+    # inherited stdout) after NUnit has completed. Own the process and both pipes
+    # so the harness returns before the outer GitHub step timeout cancels cleanup.
+    # Exact, case-sensitive whole-line terminal messages start a 30-second shutdown
+    # deadline. Results written earlier do not start it: framework cleanup still runs.
+    # The existing caller validates the fresh result/marker even after a forced exit.
+    $completionPattern = '^(?:Test run completed\. Exiting with code [0-9]+ \([^\r\n]+\)\. Run completed\.|Batchmode quit successfully invoked - shutting down!)$'
+    $processResult = Invoke-ProcessWithTreeKillTimeout `
+        -FilePath $EditorPath `
+        -Arguments $Arguments `
+        -TimeoutSeconds $TimeoutSeconds `
+        -ShutdownTimeoutSeconds $ShutdownTimeoutSeconds `
+        -CompletionPattern $completionPattern `
+        -LogPath $LogPath `
+        -Label $Label
+    $exitCode = $processResult.ExitCode
     Clear-NonFatalNativeExitCode -Context $Label
-    Write-Host "::endgroup::"
     if ($exitCode -ne 0) {
         # Proactively surface catastrophic compile-time failure patterns
         # (PrecompiledAssemblyException, CompilationFailedException, CS####,
@@ -5109,8 +5159,8 @@ function Write-UnityBenignExitWarning {
         [string]$LogPath
     )
 
-    $cause = if ($TimedOut) {
-        'was tree-killed by the watchdog (likely a deferred Application.Quit)'
+    $cause = if ($TimedOut -or $ExitCode -eq 124) {
+        'did not finish process/output-stream shutdown before the watchdog deadline'
     } else {
         $description = Get-NativeExitCodeDescription -ExitCode $ExitCode
         $crashNote = if (Test-NativeCrashExitCode -ExitCode $ExitCode) { ' (a native crash code)' } else { '' }
@@ -6787,6 +6837,7 @@ try {
             -EditorPath $UnityEditorPath `
             -Arguments $configureArgs `
             -Label "Configure $configurationScope IL2CPP project" `
+            -TimeoutSeconds (Get-StandaloneBuildTimeoutSeconds) `
             -LogPath $configureLogPath
         # The configurator has run; drop the marker-path env var so it cannot be
         # inherited by the later build/player child processes (only Apply reads it,


### PR DESCRIPTION
## Why

Unity 2021 passed 941 tests, then waited 90 minutes during shutdown (#548).
The local bridge lost run identity and reported completion before framework cleanup (#544).
It also risked overwriting legacy evidence and rejected successful runs containing ignored tests.

## What changed

- Bound editor shutdown after exact terminal messages. Reject unconfirmed cleanup and preserve logs.
- Preserve the existing standalone build and configuration timeout policy.
- Maintain bridge source, run identity, full result trees, framework errors, and passive cleanup records.
- Preserve legacy evidence and accept passing/skipped results while rejecting failed or inconclusive suites.
- Allow local observer bootstrap when passive fields are missing. Preserve actual tool approval boundaries.
- Report allocation counts without repeating or weakening the measured window (#545).
- Replay host activation and owner token cleanup across all message kinds (#509).
- Move subprocess tests out of fast pre-push checks. Full CI retains every case.

## How we know

- [Local Unity acceptance](https://github.com/Ambiguous-Interactive/DxMessaging/issues/544#issuecomment-5563038053) verifies installation, deliberate framework failure, and consecutive 18-case PlayMode runs.
- All 24 native allocation-probe cases pass, including four new diagnostics. Every run restores the original scene.
- All 658 documentation tests pass, including 41 bridge cases. All 1,206 local script tests pass.
- [Native shutdown evidence](https://github.com/Ambiguous-Interactive/DxMessaging/issues/548#issuecomment-5562146120) shows the reproduced hang contained after 30 seconds. The complete EditMode step takes 77 seconds.
- [Unity CI at `6b4fd13b`](https://github.com/Ambiguous-Interactive/DxMessaging/actions/runs/34062590784) passes all twelve editor/mode legs. All 18 host cases pass in each of eight runtime legs.
- [Performance CI](https://github.com/Ambiguous-Interactive/DxMessaging/actions/runs/34062590810) passes with matching canonical profiles. All 48 supported comparison rows are present.
- Artifact audit verifies 21 digests and 15 native result files, with no failed or inconclusive nodes.
- Formatting, spelling, repository checks, and independent implementation reviews pass.

The final skill-only commit is `97fae66b`; its CI result is pending.

## Follow-up

The original allocation failure (#545) and isolated GenerateOnly timeout (#549) remain unattributed.
Broader destruction and scene-unload replay remains open (#509).
The retired observer remains idle because MCP cannot serve its removal approval interaction.

Closes #548.
Closes #544.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Unity CI process lifecycle and shutdown semantics where incorrect behavior could mask hangs or accept bad runs; local MCP runner ownership also gates when tests may start.
> 
> **Overview**
> Adds a **maintained** `DxMcpTestRunner` source (`.txt` in-repo, copied to the host Editor) that owns run GUIDs, refuses stale evidence, writes full result trees plus `.cleanup.*` sidecars, captures framework errors, and emits passive `editor-state.json` snapshots. **41** dotnet bridge tests compile that source with Unity doubles; agent docs describe dual polling (raw `.status` vs cleanup), bootstrap when the observer is incomplete, and installation from `scripts/mcp/README.md`.
> 
> **CI harness:** `Invoke-UnityEditor` no longer pipes Unity through PowerShell; it uses the tree-kill watchdog with terminal-message shutdown deadlines, fail-closed when process-tree termination cannot be confirmed, and new `editor-process-watchdog.test.ps1`. Heavy subprocess checks move from fast `unity-perf.test.js` into `run-ci-tests-enter-play-mode.test.js`.
> 
> **Product tests:** `AllocationAssertions` surfaces measured GC counts on failure without remeasuring; allocation-probe contract tests lock that in. `DifferentialHostTraceTests` replays bus traces through real `MessagingComponent` hosts via extended `MessageBusTraceAdapter` hooks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97fae66b0925b1a2d63108369d4101d91448bf8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->