### PR TITLE
Strengthen handle replay and performance evidence checks

### DIFF
--- a/Tests/Runtime/Core/DifferentialBusTraceTests.cs
+++ b/Tests/Runtime/Core/DifferentialBusTraceTests.cs
@@ -348,7 +348,7 @@ namespace DxMessaging.Tests.Runtime.Core
             BusTraceSequence minimal = DifferentialBusTrace.Shrink(sequence, EvaluateFinal);
             Assert.That(minimal.Operations.Count, Is.EqualTo(1), report);
             Assert.That(minimal.Operations[0].Kind, Is.EqualTo(BusTraceOperationKind.Emit), report);
-            Assert.That(minimal.Version, Is.EqualTo(8), report);
+            Assert.That(minimal.Version, Is.EqualTo(sequence.Version), report);
             StringAssert.Contains("observationSchema=2", mismatch.BuildReport(sequence), report);
         }
 
@@ -407,7 +407,7 @@ namespace DxMessaging.Tests.Runtime.Core
 
         [Test]
         public void GeneratorVersionPinsKnownSeedPrefix(
-            [Values(1, 2, 3, 4, 5, 6, 7, 8)] int version
+            [Values(1, 2, 3, 4, 5, 6, 7, 8, 9)] int version
         )
         {
             BusTraceSequence sequence = DifferentialBusTrace.Generate(
@@ -418,11 +418,11 @@ namespace DxMessaging.Tests.Runtime.Core
             );
             Assert.That(
                 BusTraceSequence.GeneratorVersion,
-                Is.EqualTo(8),
+                Is.EqualTo(9),
                 "Changing generation requires a new version and a reviewed replay fixture."
             );
             CollectionAssert.AreEqual(
-                version == 8
+                version >= 8
                         ? new[]
                         {
                             "Register(token=0,context=0,value=0,priority=0)[handleSlot=0,sourceHandleSlot=-1]",
@@ -966,6 +966,468 @@ namespace DxMessaging.Tests.Runtime.Core
                 Enum.GetValues(typeof(BusTraceOperationKind)),
                 kinds,
                 "Version eight must retain every existing operation and add duplicates/copies."
+            );
+        }
+
+        [Test]
+        public void ExplicitHandleCallbackActionsPreserveReusedIdentitiesAndShrinkMutants(
+            [ValueSource(typeof(MessageScenarios), nameof(MessageScenarios.AllKinds))]
+                MessageScenario scenario,
+            [Values(
+                "EmitWithReset",
+                "EmitWithThrow",
+                "EmitWithDisable",
+                "EmitWithHandlerActive",
+                "EmitNested"
+            )]
+                string action
+        )
+        {
+            BusTraceOperationKind kind = (BusTraceOperationKind)
+                Enum.Parse(typeof(BusTraceOperationKind), action);
+            BusTraceSequence sequence = new(
+                scenario,
+                509,
+                new[]
+                {
+                    new BusTraceOperation(BusTraceOperationKind.Register, handleSlot: 0),
+                    new BusTraceOperation(
+                        BusTraceOperationKind.DuplicateRegistration,
+                        handleSlot: 1,
+                        sourceHandleSlot: 0
+                    ),
+                    new BusTraceOperation(BusTraceOperationKind.Remove, handleSlot: 0),
+                    new BusTraceOperation(
+                        BusTraceOperationKind.Register,
+                        priority: 1,
+                        handleSlot: 0
+                    ),
+                    new BusTraceOperation(
+                        BusTraceOperationKind.CopyHandle,
+                        handleSlot: 2,
+                        sourceHandleSlot: 0
+                    ),
+                    new BusTraceOperation(
+                        BusTraceOperationKind.Register,
+                        token: 1,
+                        context: 1,
+                        kindOffset: 1,
+                        handleSlot: 3
+                    ),
+                    new BusTraceOperation(
+                        kind,
+                        value: 11,
+                        nestedToken: kind == BusTraceOperationKind.EmitNested ? 1 : 0,
+                        depth: kind == BusTraceOperationKind.EmitNested ? 10 : 0,
+                        handlerToken: kind == BusTraceOperationKind.EmitWithHandlerActive ? 1 : 0,
+                        handleSlot: 2,
+                        sourceHandleSlot: kind == BusTraceOperationKind.EmitNested ? 3 : -1
+                    ),
+                    new BusTraceOperation(BusTraceOperationKind.Disable),
+                    new BusTraceOperation(BusTraceOperationKind.Enable),
+                    new BusTraceOperation(BusTraceOperationKind.Emit, value: 17),
+                    new BusTraceOperation(BusTraceOperationKind.Remove, handleSlot: 2),
+                    new BusTraceOperation(BusTraceOperationKind.Remove, handleSlot: 2),
+                    new BusTraceOperation(BusTraceOperationKind.Emit, value: 19),
+                }
+            );
+            IReadOnlyList<BusTraceObservation> control = DifferentialBusTrace.Replay(
+                sequence,
+                item => CreateAdapter(item, false)
+            );
+            string report = $"[{scenario.Kind}] action={action}\n" + string.Join("\n", control);
+            CollectionAssert.AreEqual(
+                new[]
+                {
+                    "token=0,value=11,registration=0,callback=0",
+                    "token=0,value=11,registration=0,callback=1",
+                },
+                control[6].Callbacks.Take(2),
+                report
+            );
+            Assert.That(
+                control[6].Exception != null,
+                Is.EqualTo(kind == BusTraceOperationKind.EmitWithThrow),
+                report
+            );
+            CollectionAssert.AreEqual(
+                kind == BusTraceOperationKind.EmitWithThrow
+                    ? new[] { "token=0,value=17,registration=0,callback=0" }
+                    : new[]
+                    {
+                        "token=0,value=17,registration=0,callback=0",
+                        "token=0,value=17,registration=0,callback=1",
+                    },
+                control[9].Callbacks,
+                report
+            );
+            CollectionAssert.AreEqual(
+                new[] { "token=0,value=19,registration=0,callback=0" },
+                control[12].Callbacks,
+                report
+            );
+            Assert.That(
+                control.Where((_, index) => index != 6).All(item => item.Exception == null),
+                Is.True,
+                report
+            );
+            Assert.That(Evaluate(sequence, false), Is.Null, report);
+            BusTraceMismatch mismatch = EvaluateMutant(sequence, "explicit-callback");
+            Assert.That(mismatch, Is.Not.Null, report);
+            BusTraceSequence minimal = DifferentialBusTrace.Shrink(
+                sequence,
+                item => EvaluateMutant(item, "explicit-callback")
+            );
+            Assert.That(DifferentialBusTrace.IsValid(minimal), Is.True, report);
+            Assert.That(minimal.Operations.Count, Is.LessThan(sequence.Operations.Count), report);
+            Assert.That(minimal.Version, Is.EqualTo(9), report);
+            Assert.That(
+                EvaluateMutant(minimal, "explicit-callback")?.Category,
+                Is.EqualTo(mismatch.Category),
+                report
+            );
+            Assert.That(Evaluate(minimal, false), Is.Null, report);
+            for (int index = 0; index < minimal.Operations.Count; ++index)
+            {
+                List<BusTraceOperation> remaining = new(minimal.Operations);
+                remaining.RemoveAt(index);
+                BusTraceSequence deletion = new(scenario, minimal.Seed, remaining, minimal.Version);
+                Assert.That(
+                    !DifferentialBusTrace.IsValid(deletion)
+                        || EvaluateMutant(deletion, "explicit-callback")?.Category
+                            != mismatch.Category,
+                    Is.True,
+                    $"{report}; deletion={index}"
+                );
+            }
+        }
+
+        [Test]
+        public void ExplicitThrowCleanupLeavesDuplicateUsableAndStaleAliasCannotRearm(
+            [ValueSource(typeof(MessageScenarios), nameof(MessageScenarios.AllKinds))]
+                MessageScenario scenario
+        )
+        {
+            BusTraceSequence sequence = new(
+                scenario,
+                509,
+                new[]
+                {
+                    new BusTraceOperation(BusTraceOperationKind.Register, handleSlot: 0),
+                    new BusTraceOperation(
+                        BusTraceOperationKind.DuplicateRegistration,
+                        handleSlot: 1,
+                        sourceHandleSlot: 0
+                    ),
+                    new BusTraceOperation(
+                        BusTraceOperationKind.CopyHandle,
+                        handleSlot: 2,
+                        sourceHandleSlot: 1
+                    ),
+                    new BusTraceOperation(
+                        BusTraceOperationKind.EmitWithThrow,
+                        value: 11,
+                        handleSlot: 2
+                    ),
+                    new BusTraceOperation(
+                        BusTraceOperationKind.EmitWithThrow,
+                        value: 13,
+                        handleSlot: 2
+                    ),
+                    new BusTraceOperation(
+                        BusTraceOperationKind.EmitWithThrow,
+                        value: 17,
+                        handleSlot: 0
+                    ),
+                    new BusTraceOperation(BusTraceOperationKind.Remove, handleSlot: 0),
+                    new BusTraceOperation(BusTraceOperationKind.Register, handleSlot: 0),
+                    new BusTraceOperation(
+                        BusTraceOperationKind.EmitWithThrow,
+                        value: 19,
+                        handleSlot: 2
+                    ),
+                }
+            );
+            IReadOnlyList<BusTraceObservation> observations = DifferentialBusTrace.Replay(
+                sequence,
+                item => CreateAdapter(item, false)
+            );
+            string report = $"[{scenario.Kind}] " + string.Join("\n", observations);
+            for (int index = 0; index < observations.Count; ++index)
+            {
+                Assert.That(
+                    observations[index].Exception != null,
+                    Is.EqualTo(index == 3 || index == 5),
+                    $"{report}; operation={index}"
+                );
+            }
+            CollectionAssert.AreEqual(
+                new[] { "token=0,value=13,registration=0,callback=0" },
+                observations[4].Callbacks,
+                report
+            );
+            CollectionAssert.AreEqual(
+                new[] { "token=0,value=19,registration=0,callback=1" },
+                observations[8].Callbacks,
+                report
+            );
+            Assert.That(Evaluate(sequence, false), Is.Null, report);
+            BusTraceMismatch mismatch = EvaluateMutant(sequence, "explicit-cleanup");
+            Assert.That(mismatch, Is.Not.Null, report);
+            BusTraceSequence minimal = DifferentialBusTrace.Shrink(
+                sequence,
+                item => EvaluateMutant(item, "explicit-cleanup")
+            );
+            Assert.That(DifferentialBusTrace.IsValid(minimal), Is.True, report);
+            Assert.That(minimal.Operations.Count, Is.LessThan(sequence.Operations.Count), report);
+            Assert.That(
+                EvaluateMutant(minimal, "explicit-cleanup")?.Category,
+                Is.EqualTo(mismatch.Category),
+                report
+            );
+            Assert.That(Evaluate(minimal, false), Is.Null, report);
+        }
+
+        [Test]
+        public void ExplicitNestedHandlesAlternateAllKindsThroughDepthTen(
+            [ValueSource(typeof(MessageScenarios), nameof(MessageScenarios.AllKinds))]
+                MessageScenario scenario
+        )
+        {
+            foreach (int offset in new[] { 0, 1, 2 })
+            foreach (int depth in new[] { 1, 10 })
+            {
+                BusTraceSequence sequence = new(
+                    scenario,
+                    509,
+                    new[]
+                    {
+                        new BusTraceOperation(BusTraceOperationKind.Register, handleSlot: 0),
+                        new BusTraceOperation(
+                            BusTraceOperationKind.Register,
+                            token: 1,
+                            context: 1,
+                            kindOffset: offset,
+                            handleSlot: 1
+                        ),
+                        new BusTraceOperation(
+                            BusTraceOperationKind.CopyHandle,
+                            token: 1,
+                            handleSlot: 2,
+                            sourceHandleSlot: 1
+                        ),
+                        new BusTraceOperation(
+                            BusTraceOperationKind.EmitNested,
+                            value: 11,
+                            nestedToken: 1,
+                            depth: depth,
+                            handleSlot: 0,
+                            sourceHandleSlot: 2
+                        ),
+                        new BusTraceOperation(BusTraceOperationKind.Emit, value: 19),
+                    }
+                );
+                IReadOnlyList<BusTraceObservation> observations = DifferentialBusTrace.Replay(
+                    sequence,
+                    item => CreateAdapter(item, false)
+                );
+                string report =
+                    $"[{scenario.Kind}] offset={offset}, depth={depth}: "
+                    + string.Join("\n", observations);
+                Assert.That(observations.All(item => item.Exception == null), Is.True, report);
+                // A sibling on the same kind must not consume the selected trigger.
+                Assert.That(
+                    observations[3]
+                        .Callbacks.Any(item => item.StartsWith($"nested-enter:depth={depth - 1},")),
+                    Is.True,
+                    report
+                );
+                Assert.That(
+                    observations[3]
+                        .Callbacks.Any(item => item.StartsWith($"nested-enter:depth={depth},")),
+                    Is.False,
+                    report
+                );
+                Assert.That(
+                    observations[3].Callbacks.Count(item => item.StartsWith("nested-enter:")),
+                    Is.EqualTo(depth),
+                    report
+                );
+                Assert.That(
+                    observations[3].Callbacks.Count(item => item.StartsWith("nested-return:")),
+                    Is.EqualTo(depth),
+                    report
+                );
+                Assert.That(
+                    observations[4].Callbacks.All(item => !item.StartsWith("nested-")),
+                    Is.True,
+                    report
+                );
+                Assert.That(Evaluate(sequence, false), Is.Null, report);
+            }
+        }
+
+        [Test]
+        public void ExplicitCallbackValidityRequiresOwnedLiveTriggerAndNestedDependencies()
+        {
+            MessageScenario scenario = MessageScenario.Untargeted();
+            foreach (BusTraceOperationKind kind in Enum.GetValues(typeof(BusTraceOperationKind)))
+            {
+                if (!DifferentialBusTrace.IsCallbackAction(kind))
+                {
+                    continue;
+                }
+                BusTraceOperation register = new(
+                    BusTraceOperationKind.Register,
+                    token: 3,
+                    handleSlot: 0
+                );
+                BusTraceOperation nested = new(
+                    BusTraceOperationKind.Register,
+                    token: 2,
+                    handleSlot: 1
+                );
+                BusTraceOperation callback = new(
+                    kind,
+                    token: 3,
+                    handleSlot: 0,
+                    nestedToken: kind == BusTraceOperationKind.EmitNested ? 2 : 0,
+                    depth: kind == BusTraceOperationKind.EmitNested ? 1 : 0,
+                    sourceHandleSlot: kind == BusTraceOperationKind.EmitNested ? 1 : -1
+                );
+                BusTraceOperation[] valid = { register, nested, callback };
+                string report = string.Join(";", valid);
+                Assert.That(
+                    DifferentialBusTrace.IsValid(new(scenario, 509, valid)),
+                    Is.True,
+                    report
+                );
+                Assert.That(
+                    DifferentialBusTrace.IsValid(new(scenario, 509, valid, 8)),
+                    Is.False,
+                    report
+                );
+                foreach (
+                    BusTraceOperation[] invalid in new[]
+                    {
+                        new[] { callback },
+                        new[]
+                        {
+                            new BusTraceOperation(BusTraceOperationKind.Register, handleSlot: 0),
+                            nested,
+                            callback,
+                        },
+                        new[]
+                        {
+                            register,
+                            nested,
+                            new BusTraceOperation(
+                                BusTraceOperationKind.Remove,
+                                token: 3,
+                                handleSlot: 0
+                            ),
+                            callback,
+                        },
+                        new[]
+                        {
+                            register,
+                            nested,
+                            new BusTraceOperation(
+                                kind,
+                                token: 3,
+                                handleSlot: 0,
+                                sourceHandleSlot: 1
+                            ),
+                        },
+                    }
+                )
+                {
+                    Assert.That(
+                        DifferentialBusTrace.IsValid(new(scenario, 509, invalid)),
+                        Is.False,
+                        string.Join(";", invalid)
+                    );
+                }
+                if (kind == BusTraceOperationKind.EmitNested)
+                {
+                    Assert.That(
+                        DifferentialBusTrace.IsValid(
+                            new(scenario, 509, new[] { register, callback })
+                        ),
+                        Is.False,
+                        report
+                    );
+                    Assert.That(
+                        DifferentialBusTrace.IsValid(
+                            new(
+                                scenario,
+                                509,
+                                new[]
+                                {
+                                    register,
+                                    new BusTraceOperation(
+                                        BusTraceOperationKind.Register,
+                                        token: 1,
+                                        handleSlot: 1
+                                    ),
+                                    callback,
+                                }
+                            )
+                        ),
+                        Is.False,
+                        report
+                    );
+                }
+            }
+        }
+
+        [Test]
+        public void VersionNineGeneratesEveryExplicitCallbackActionDeterministically()
+        {
+            HashSet<BusTraceOperationKind> callbacks = new();
+            HashSet<BusTraceOperationKind> all = new();
+            for (uint seed = 0; seed < 32; ++seed)
+            {
+                BusTraceSequence sequence = DifferentialBusTrace.Generate(
+                    MessageScenario.Untargeted(),
+                    seed,
+                    256,
+                    9
+                );
+                Assert.That(DifferentialBusTrace.IsValid(sequence), Is.True, $"seed={seed}");
+                CollectionAssert.AreEqual(
+                    sequence.Operations,
+                    DifferentialBusTrace.Generate(sequence.Scenario, seed, 256, 9).Operations,
+                    $"seed={seed}"
+                );
+                foreach (BusTraceOperation operation in sequence.Operations)
+                {
+                    all.Add(operation.Kind);
+                    if (
+                        operation.HandleSlot >= 0
+                        && DifferentialBusTrace.IsCallbackAction(operation.Kind)
+                    )
+                    {
+                        callbacks.Add(operation.Kind);
+                    }
+                }
+            }
+            CollectionAssert.AreEquivalent(
+                Enum.GetValues(typeof(BusTraceOperationKind)),
+                all,
+                "Version nine retains the full operation vocabulary."
+            );
+            CollectionAssert.AreEquivalent(
+                new[]
+                {
+                    BusTraceOperationKind.EmitWithReset,
+                    BusTraceOperationKind.EmitWithThrow,
+                    BusTraceOperationKind.EmitWithDisable,
+                    BusTraceOperationKind.EmitWithHandlerActive,
+                    BusTraceOperationKind.EmitNested,
+                },
+                callbacks,
+                "Every callback action must use explicit handles in generated sequences."
             );
         }
 
@@ -1945,7 +2407,7 @@ namespace DxMessaging.Tests.Runtime.Core
             [ValueSource(typeof(MessageScenarios), nameof(MessageScenarios.AllKinds))]
                 MessageScenario scenario,
             [Values(17, 42)] int seed,
-            [Values(3, 4, 5, 6, 7, 8)] int version
+            [Values(3, 4, 5, 6, 7, 8, 9)] int version
         )
         {
             BusTraceSequence sequence = DifferentialBusTrace.Generate(
@@ -2137,22 +2599,30 @@ namespace DxMessaging.Tests.Runtime.Core
         public void CallbackTriggerWithoutMatchingRegistrationDoesNotRemainArmed(
             [ValueSource(typeof(MessageScenarios), nameof(MessageScenarios.AllKinds))]
                 MessageScenario scenario,
-            [Values("reset", "throw", "nested", "disable")] string callback
+            [Values("reset", "throw", "nested", "disable", "handler")] string callback
         )
         {
-            // Untargeted dispatch has no unmatched-context case; every kind has a disabled trigger.
-            bool[] routes =
-                scenario.Kind == MessageKind.Untargeted ? new[] { false } : new[] { false, true };
-            foreach (bool otherRoute in routes)
+            foreach (int handleSlot in new[] { -1, 0 })
+            foreach (string suppression in new[] { "disabled", "inactive", "route" })
             {
+                if (suppression == "route" && scenario.Kind == MessageKind.Untargeted)
+                {
+                    continue;
+                }
                 using MessageBusTraceAdapter adapter = CreateAdapter(scenario, false);
-                adapter.Execute(new BusTraceOperation(BusTraceOperationKind.Register));
+                adapter.Execute(
+                    new BusTraceOperation(BusTraceOperationKind.Register, handleSlot: handleSlot)
+                );
                 adapter.Execute(
                     new BusTraceOperation(BusTraceOperationKind.Register, token: 1, priority: 1)
                 );
-                if (!otherRoute)
+                if (suppression == "disabled")
                 {
                     adapter.Execute(new BusTraceOperation(BusTraceOperationKind.Disable));
+                }
+                if (suppression == "inactive")
+                {
+                    adapter.Execute(new BusTraceOperation(BusTraceOperationKind.SetHandlerActive));
                 }
                 BusTraceObservation untriggered = adapter.Execute(
                     new BusTraceOperation(
@@ -2161,22 +2631,32 @@ namespace DxMessaging.Tests.Runtime.Core
                             "throw" => BusTraceOperationKind.EmitWithThrow,
                             "nested" => BusTraceOperationKind.EmitNested,
                             "disable" => BusTraceOperationKind.EmitWithDisable,
+                            "handler" => BusTraceOperationKind.EmitWithHandlerActive,
                             _ => BusTraceOperationKind.EmitWithReset,
                         },
-                        context: otherRoute ? 1 : 0,
+                        context: suppression == "route" ? 1 : 0,
                         value: 10,
-                        depth: callback == "nested" ? 10 : 0
+                        depth: callback == "nested" ? 10 : 0,
+                        handlerToken: callback == "handler" ? 1 : 0,
+                        handleSlot: handleSlot,
+                        sourceHandleSlot: callback == "nested" ? handleSlot : -1
                     )
                 );
                 string label =
-                    $"[{scenario.Kind}] callback={callback}, otherRoute={otherRoute}: {untriggered}";
+                    $"[{scenario.Kind}] callback={callback}, suppression={suppression}, handleSlot={handleSlot}: {untriggered}";
                 Assert.That(untriggered.Exception, Is.Null, label);
                 CollectionAssert.AreEqual(
-                    otherRoute ? Array.Empty<string>() : new[] { "token=1,value=10" },
+                    suppression == "route" ? Array.Empty<string>() : new[] { "token=1,value=10" },
                     untriggered.Callbacks,
                     label
                 );
                 adapter.Execute(new BusTraceOperation(BusTraceOperationKind.Enable));
+                adapter.Execute(
+                    new BusTraceOperation(
+                        BusTraceOperationKind.SetHandlerActive,
+                        handlerActive: true
+                    )
+                );
                 foreach (int value in new[] { 11, 12 })
                 {
                     BusTraceObservation later = adapter.Execute(
@@ -2184,7 +2664,12 @@ namespace DxMessaging.Tests.Runtime.Core
                     );
                     Assert.That(later.Exception, Is.Null, label + "\n" + later);
                     CollectionAssert.AreEquivalent(
-                        new[] { $"token=0,value={value}", $"token=1,value={value}" },
+                        new[]
+                        {
+                            $"token=0,value={value}"
+                                + (handleSlot >= 0 ? ",registration=0,callback=0" : string.Empty),
+                            $"token=1,value={value}",
+                        },
                         later.Callbacks,
                         label + "\n" + later
                     );
@@ -2317,7 +2802,7 @@ namespace DxMessaging.Tests.Runtime.Core
         }
 
         [TestCase(0)]
-        [TestCase(9)]
+        [TestCase(10)]
         public void UnsupportedGeneratorVersionsAreRejected(int version)
         {
             Assert.Throws<ArgumentOutOfRangeException>(
@@ -2831,6 +3316,8 @@ namespace DxMessaging.Tests.Runtime.Core
             bus.DiagnosticsMode = false;
             return fault switch
             {
+                "explicit-callback" => new IgnoredExplicitCallbackAdapter(scenario, bus),
+                "explicit-cleanup" => new WrongExplicitCallbackCleanupAdapter(scenario, bus),
                 "order" => new EqualPriorityReorderAdapter(scenario, bus),
                 "duplicate-as-copy" => new DuplicateAsCopyAdapter(scenario, bus),
                 "reused-callback-order" => new ReusedCallbackOrderAdapter(scenario, bus),
@@ -2851,6 +3338,36 @@ namespace DxMessaging.Tests.Runtime.Core
 
         // Each mutant changes a real operation before the shared observer reads production state.
         // None rewrites observations or implements message routing.
+        private sealed class WrongExplicitCallbackCleanupAdapter : MessageBusTraceAdapter
+        {
+            internal WrongExplicitCallbackCleanupAdapter(MessageScenario scenario, MessageBus bus)
+                : base(scenario, bus, reset: bus.ResetState) { }
+
+            protected override void CleanupThrowingCallback(BusTraceOperation operation) =>
+                base.CleanupThrowingCallback(
+                    new BusTraceOperation(
+                        BusTraceOperationKind.Remove,
+                        token: operation.Token,
+                        handleSlot: operation.HandleSlot >= 0 ? 0 : -1
+                    )
+                );
+        }
+
+        private sealed class IgnoredExplicitCallbackAdapter : MessageBusTraceAdapter
+        {
+            internal IgnoredExplicitCallbackAdapter(MessageScenario scenario, MessageBus bus)
+                : base(scenario, bus, reset: bus.ResetState) { }
+
+            protected override bool MatchesCallback(
+                BusTraceOperation operation,
+                int token,
+                int callbackIdentity,
+                bool useNested = false
+            ) =>
+                operation.HandleSlot < 0
+                && base.MatchesCallback(operation, token, callbackIdentity, useNested);
+        }
+
         private sealed class ReusedCallbackOrderAdapter : MessageBusTraceAdapter
         {
             private bool _registered;

--- a/Tests/Runtime/Core/TestAttributeContractTests.cs
+++ b/Tests/Runtime/Core/TestAttributeContractTests.cs
@@ -18,6 +18,15 @@ namespace DxMessaging.Tests.Runtime.Core
         private const string TestAssemblyNamePrefix = "WallstopStudios.DxMessaging.Tests";
         private const string TestNamespacePrefix = "DxMessaging.Tests";
 
+        private MethodInfo[] _testMethods;
+
+        [OneTimeSetUp]
+        public void ResetMethodSnapshot()
+        {
+            // Rediscover for each fixture run, including repeated runs without domain reload.
+            _testMethods = null;
+        }
+
         /// <summary>
         /// Matches the C# 9 target-typed pattern <c>GameObject identifier = new(...)</c>.
         /// Used by <see cref="FixturesUsingMessagingTestBaseUseSpawnedCleanupPattern"/>
@@ -1298,7 +1307,7 @@ namespace DxMessaging.Tests.Runtime.Core
             return roots;
         }
 
-        private static IEnumerable<MethodInfo> FindMethods(Func<MethodInfo, bool> predicate)
+        private IEnumerable<MethodInfo> FindMethods(Func<MethodInfo, bool> predicate)
         {
             return GetDxMessagingTestMethods().Where(predicate);
         }
@@ -1312,7 +1321,13 @@ namespace DxMessaging.Tests.Runtime.Core
         /// sibling test assemblies), so contract tests apply uniformly across
         /// the test surface and not just the assembly that hosts this fixture.
         /// </summary>
-        private static IEnumerable<MethodInfo> GetDxMessagingTestMethods()
+        private IEnumerable<MethodInfo> GetDxMessagingTestMethods()
+        {
+            // Every contract applies its own predicate to the same complete method snapshot.
+            return _testMethods ??= CollectDxMessagingTestMethods().ToArray();
+        }
+
+        private static IEnumerable<MethodInfo> CollectDxMessagingTestMethods()
         {
             BindingFlags methodFlags =
                 BindingFlags.Instance
@@ -1352,7 +1367,7 @@ namespace DxMessaging.Tests.Runtime.Core
         private static bool HasAttribute<TAttribute>(MemberInfo method)
             where TAttribute : Attribute
         {
-            return method.GetCustomAttributes(typeof(TAttribute), inherit: false).Length > 0;
+            return method.IsDefined(typeof(TAttribute), inherit: false);
         }
 
         private static string FormatMethod(MethodInfo method)

--- a/Tests/Runtime/TestUtilities/DifferentialBusTrace.cs
+++ b/Tests/Runtime/TestUtilities/DifferentialBusTrace.cs
@@ -81,6 +81,8 @@ namespace DxMessaging.Tests.Runtime
 
         // -1 retains the version-one through seven token-associated handle lane.
         // Nonnegative slots hold independent handles, including aliases and duplicates.
+        // Version nine callback actions use HandleSlot as their trigger identity;
+        // EmitNested uses SourceHandleSlot as its alternating nested registration.
         private readonly int _handleSlot;
         private readonly int _sourceHandleSlot;
         internal int HandleSlot => _handleSlot - 1;
@@ -114,7 +116,7 @@ namespace DxMessaging.Tests.Runtime
     /// <summary>Immutable, versioned replay inputs; a seed identifies the original generator sequence.</summary>
     internal sealed class BusTraceSequence
     {
-        internal const int GeneratorVersion = 8;
+        internal const int GeneratorVersion = 9;
         internal const int HandleSlotCount = 8;
         internal const int TokenCount = 4;
         internal const int MaxOperations = 256;
@@ -261,9 +263,9 @@ namespace DxMessaging.Tests.Runtime
             {
                 throw new ArgumentOutOfRangeException(nameof(length));
             }
-            if (generatorVersion == 8)
+            if (generatorVersion == 8 || generatorVersion == 9)
             {
-                return GenerateHandleSlots(scenario, seed, length);
+                return GenerateHandleSlots(scenario, seed, length, generatorVersion);
             }
             List<BusTraceOperation> operations = new(length);
             bool[] registered = new bool[BusTraceSequence.TokenCount];
@@ -405,7 +407,8 @@ namespace DxMessaging.Tests.Runtime
         private static BusTraceSequence GenerateHandleSlots(
             MessageScenario scenario,
             uint seed,
-            int length
+            int length,
+            int version
         )
         {
             List<BusTraceOperation> operations = new(length);
@@ -448,7 +451,7 @@ namespace DxMessaging.Tests.Runtime
                 int slot = (int)(Next(ref state) % BusTraceSequence.HandleSlotCount);
                 int source = (int)(Next(ref state) % BusTraceSequence.HandleSlotCount);
                 int owner = (int)(Next(ref state) % BusTraceSequence.TokenCount);
-                int choice = (int)(Next(ref state) % 8);
+                int choice = (int)(Next(ref state) % (version == 8 ? 8U : 13U));
                 int value = unchecked((int)Next(ref state));
                 BusTraceOperation operation = choice switch
                 {
@@ -485,7 +488,27 @@ namespace DxMessaging.Tests.Runtime
                     ),
                     5 => new(BusTraceOperationKind.Enable, token: owner),
                     6 => new(BusTraceOperationKind.Disable, token: owner),
-                    _ => new(BusTraceOperationKind.Trim, value: value & 1),
+                    7 => new(BusTraceOperationKind.Trim, value: value & 1),
+                    _ => new(
+                        choice switch
+                        {
+                            8 => BusTraceOperationKind.EmitWithReset,
+                            9 => BusTraceOperationKind.EmitWithThrow,
+                            10 => BusTraceOperationKind.EmitWithDisable,
+                            11 => BusTraceOperationKind.EmitWithHandlerActive,
+                            _ => BusTraceOperationKind.EmitNested,
+                        },
+                        token: handles.Owner(slot),
+                        context: handles.Registration(slot).Context,
+                        value: value,
+                        kindOffset: handles.Registration(slot).KindOffset,
+                        nestedToken: choice == 12 ? handles.Owner(source) : 0,
+                        depth: choice == 12 ? 1 + (int)(Next(ref state) % 10) : 0,
+                        handlerToken: choice == 11 ? owner : 0,
+                        handlerActive: choice == 11 && (value & 1) != 0,
+                        handleSlot: slot,
+                        sourceHandleSlot: choice == 12 ? source : -1
+                    ),
                 };
                 if (operation.HandleSlot >= 0 && !handles.Apply(operation))
                 {
@@ -493,7 +516,7 @@ namespace DxMessaging.Tests.Runtime
                 }
                 operations.Add(operation);
             }
-            return new BusTraceSequence(scenario, seed, operations, 8);
+            return new BusTraceSequence(scenario, seed, operations, version);
         }
 
         // Tracks issued identities and aliases only. Never predicts delivery or bus storage.
@@ -502,15 +525,35 @@ namespace DxMessaging.Tests.Runtime
             private readonly int[] _identities = new int[BusTraceSequence.HandleSlotCount];
             private readonly int[] _owners = new int[BusTraceSequence.HandleSlotCount];
             private readonly bool[] _live = new bool[BusTraceSequence.MaxOperations + 1];
+            private readonly BusTraceOperation[] _registrations = new BusTraceOperation[
+                BusTraceSequence.HandleSlotCount
+            ];
             private int _nextIdentity;
 
             internal int Owner(int slot) => _owners[slot];
+
+            internal BusTraceOperation Registration(int slot) => _registrations[slot];
 
             internal bool Apply(BusTraceOperation operation)
             {
                 int slot = operation.HandleSlot;
                 int source = operation.SourceHandleSlot;
                 int identity = _identities[slot];
+                if (IsCallbackAction(operation.Kind))
+                {
+                    // Only issued dependencies are checked. Callback cleanup may or may not
+                    // execute, depending on production dispatch, activity, and routing.
+                    return _live[identity]
+                        && _owners[slot] == operation.Token
+                        && (
+                            operation.Kind == BusTraceOperationKind.EmitNested
+                                ? operation.Depth > 0
+                                    && source >= 0
+                                    && _live[_identities[source]]
+                                    && _owners[source] == operation.NestedToken
+                                : source == -1
+                        );
+                }
                 if (operation.Kind == BusTraceOperationKind.Remove)
                 {
                     if (source != -1 || identity == 0 || _owners[slot] != operation.Token)
@@ -552,6 +595,7 @@ namespace DxMessaging.Tests.Runtime
                     {
                         _identities[slot] = _identities[source];
                         _owners[slot] = operation.Token;
+                        _registrations[slot] = _registrations[source];
                         return true;
                     }
                 }
@@ -559,12 +603,20 @@ namespace DxMessaging.Tests.Runtime
                 {
                     return false;
                 }
+                _registrations[slot] = source < 0 ? operation : _registrations[source];
                 _identities[slot] = ++_nextIdentity;
                 _owners[slot] = operation.Token;
                 _live[_nextIdentity] = true;
                 return true;
             }
         }
+
+        internal static bool IsCallbackAction(BusTraceOperationKind kind) =>
+            kind == BusTraceOperationKind.EmitWithReset
+            || kind == BusTraceOperationKind.EmitWithThrow
+            || kind == BusTraceOperationKind.EmitWithDisable
+            || kind == BusTraceOperationKind.EmitWithHandlerActive
+            || kind == BusTraceOperationKind.EmitNested;
 
         /// <summary>Checks handle existence and input bounds only; never predicts which callbacks should execute.</summary>
         internal static bool IsValid(BusTraceSequence sequence)
@@ -649,7 +701,10 @@ namespace DxMessaging.Tests.Runtime
                 }
                 if (operation.HandleSlot >= 0)
                 {
-                    if (!handles.Apply(operation))
+                    if (
+                        (sequence.Version < 9 && IsCallbackAction(operation.Kind))
+                        || !handles.Apply(operation)
+                    )
                     {
                         return false;
                     }

--- a/Tests/Runtime/TestUtilities/MessageBusTraceAdapter.cs
+++ b/Tests/Runtime/TestUtilities/MessageBusTraceAdapter.cs
@@ -14,9 +14,9 @@ namespace DxMessaging.Tests.Runtime
         private readonly IMessageBus _bus;
         private readonly IMessageBus _emitter;
         private readonly Action _reset;
-        private int _resetOnCallbackToken = -1;
-        private int _throwOnCallbackToken = -1;
-        private int _disableOnCallbackToken = -1;
+        private BusTraceOperation? _resetOperation;
+        private BusTraceOperation? _throwOperation;
+        private BusTraceOperation? _disableOperation;
         private BusTraceOperation? _handlerActiveOperation;
         private BusTraceOperation? _nestedOperation;
         private int _depth;
@@ -39,6 +39,12 @@ namespace DxMessaging.Tests.Runtime
             new MessageRegistrationHandle[BusTraceSequence.HandleSlotCount];
         private readonly Func<MessageRegistrationHandle>[] _registrationFactories =
             new Func<MessageRegistrationHandle>[BusTraceSequence.HandleSlotCount];
+        private readonly int[] _explicitCallbackIdentities = new int[
+            BusTraceSequence.HandleSlotCount
+        ];
+        private readonly BusTraceOperation[] _explicitRegistrations = new BusTraceOperation[
+            BusTraceSequence.HandleSlotCount
+        ];
         private int _nextCallbackIdentity;
         private readonly List<string> _callbacks = new();
         private readonly List<string> _finalEmissions = new();
@@ -172,25 +178,25 @@ namespace DxMessaging.Tests.Runtime
                         }
                         break;
                     case BusTraceOperationKind.EmitWithDisable:
-                        _disableOnCallbackToken = operation.Token;
+                        _disableOperation = operation;
                         try
                         {
                             Emit(operation);
                         }
                         finally
                         {
-                            _disableOnCallbackToken = -1;
+                            _disableOperation = null;
                         }
                         break;
                     case BusTraceOperationKind.EmitWithThrow:
-                        _throwOnCallbackToken = operation.Token;
+                        _throwOperation = operation;
                         try
                         {
                             Emit(operation);
                         }
                         finally
                         {
-                            _throwOnCallbackToken = -1;
+                            _throwOperation = null;
                         }
                         break;
                     case BusTraceOperationKind.EmitWithReset:
@@ -200,7 +206,7 @@ namespace DxMessaging.Tests.Runtime
                                 "This adapter has no local reset action."
                             );
                         }
-                        _resetOnCallbackToken = operation.Token;
+                        _resetOperation = operation;
                         try
                         {
                             Emit(operation);
@@ -208,7 +214,7 @@ namespace DxMessaging.Tests.Runtime
                         finally
                         {
                             // A disabled or differently routed trigger may never receive a callback.
-                            _resetOnCallbackToken = -1;
+                            _resetOperation = null;
                         }
                         break;
                     default:
@@ -341,6 +347,7 @@ namespace DxMessaging.Tests.Runtime
             _registrationFactories[operation.HandleSlot] = _registrationFactories[
                 operation.SourceHandleSlot
             ];
+            CopyRegistrationIdentity(operation);
         }
 
         protected virtual void DuplicateRegistration(BusTraceOperation operation)
@@ -350,6 +357,17 @@ namespace DxMessaging.Tests.Runtime
             ];
             _explicitHandles[operation.HandleSlot] = register();
             _registrationFactories[operation.HandleSlot] = register;
+            CopyRegistrationIdentity(operation);
+        }
+
+        private void CopyRegistrationIdentity(BusTraceOperation operation)
+        {
+            _explicitCallbackIdentities[operation.HandleSlot] = _explicitCallbackIdentities[
+                operation.SourceHandleSlot
+            ];
+            _explicitRegistrations[operation.HandleSlot] = _explicitRegistrations[
+                operation.SourceHandleSlot
+            ];
         }
 
         protected virtual void Remove(BusTraceOperation operation)
@@ -374,6 +392,18 @@ namespace DxMessaging.Tests.Runtime
 
         protected virtual void CleanupThrowingCallback(int slot) =>
             _tokens[slot].RemoveRegistration(_handles[slot]);
+
+        protected virtual void CleanupThrowingCallback(BusTraceOperation operation)
+        {
+            if (operation.HandleSlot >= 0)
+            {
+                Remove(operation);
+            }
+            else
+            {
+                CleanupThrowingCallback(operation.Token);
+            }
+        }
 
         // Mutants change real callback behavior here; observation construction remains shared.
         protected virtual void OnCallback(int slot, IMessage message) { }
@@ -442,6 +472,8 @@ namespace DxMessaging.Tests.Runtime
         )
         {
             int callbackIdentity = _nextCallbackIdentity++;
+            _explicitCallbackIdentities[operation.HandleSlot] = callbackIdentity;
+            _explicitRegistrations[operation.HandleSlot] = operation;
             MessageScenario scenario = Scenario(operation.KindOffset);
             MessageRegistrationToken token = _tokens[operation.Token];
             InstanceId context = new(2000 + operation.Context);
@@ -622,32 +654,40 @@ namespace DxMessaging.Tests.Runtime
                     )
             );
             OnCallback(token, message);
-            // Versions one through seven address the token-associated registration.
-            // Explicit sibling callbacks must not consume that registration's trigger.
-            if (handleSlot >= 0)
-            {
-                return;
-            }
-            if (_handlerActiveOperation.HasValue && token == _handlerActiveOperation.Value.Token)
+            if (
+                _handlerActiveOperation.HasValue
+                && MatchesCallback(_handlerActiveOperation.Value, token, callbackIdentity)
+            )
             {
                 BusTraceOperation operation = _handlerActiveOperation.Value;
                 _handlerActiveOperation = null;
                 SetHandlerActive(operation.HandlerToken, operation.HandlerActive);
             }
-            if (token == _disableOnCallbackToken)
+            if (
+                _disableOperation.HasValue
+                && MatchesCallback(_disableOperation.Value, token, callbackIdentity)
+            )
             {
-                _disableOnCallbackToken = -1;
+                _disableOperation = null;
                 DisableFromCallback(token);
             }
             if (_nestedOperation.HasValue)
             {
                 BusTraceOperation nested = _nestedOperation.Value;
-                int trigger = (_depth & 1) == 0 ? nested.Token : nested.NestedToken;
-                if (token == trigger && _depth < nested.Depth)
+                bool useNested = (_depth & 1) != 0;
+                if (
+                    MatchesCallback(nested, token, callbackIdentity, useNested)
+                    && _depth < nested.Depth
+                )
                 {
                     long emission = _bus.EmissionId;
                     int next = (_depth & 1) == 0 ? nested.NestedToken : nested.Token;
-                    BusTraceOperation registration = _registrations[next];
+                    BusTraceOperation registration =
+                        nested.HandleSlot >= 0
+                            ? _explicitRegistrations[
+                                useNested ? nested.HandleSlot : nested.SourceHandleSlot
+                            ]
+                            : _registrations[next];
                     _callbacks.Add($"nested-enter:depth={_depth},emission={emission}");
                     ++_depth;
                     try
@@ -669,23 +709,53 @@ namespace DxMessaging.Tests.Runtime
                     }
                 }
             }
-            if (token == _throwOnCallbackToken)
+            if (
+                _throwOperation.HasValue
+                && MatchesCallback(_throwOperation.Value, token, callbackIdentity)
+            )
             {
-                _throwOnCallbackToken = -1;
+                BusTraceOperation operation = _throwOperation.Value;
+                _throwOperation = null;
                 try
                 {
                     throw new InvalidOperationException("intentional trace callback failure");
                 }
                 finally
                 {
-                    CleanupThrowingCallback(token);
+                    CleanupThrowingCallback(operation);
                 }
             }
-            if (token == _resetOnCallbackToken)
+            if (
+                _resetOperation.HasValue
+                && MatchesCallback(_resetOperation.Value, token, callbackIdentity)
+            )
             {
-                _resetOnCallbackToken = -1;
+                _resetOperation = null;
                 _reset();
             }
+        }
+
+        protected virtual bool MatchesCallback(
+            BusTraceOperation operation,
+            int token,
+            int callbackIdentity,
+            bool useNested = false
+        )
+        {
+            int owner = useNested ? operation.NestedToken : operation.Token;
+            if (token != owner)
+            {
+                return false;
+            }
+            if (operation.HandleSlot < 0)
+            {
+                return callbackIdentity < 0;
+            }
+            int slot = useNested ? operation.SourceHandleSlot : operation.HandleSlot;
+            // Copies and duplicates retain delegate identity even after the original slot
+            // is reused. Actual token state excludes handles consumed by callback cleanup.
+            return callbackIdentity == _explicitCallbackIdentities[slot]
+                && _tokens[owner]._metadata.ContainsKey(_explicitHandles[slot]);
         }
 
         internal readonly struct UntargetedPayload : IUntargetedMessage<UntargetedPayload>

--- a/docs/runbooks/perf-benchmark-methodology.md
+++ b/docs/runbooks/perf-benchmark-methodology.md
@@ -276,7 +276,10 @@ metrics because the Release player strips the required profiler recorder (see
   and inside the actual build process. `build-options-profile.json` records
   Unity's final post-build options, and `runtime-profile.json` records
   `Debug.isDebugBuild`. The runner compares every field with the archived
-  profile and fails on a missing, extra, mistyped, or different value. The
+  profile and fails on a missing, extra, mistyped, or different value. Each
+  evidence file must also name the exact Unity version requested by the runner.
+  Standalone validation requires `-ExpectedUnityVersion` when checking evidence;
+  `-ProfileOnly` validates the shared profile without selecting an editor. The
   `DXM perf config:` log line and each row's platform
   string (`Standalone IL2CPP x64 Release (WindowsPlayer; ...)`) remain
   diagnostic surfaces; a published `x64 Debug` row is a configuration bug. A Release player

--- a/docs/runbooks/perf-evidence-bundles.md
+++ b/docs/runbooks/perf-evidence-bundles.md
@@ -66,18 +66,18 @@ bytes. Cite a result only after `replay` succeeds.
 
 ## What fails, and what it means
 
-| Failure                                                   | Cause                                                           |
-| --------------------------------------------------------- | --------------------------------------------------------------- |
-| `hashes to ... but the manifest declares ...`             | A raw file changed after sealing                                |
-| `is declared by the manifest but could not be read`       | A required artifact is missing or unreachable                   |
-| `Undeclared files are present in the bundle`              | Something was added after sealing                               |
-| `does not match its own contents`                         | The manifest itself was edited, including its normalized result |
-| `is already sealed as ... but these bytes seal as ...`    | An overwrite of sealed evidence; publish a new revision instead |
-| `looks like it contains ...; scrub it before sealing`     | Sensitive data is still present; see below                      |
-| `does not use a reviewed text evidence extension ...`     | The artifact class has no approved inspection rule              |
-| `is not valid UTF-8 or byte-order-marked UTF-16 text ...` | The file has malformed or opaque bytes                          |
-| `contains non-text control bytes` or `too many NUL bytes` | The file does not meet the reviewed-text contract               |
-| `reports ... for cell ... but its own evidence says ...`  | The matrix summary disagrees with the per-cell evidence         |
+| Failure                                                       | Cause                                                           |
+| ------------------------------------------------------------- | --------------------------------------------------------------- |
+| `hashes to ... but the manifest declares ...`                 | A raw file changed after sealing                                |
+| `is declared by the manifest but could not be read`           | A required artifact is missing or unreachable                   |
+| `Undeclared files are present in the bundle`                  | Something was added after sealing                               |
+| `does not match its own contents`                             | The manifest itself was edited, including its normalized result |
+| `is already sealed as ... but these bytes seal as ...`        | An overwrite of sealed evidence; publish a new revision instead |
+| `looks like it contains ...; scrub it before sealing`         | Sensitive data is still present; see below                      |
+| `does not use a reviewed text evidence extension ...`         | The artifact class has no approved inspection rule              |
+| `is not valid UTF-8 or byte-order-marked UTF-16 text ...`     | The file has malformed or opaque bytes                          |
+| `contains non-text control bytes` or `too many NUL bytes`     | The file does not meet the reviewed-text contract               |
+| `reports fields for cell ... that disagree with its raw cell` | The matrix summary disagrees with the per-cell evidence         |
 
 ## Sensitive-data refusal
 
@@ -163,7 +163,9 @@ reviewer's machine. Order every array by an ordinal key rather than by directory
 
 Register it in `REDUCERS` in `scripts/unity/perf-evidence-bundle.js` and add cases to
 `scripts/__tests__/perf-evidence-bundle.test.js` covering a missing input, a corrupted input, and a
-summary that disagrees with the raw rows it claims to describe.
+summary that disagrees with the raw rows it claims to describe. Compare every copied
+field, including profile identity and nested fields, while allowing object-key order
+and the producer's `cellId` override.
 
 ## Where bundles are produced
 

--- a/scripts/__tests__/fixtures/unity-redaction-vectors.json
+++ b/scripts/__tests__/fixtures/unity-redaction-vectors.json
@@ -667,7 +667,19 @@
     ["cell", "timings.firstTypedDispatchUs", -1],
     ["cell", "timings.firstTypedDispatchUs", "40"],
     ["cell", "timings.dispatchLoopShape", ""],
-    ["cell", "timings.dispatchLoopShape", true]
+    ["cell", "timings.dispatchLoopShape", true],
+    ["summary", "schemaVersion", 2],
+    ["summary", "profileId", "different-profile"],
+    [
+      "summary",
+      "profileSha256",
+      "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    ],
+    ["summary", "profileId", null, true],
+    ["summary", "unknownSummaryField", true],
+    ["raw", "unknownRawField", true],
+    ["summary", "timings.dispatchLoopCount", 2],
+    ["summary", "diagnostics", ["second", "first"]]
   ],
   "structuredValues": [
     [

--- a/scripts/__tests__/perf-evidence-bundle.test.js
+++ b/scripts/__tests__/perf-evidence-bundle.test.js
@@ -46,6 +46,7 @@ function cellEvidence(level, topologyId, messageTypeCount, index) {
     messageTypeCount,
     unityVersion: "6000.5.2f1",
     libraryState: "cold",
+    diagnostics: ["first", "second"],
     buildDurationMs: 120000 + index,
     editorBuildWallClockMs: 130000 + index,
     playerTotalBytes: 40000000 + index * 1000,
@@ -264,7 +265,7 @@ test("replay rejects a bundle whose sealed bytes no longer produce the published
   verifyBundle(manifestPath);
   assert.throws(
     () => replayBundle(manifestPath),
-    /reports playerTotalBytes=\d+ for cell high-semantic-18 but its own evidence says/,
+    /shipping-matrix-evidence\.json.*high-semantic-18.*raw cell/,
     "a summary that disagrees with its own per-cell evidence must not replay"
   );
 });
@@ -628,19 +629,21 @@ test("sealing refuses malformed byte-order-marked UTF-16", () => {
   );
 });
 
-for (const [target, field, value] of VECTORS.invalidShippingInputs) {
+for (const [target, field, value, remove] of VECTORS.invalidShippingInputs) {
   test(`shipping reducer rejects ${target} ${field}=${JSON.stringify(value)}`, () => {
     const root = writeMatrixBundle(temporaryDirectory());
     const file = path.join(
       root,
-      target === "matrix"
+      ["matrix", "summary"].includes(target)
         ? "shipping-matrix-evidence.json"
         : "high-semantic-18/shipping-cell-evidence.json"
     );
     const input = JSON.parse(fs.readFileSync(file, "utf8"));
     const keys = field.split(".");
-    const holder = keys.length === 1 ? input : input[keys[0]];
-    holder[keys.at(-1)] = value;
+    const subject = target === "summary" ? input.cells[0] : input;
+    const holder = keys.length === 1 ? subject : subject[keys[0]];
+    if (remove) delete holder[keys.at(-1)];
+    else holder[keys.at(-1)] = value;
     writeJson(file, input);
     if (target === "cell") {
       const summaryPath = path.join(root, "shipping-matrix-evidence.json");
@@ -680,6 +683,12 @@ test("shipping reducer preserves explicit failed outcomes and ignores row order"
   const matrix = JSON.parse(fs.readFileSync(file, "utf8"));
   const expected = reduceShippingFidelityMatrix(contentsOf(root));
   matrix.cells.reverse();
+  matrix.cells = matrix.cells.map((row) => Object.fromEntries(Object.entries(row).reverse()));
+  const cellPath = path.join(root, "high-semantic-18/shipping-cell-evidence.json");
+  const raw = JSON.parse(fs.readFileSync(cellPath, "utf8"));
+  raw.cellId = "ignored-by-the-matrix-producer";
+  raw.timings = Object.fromEntries(Object.entries(raw.timings).reverse());
+  writeJson(cellPath, raw);
   writeJson(file, matrix);
   assert.deepEqual(reduceShippingFidelityMatrix(contentsOf(root)), expected);
   matrix.cellCount += 2;

--- a/scripts/unity/__tests__/il2cpp-profile.test.ps1
+++ b/scripts/unity/__tests__/il2cpp-profile.test.ps1
@@ -9,6 +9,7 @@ $repoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSScript
 $validatorPath = Join-Path (Split-Path -Parent $PSScriptRoot) 'validate-il2cpp-profile.ps1'
 $runnerPath = Join-Path (Split-Path -Parent $PSScriptRoot) 'run-ci-tests.ps1'
 $workflowPath = Join-Path $repoRoot '.github/workflows/perf-numbers.yml'
+$testUnityVersion = '6000.3.16f1'
 $sourceProfilePath = Join-Path $repoRoot '.github/perf/canonical-il2cpp-profile.v1.json'
 $fixtureRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("dxm-il2cpp-profile-{0}" -f [guid]::NewGuid().ToString('N'))
 
@@ -142,6 +143,28 @@ try {
     foreach ($kind in @('configuration', 'buildOptions', 'runtime')) {
         Assert-That "the runner validates $kind evidence" ($runnerText.Contains("-EvidenceKind $kind"))
     }
+    $evidenceCommands = @($runnerAst.FindAll({
+        param($node)
+        $node -is [System.Management.Automation.Language.CommandAst] -and
+            $node.CommandElements[0].Extent.Text -eq '$profileValidatorPath' -and
+            @($node.CommandElements | Where-Object {
+                $_ -is [System.Management.Automation.Language.CommandParameterAst] -and
+                    $_.ParameterName -eq 'EvidenceKind'
+            }).Count -gt 0
+    }, $true))
+    Assert-That 'the runner contains profile evidence validation calls' ($evidenceCommands.Count -gt 0)
+    foreach ($command in $evidenceCommands) {
+        $elements = @($command.CommandElements)
+        $versionArguments = @(for ($index = 1; $index -lt $elements.Count - 1; ++$index) {
+            if ($elements[$index] -is [System.Management.Automation.Language.CommandParameterAst] -and
+                $elements[$index].ParameterName -eq 'ExpectedUnityVersion') {
+                $elements[$index + 1].Extent.Text
+            }
+        })
+        Assert-That "profile evidence validation at line $($command.Extent.StartLineNumber) binds the requested editor" (
+            $versionArguments.Count -eq 1 -and $versionArguments[0] -ceq '$UnityVersion'
+        )
+    }
     Assert-That 'the performance standalone leg passes the canonical profile' (
         $workflowText.Contains("CanonicalProfilePath = '.github/perf/canonical-il2cpp-profile.v1.json'")
     )
@@ -197,15 +220,30 @@ try {
             profileId = $profile.profileId
             profileSha256 = $profileSha256
             evidenceKind = $kind
-            unityVersion = '6000.3.16f1'
+            unityVersion = $testUnityVersion
             values = Copy-JsonValue -Value $profile.$kind
         }
         Write-TestJson -Path $evidencePath -Value $evidence
         & $validatorPath `
             -ProfilePath $profilePath `
             -EvidencePath $evidencePath `
-            -EvidenceKind $kind `
+            -EvidenceKind $kind -ExpectedUnityVersion $testUnityVersion `
             -ExpectedSha256 $profileSha256
+
+        foreach ($wrongVersion in @('2021.3.45f1', '6000.3.16F1', '6000.3.16f1 ')) {
+            $wrongVersionEvidence = Copy-JsonValue -Value $evidence
+            $wrongVersionEvidence.unityVersion = $wrongVersion
+            Write-TestJson -Path $evidencePath -Value $wrongVersionEvidence
+            Assert-Fails "$kind evidence from a different editor ($wrongVersion)" -ExpectedMessage "$kind.unityVersion differs" {
+                & $validatorPath -ProfilePath $profilePath -EvidencePath $evidencePath -EvidenceKind $kind -ExpectedUnityVersion $testUnityVersion
+            }
+        }
+        Write-TestJson -Path $evidencePath -Value $evidence
+        foreach ($missingExpectedVersion in @($null, '', ' ')) {
+            Assert-Fails "$kind missing expected editor version" -ExpectedMessage 'ExpectedUnityVersion is required' {
+                & $validatorPath -ProfilePath $profilePath -EvidencePath $evidencePath -EvidenceKind $kind -ExpectedUnityVersion $missingExpectedVersion
+            }
+        }
 
         foreach ($property in $profile.$kind.PSObject.Properties) {
             $mutated = Copy-JsonValue -Value $evidence
@@ -216,7 +254,7 @@ try {
             }
             Write-TestJson -Path $evidencePath -Value $mutated
             Assert-Fails "$kind.$($property.Name) drift" {
-                & $validatorPath -ProfilePath $profilePath -EvidencePath $evidencePath -EvidenceKind $kind
+                & $validatorPath -ProfilePath $profilePath -EvidencePath $evidencePath -EvidenceKind $kind -ExpectedUnityVersion $testUnityVersion
             }
         }
 
@@ -225,14 +263,14 @@ try {
         $missing.values.PSObject.Properties.Remove($firstPropertyName)
         Write-TestJson -Path $evidencePath -Value $missing
         Assert-Fails "$kind missing value" {
-            & $validatorPath -ProfilePath $profilePath -EvidencePath $evidencePath -EvidenceKind $kind
+            & $validatorPath -ProfilePath $profilePath -EvidencePath $evidencePath -EvidenceKind $kind -ExpectedUnityVersion $testUnityVersion
         }
 
         $extra = Copy-JsonValue -Value $evidence
         $extra.values | Add-Member -NotePropertyName unexpected -NotePropertyValue $true
         Write-TestJson -Path $evidencePath -Value $extra
         Assert-Fails "$kind extra value" {
-            & $validatorPath -ProfilePath $profilePath -EvidencePath $evidencePath -EvidenceKind $kind
+            & $validatorPath -ProfilePath $profilePath -EvidencePath $evidencePath -EvidenceKind $kind -ExpectedUnityVersion $testUnityVersion
         }
     }
 
@@ -242,20 +280,20 @@ try {
         profileId = $profile.profileId
         profileSha256 = $profileSha256
         evidenceKind = 'runtime'
-        unityVersion = '6000.3.16f1'
+        unityVersion = $testUnityVersion
         values = [ordered]@{ debugBuild = $false }
     }
     $runtimeEvidence.unexpected = $true
     Write-TestJson -Path $runtimeEvidencePath -Value $runtimeEvidence
     Assert-Fails 'extra evidence property' {
-        & $validatorPath -ProfilePath $profilePath -EvidencePath $runtimeEvidencePath -EvidenceKind runtime
+        & $validatorPath -ProfilePath $profilePath -EvidencePath $runtimeEvidencePath -EvidenceKind runtime -ExpectedUnityVersion $testUnityVersion
     }
 
     $runtimeEvidence.Remove('unexpected')
     $runtimeEvidence.schemaVersion = '1'
     Write-TestJson -Path $runtimeEvidencePath -Value $runtimeEvidence
     Assert-Fails 'string evidence schema version' {
-        & $validatorPath -ProfilePath $profilePath -EvidencePath $runtimeEvidencePath -EvidenceKind runtime
+        & $validatorPath -ProfilePath $profilePath -EvidencePath $runtimeEvidencePath -EvidenceKind runtime -ExpectedUnityVersion $testUnityVersion
     }
 
     $runtimeEvidence.schemaVersion = 1
@@ -264,7 +302,7 @@ try {
         $missingMetadata.PSObject.Properties.Remove($metadataField)
         Write-TestJson -Path $runtimeEvidencePath -Value $missingMetadata
         Assert-Fails "missing evidence $metadataField" -ExpectedMessage "missing=$metadataField" {
-            & $validatorPath -ProfilePath $profilePath -EvidencePath $runtimeEvidencePath -EvidenceKind runtime
+            & $validatorPath -ProfilePath $profilePath -EvidencePath $runtimeEvidencePath -EvidenceKind runtime -ExpectedUnityVersion $testUnityVersion
         }
     }
     $wrongMetadataValues = [ordered]@{
@@ -279,14 +317,14 @@ try {
         $wrongMetadata.$metadataField = $wrongMetadataValues[$metadataField]
         Write-TestJson -Path $runtimeEvidencePath -Value $wrongMetadata
         Assert-Fails "wrong evidence $metadataField" {
-            & $validatorPath -ProfilePath $profilePath -EvidencePath $runtimeEvidencePath -EvidenceKind runtime
+            & $validatorPath -ProfilePath $profilePath -EvidencePath $runtimeEvidencePath -EvidenceKind runtime -ExpectedUnityVersion $testUnityVersion
         }
     }
     Assert-Fails 'missing evidence file' -ExpectedMessage 'does not exist' {
         & $validatorPath `
             -ProfilePath $profilePath `
             -EvidencePath (Join-Path $fixtureRoot 'missing-evidence.json') `
-            -EvidenceKind runtime
+            -EvidenceKind runtime -ExpectedUnityVersion $testUnityVersion
     }
 
     Assert-Fails 'wrong expected profile hash' {

--- a/scripts/unity/perf-evidence-reducers.js
+++ b/scripts/unity/perf-evidence-reducers.js
@@ -1,4 +1,5 @@
 "use strict";
+const { isDeepStrictEqual } = require("node:util");
 // Reducers use only supplied bytes and ordinal ordering. Replay requires exact JSON equality.
 const MATRIX_EVIDENCE_NAME = "shipping-matrix-evidence.json";
 const CELL_EVIDENCE_SUFFIX = "/shipping-cell-evidence.json";
@@ -58,16 +59,6 @@ function requireStringArray(value, label) {
   )
     throw new Error(`${label} must be an array of unique non-empty strings.`);
   return [...value].sort();
-}
-function assertMatrixRowAgrees(row, cell, cellId) {
-  for (const field of [...CELL_FIELDS, ...TIMING_FIELDS]) {
-    const value = TIMING_FIELDS.includes(field) ? row.timings?.[field] : row[field];
-    if (value !== cell[field]) {
-      throw new Error(
-        `${MATRIX_EVIDENCE_NAME} reports ${field}=${JSON.stringify(value)} for cell ${cellId} but its own evidence says ${JSON.stringify(cell[field])}.`
-      );
-    }
-  }
 }
 // Summarize integer sizes by stripping level in ordinal order.
 function summarizeByStrippingLevel(cells) {
@@ -135,11 +126,11 @@ function reduceShippingFidelityMatrix(contents) {
         cellPath
       );
     }
-    const row = rows.get(cellId);
-    if (row === undefined) {
-      throw new Error(`${MATRIX_EVIDENCE_NAME} does not list completed cell ${cellId}.`);
-    }
-    assertMatrixRowAgrees(row, cell, cellId);
+    // Read-ShippingCellEvidence copies every raw field, overriding only cellId.
+    if (!isDeepStrictEqual(rows.get(cellId), { ...evidence, cellId }))
+      throw new Error(
+        `${MATRIX_EVIDENCE_NAME} reports fields for cell ${cellId} that disagree with its raw cell.`
+      );
     cells.push(cell);
   }
   return {

--- a/scripts/unity/run-ci-tests.ps1
+++ b/scripts/unity/run-ci-tests.ps1
@@ -6870,6 +6870,7 @@ try {
                 -ProfilePath $resolvedCanonicalProfilePath `
                 -EvidencePath $configuredProfileEvidencePath `
                 -EvidenceKind configuration `
+                -ExpectedUnityVersion $UnityVersion `
                 -ExpectedSha256 $canonicalProfileSha256
         } elseif (
             $isShippingFidelity -and
@@ -6999,12 +7000,14 @@ try {
                 -ProfilePath $resolvedCanonicalProfilePath `
                 -EvidencePath $shippingBuildConfigurationPath `
                 -EvidenceKind configuration `
+                -ExpectedUnityVersion $UnityVersion `
                 -ExpectedSha256 $canonicalProfileSha256
         }
         & $profileValidatorPath `
             -ProfilePath $resolvedCanonicalProfilePath `
             -EvidencePath $buildOptionsProfileEvidencePath `
             -EvidenceKind buildOptions `
+            -ExpectedUnityVersion $UnityVersion `
             -ExpectedSha256 $canonicalProfileSha256
         Test-ShippingAssemblyEvidence `
             -Path $shippingAssemblyEvidencePath `
@@ -7061,6 +7064,7 @@ try {
                 -ProfilePath $resolvedCanonicalProfilePath `
                 -EvidencePath $shippingRun.RuntimePath `
                 -EvidenceKind runtime `
+                -ExpectedUnityVersion $UnityVersion `
                 -ExpectedSha256 $canonicalProfileSha256
             if ($shippingPlayerResult.TimedOut -or $shippingPlayerResult.ExitCode -ne 0) {
                 Write-UnityBenignExitWarning `
@@ -7217,12 +7221,14 @@ try {
                     -ProfilePath $resolvedCanonicalProfilePath `
                     -EvidencePath $buildConfigurationEvidencePath `
                     -EvidenceKind configuration `
+                    -ExpectedUnityVersion $UnityVersion `
                     -ExpectedSha256 $canonicalProfileSha256
             }
             & $profileValidatorPath `
                 -ProfilePath $resolvedCanonicalProfilePath `
                 -EvidencePath $buildOptionsProfileEvidencePath `
                 -EvidenceKind buildOptions `
+                -ExpectedUnityVersion $UnityVersion `
                 -ExpectedSha256 $canonicalProfileSha256
         }
 
@@ -7357,6 +7363,7 @@ try {
                     -ProfilePath $resolvedCanonicalProfilePath `
                     -EvidencePath $currentRuntimeProfilePath `
                     -EvidenceKind runtime `
+                    -ExpectedUnityVersion $UnityVersion `
                     -ExpectedSha256 $canonicalProfileSha256
             }
 

--- a/scripts/unity/validate-il2cpp-profile.ps1
+++ b/scripts/unity/validate-il2cpp-profile.ps1
@@ -11,6 +11,8 @@ param(
 
     [string]$ExpectedSha256,
 
+    [string]$ExpectedUnityVersion,
+
     [switch]$ProfileOnly
 )
 
@@ -240,6 +242,10 @@ if ([string]::IsNullOrWhiteSpace($EvidencePath) -or [string]::IsNullOrWhiteSpace
     throw 'EvidencePath and EvidenceKind are required unless ProfileOnly is set.'
 }
 
+if ([string]::IsNullOrWhiteSpace($ExpectedUnityVersion)) {
+    throw 'ExpectedUnityVersion is required when validating profile evidence.'
+}
+
 $evidence = Get-RequiredJsonObject -Path $EvidencePath -Label "$EvidenceKind profile evidence"
 
 Assert-ExactProperties `
@@ -264,6 +270,11 @@ if ($evidence.evidenceKind -isnot [string] -or $evidence.evidenceKind -cne $Evid
 if ($evidence.unityVersion -isnot [string] -or [string]::IsNullOrWhiteSpace($evidence.unityVersion)) {
     throw "$EvidenceKind profile evidence unityVersion must be a non-empty string."
 }
+
+Assert-EquivalentJsonValue `
+    -Expected $ExpectedUnityVersion `
+    -Actual $evidence.unityVersion `
+    -Path "$EvidenceKind.unityVersion"
 
 $expectedValues = $profile.$EvidenceKind
 Assert-ExactProperties `


### PR DESCRIPTION
## Why

Runtime candidates need replay coverage for mutations through copied or reused handles. Performance evidence must identify the tested editor and agree with its raw results.

## What changed

- Extend the differential oracle with explicit-handle callback mutations, nested emission, stale aliases, and failure shrinking.
- Reject profile evidence from a different Unity version at every configuration, build, and runtime validation step.
- Compare complete shipping matrix rows with raw cell evidence, including provenance and nested fields.
- Reuse contract-test method discovery and avoid constructing attributes during presence checks. Keep every assertion and test category.

## Validation

[CI](https://github.com/Ambiguous-Interactive/DxMessaging/actions/runs/34088275412), [Unity](https://github.com/Ambiguous-Interactive/DxMessaging/actions/runs/34088275556), [IL2CPP performance](https://github.com/Ambiguous-Interactive/DxMessaging/actions/runs/34088275468), and [devcontainer](https://github.com/Ambiguous-Interactive/DxMessaging/actions/runs/34088275422) pass at `3e67087da13cf3d191a739d4342d204141de24c5`. All 46 checks are complete with no failures. There are no unresolved review threads.

- All four Unity versions pass EditMode, PlayMode, and Standalone. Artifact hashes and existing case outcomes match; each runtime mode gains 33 passing oracle cases and retains all 12 contract cases.
- Local Unity passes 422 focused cases and repeated ordinary runtime runs with 1,445 passes, up from 1,412, with the same expected skip.
- All 1,269 script tests and 658 documentation tests pass. Formatting, spelling, analyzer payload, and repository validation pass.
- Eight altered evidence cases fail against the original reducer. Both reducers produce identical results for the retained 20-cell shipping artifact. The version validator accepts all ten actual profile evidence files from the two IL2CPP jobs.

## CI cost

| Measurement                           |  Before |   After |
| ------------------------------------- | ------: | ------: |
| Local ordinary runtime suite mean     | 24.65 s | 23.95 s |
| Twelve Unity correctness test steps   |   787 s |   772 s |
| Two benchmark test steps, same runner |   993 s |   992 s |

These are execution times, excluding queue waits. The correctness total uses main as baseline, except Unity 2022 uses the same-runner PR551 result whose complete source tree equals main. Runner assignments vary, so the aggregate reduction is not a causal speedup claim. Unity 6000.5 has faster test suites but higher build/startup time while recompiling changed test assemblies; the baseline reused more compiled output. Its Standalone build took 41.38 seconds versus 6.99 seconds. This run does not establish future warm-cache CI duration. Test filters, benchmark windows, and existing coverage are preserved.

Advances #506, #508, and #509. Their broader campaign acceptance remains open.
