### PR TITLE
Reduce script CI time without removing tests

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -55,8 +55,6 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         wget \
         ca-certificates \
         shellcheck \
-        bubblewrap \
-        socat \
         curl \
         gnupg \
         apt-transport-https \
@@ -398,7 +396,6 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 # refresh them without sudo while keeping these copies as the offline fallback.
 RUN npm install --global --prefix /usr/local \
         @openai/codex@latest \
-        @anthropic-ai/claude-code@latest \
         opencode-ai@latest \
         @nanocollective/nanocoder@latest \
         @z_ai/mcp-server@latest \
@@ -406,7 +403,6 @@ RUN npm install --global --prefix /usr/local \
         --no-fund \
         --no-audit \
     && codex --version \
-    && claude --version \
     && opencode --version \
     && nanocoder --version
 
@@ -604,4 +600,16 @@ ENV PATH="${PATH}:/home/vscode/.dotnet/tools"
 
 # Clean up
 WORKDIR /workspaces
+
+# Backend-only tools come last so their updates retain the shared toolchain cache.
+USER root
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends \
+        bubblewrap \
+        socat \
+    && npm install --global --prefix /usr/local --cache /tmp/dxm-backend-npm \
+        @anthropic-ai/claude-code@latest --no-fund --no-audit \
+    && rm -rf /tmp/dxm-backend-npm \
+    && claude --version
 USER vscode

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -768,10 +768,27 @@ jobs:
             npm i --no-audit --no-fund
           fi
 
-      - name: Run script tests
+      - name: Run script tests and Unity editor heartbeat guards
         if: ${{ needs.changes.outputs.scripts != 'false' }}
         shell: bash
-        run: node --test scripts/
+        run: |
+          # The heartbeat probes wait on isolated child processes; overlap those waits with Node tests.
+          heartbeat_log="$RUNNER_TEMP/unity-editor-heartbeat.log"
+          pwsh -NoLogo -NoProfile -File ./scripts/__tests__/test-editor-provisioning-heartbeat.ps1 -VerboseOutput > "$heartbeat_log" 2>&1 &
+          heartbeat_pid=$!
+          # Let the probes finish their descendant cleanup even if this shell exits early.
+          trap 'wait "$heartbeat_pid" || true' EXIT
+          script_status=0
+          node --test scripts/ || script_status=$?
+          heartbeat_status=0
+          wait "$heartbeat_pid" || heartbeat_status=$?
+          echo "::group::Unity editor heartbeat guards"
+          cat "$heartbeat_log"
+          echo "::endgroup::"
+          if [ "$script_status" -ne 0 ] || [ "$heartbeat_status" -ne 0 ]; then
+            echo "::error::Script tests exited $script_status; heartbeat guards exited $heartbeat_status."
+            exit 1
+          fi
 
       - name: Test Unity retry policies
         if: ${{ needs.changes.outputs.scripts != 'false' }}
@@ -782,11 +799,6 @@ jobs:
         if: ${{ needs.changes.outputs.scripts != 'false' }}
         shell: pwsh
         run: ./scripts/__tests__/test-msvc-toolchain.ps1 -VerboseOutput
-
-      - name: Test Unity editor heartbeat guards
-        if: ${{ needs.changes.outputs.scripts != 'false' }}
-        shell: pwsh
-        run: ./scripts/__tests__/test-editor-provisioning-heartbeat.ps1 -VerboseOutput
 
       - name: Run validators
         if: ${{ needs.changes.outputs.scripts != 'false' && matrix.os == 'ubuntu-latest' }}

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -127,4 +127,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5
+        uses: actions/deploy-pages@368f82528645a54fb793d4d04e342629a3f51346 # v5

--- a/Tests/Runtime/TestUtilities/MessageBusTraceAdapter.cs
+++ b/Tests/Runtime/TestUtilities/MessageBusTraceAdapter.cs
@@ -649,10 +649,10 @@ namespace DxMessaging.Tests.Runtime
             using EmissionCapture capture = new(this);
             if (untypedRoute)
             {
-                // These are caller-visible values through the untyped boundary. The
-                // interface argument cannot marshal struct mutations back to the call
-                // site, so the recorded values pin the boundary's original payload and
-                // context, including when dispatch throws.
+                // Record the original boxed struct and caller context after the untyped
+                // bus call, including when dispatch throws. Production bridges unbox a
+                // separate local and receive context by value, so this does not observe
+                // their internal final payload/context or call extension methods.
                 switch (scenario.Kind)
                 {
                     case MessageKind.Untargeted:
@@ -714,8 +714,8 @@ namespace DxMessaging.Tests.Runtime
         }
 
         // These are caller-visible typed ref values, including when dispatch throws.
-        // Untyped APIs and extension methods' value-context boundaries are observed
-        // separately by the untyped route above.
+        // The untyped route above records its caller's original box and context;
+        // internal untyped final values and extension-method boundaries remain unobserved.
         private void EmitTyped(
             MessageScenario scenario,
             InstanceId context,

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
       "devDependencies": {
         "@modelcontextprotocol/sdk": "1.30.0",
         "@xmldom/xmldom": "0.9.12",
-        "ajv": "8.17.1",
-        "cspell": "10.1.1",
+        "ajv": "8.20.0",
+        "cspell": "10.2.2",
         "jsonc-parser": "3.3.1",
         "markdownlint-cli2": "0.23.2",
         "prettier": "3.9.6",
@@ -21,9 +21,9 @@
       }
     },
     "node_modules/@cspell/cspell-bundled-dicts": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-10.1.1.tgz",
-      "integrity": "sha512-EvPFPWwEPbPn2pIAD4D6PRRFbuM5OCiYfY0GhmpQyWWteCwR4gRmRs06UOWqfSRKHYBL/rUqcr3OAfiF5ctAjw==",
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-10.2.2.tgz",
+      "integrity": "sha512-327sQUcfHjr9TnkX2FYluLuQHSoWjSm9AiPFBpULxHofk7VvKfye12Ur4xMbOzyv7cxMROx/OeYF0oytLuLsvQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -42,9 +42,9 @@
         "@cspell/dict-docker": "^1.1.17",
         "@cspell/dict-dotnet": "^5.0.13",
         "@cspell/dict-elixir": "^4.0.8",
-        "@cspell/dict-en_us": "^4.4.36",
+        "@cspell/dict-en_us": "^4.4.37",
         "@cspell/dict-en-common-misspellings": "^2.2.0",
-        "@cspell/dict-en-gb-mit": "^3.1.25",
+        "@cspell/dict-en-gb-mit": "^3.1.26",
         "@cspell/dict-filetypes": "^3.0.18",
         "@cspell/dict-flutter": "^1.1.1",
         "@cspell/dict-fonts": "^4.0.6",
@@ -68,17 +68,17 @@
         "@cspell/dict-markdown": "^2.0.18",
         "@cspell/dict-monkeyc": "^1.1.0",
         "@cspell/dict-node": "^5.0.9",
-        "@cspell/dict-npm": "^5.2.47",
+        "@cspell/dict-npm": "^5.2.48",
         "@cspell/dict-php": "^4.1.1",
         "@cspell/dict-powershell": "^5.0.15",
         "@cspell/dict-public-licenses": "^2.0.16",
-        "@cspell/dict-python": "^4.4.0",
+        "@cspell/dict-python": "^4.5.0",
         "@cspell/dict-r": "^2.1.1",
         "@cspell/dict-ruby": "^5.1.2",
         "@cspell/dict-rust": "^4.1.2",
         "@cspell/dict-scala": "^5.0.9",
         "@cspell/dict-shell": "^1.2.0",
-        "@cspell/dict-software-terms": "^5.4.1",
+        "@cspell/dict-software-terms": "^5.4.2",
         "@cspell/dict-sql": "^2.2.1",
         "@cspell/dict-svelte": "^1.0.7",
         "@cspell/dict-swift": "^2.0.6",
@@ -92,22 +92,22 @@
       }
     },
     "node_modules/@cspell/cspell-json-reporter": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-json-reporter/-/cspell-json-reporter-10.1.1.tgz",
-      "integrity": "sha512-6makYERzgDCBGeOG7jSgZBOWxJKxBV6k0UQ60xDBZNrccACP45q8zO9YIXdHAYLmHB52l3Iz2vifeG7zhue7jA==",
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-json-reporter/-/cspell-json-reporter-10.2.2.tgz",
+      "integrity": "sha512-gm9J5COxrLqb4WV2EX6x2INoRDOq3shiaFNhUu3cOhb8YHj5e/IPJ+uVT9nBl9BZKGVRX82vseezkiss9ofiGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-types": "10.1.1"
+        "@cspell/cspell-types": "10.2.2"
       },
       "engines": {
         "node": ">=22.18.0"
       }
     },
     "node_modules/@cspell/cspell-performance-monitor": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-performance-monitor/-/cspell-performance-monitor-10.1.1.tgz",
-      "integrity": "sha512-M3Bq+K0jmbnAE2dWB8vG/TljagcKWuILTpcf6sIMB/jTaT7QH9FyzVp0Q6srlN3GEdSBwFBqrfWCorkjRUd0cQ==",
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-performance-monitor/-/cspell-performance-monitor-10.2.2.tgz",
+      "integrity": "sha512-BPPKqUPvRH7KEx5cnZY2KJHA81+V002pJirUkxT3gsrqLP/a3C0CWsZ/ST9f8ZE8OLNLHnmNkPizRPiDHada4Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -115,9 +115,9 @@
       }
     },
     "node_modules/@cspell/cspell-pipe": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-10.1.1.tgz",
-      "integrity": "sha512-WOuL9zdcl38b9P5Kpco3c1vg5v82bSWZ7LVeARbyrOmW60HxS8uP4nkbCGeU6pINvJCs0JUQxEZCRMHuEF0dfQ==",
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-10.2.2.tgz",
+      "integrity": "sha512-WP+kwmg9ltgjXo5N8m0Xwchgob6wJ+c5omY4/WNSLsyEncuRjK1e6wYYN/gs+D/d3ISzC8+yb5Ma13ymkEC+4Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -125,9 +125,9 @@
       }
     },
     "node_modules/@cspell/cspell-resolver": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-resolver/-/cspell-resolver-10.1.1.tgz",
-      "integrity": "sha512-bbsykc5c7dDdPTDFdsY0GKwXlflDDaTUycAegziFLCcp8b/q1txQmqBxx95ok1pjpU10sWxiJztZZRayFcM5sg==",
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-resolver/-/cspell-resolver-10.2.2.tgz",
+      "integrity": "sha512-DZO2vALwXVi8ajkS0p0DHPD4Uzq86fHBLksZF3MJOWV2nBZxrrUI1/kXA3Fiuil/EXSJG3tf0WX5/efoamP2Iw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -138,9 +138,9 @@
       }
     },
     "node_modules/@cspell/cspell-service-bus": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-service-bus/-/cspell-service-bus-10.1.1.tgz",
-      "integrity": "sha512-Z3BUsVllqyAoJSGXcyFp0hXtBVKEfrxVcSy3UPoSoLW9gZZjXmFwOorhga3+fMseC9VRK3L6mKSccn9YGAjsnA==",
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-service-bus/-/cspell-service-bus-10.2.2.tgz",
+      "integrity": "sha512-0UEvuTZ/mLQXg5iy1w7xzUf0gACGnaFRuY7yac7aFQjM//rP+2BXK8bC6g+4reqwBJhjeDrEHy7SvvDICgGMAg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -148,9 +148,9 @@
       }
     },
     "node_modules/@cspell/cspell-types": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-10.1.1.tgz",
-      "integrity": "sha512-lsc+/pazJQ47Zy7qyuFiQRZzco+kBSUmAtCzbmT96pFpAVxR+b4A8qRBoTdiq4OXBRXRT+CqWMNynSiwQJWM6g==",
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-10.2.2.tgz",
+      "integrity": "sha512-QfB4ux76pdgOmlhB2IUZKmkq/Ce4nojIlXzGlWGPj+gSuGC6bakL6f5lt4I0YAM8hxOwYPFvJRfkqebym1VtyQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -158,13 +158,13 @@
       }
     },
     "node_modules/@cspell/cspell-worker": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-worker/-/cspell-worker-10.1.1.tgz",
-      "integrity": "sha512-X9Ehif6c/9BRIODBjWMr0paHQrY3Jw7q0FWeSdxPZrnKhgJ+cX4vtvqlSD1dGXMV2/fGh10p1HznuDhNlQ4tjg==",
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-worker/-/cspell-worker-10.2.2.tgz",
+      "integrity": "sha512-IIoICOihmGbEftfBN35hpD5q0eS8yjzVst7Fvpbjo+XfyuUwZQNg9jzPOW4nNUskzpJT3puDRbZ8AxrodS5Kpw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cspell-lib": "10.1.1"
+        "cspell-lib": "10.2.2"
       },
       "engines": {
         "node": ">=22.18.0"
@@ -467,9 +467,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-npm": {
-      "version": "5.2.47",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-5.2.47.tgz",
-      "integrity": "sha512-r5ePbkmRtpMwiv+MHd6be1xIRLuXoEwaSLIZLu3mY+qtPVo0LUj/kVl4YeIxHONiwyef75zqS3gnT+s5UF7diQ==",
+      "version": "5.2.48",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-5.2.48.tgz",
+      "integrity": "sha512-R5dDnXTxZFOdb/4XSugCjsb3gXTHcEURGFAVOThg5QVu2YRI+yYj5vGgj9gSNffbgoQsNnaukPoB5v1tjF+tRA==",
       "dev": true,
       "license": "MIT"
     },
@@ -596,13 +596,13 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dynamic-import": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@cspell/dynamic-import/-/dynamic-import-10.1.1.tgz",
-      "integrity": "sha512-bNI+Gp0Rnx/WyOvni4TksvNWeQvCfyQAhZRIGMt+9bbLyniVagnftnoahV/yoF9h3WWxU3tL2eaVZx9B5dijuQ==",
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@cspell/dynamic-import/-/dynamic-import-10.2.2.tgz",
+      "integrity": "sha512-nYu5CP0OERXGoA1neXI7ieBSI9RSq79vTpWY4sZyK3Z9y8sL077jR3sQI5Q1ePb5tKFXof1UmRdgLS3F0Ef3uA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/url": "10.1.1",
+        "@cspell/url": "10.2.2",
         "import-meta-resolve": "^4.2.0"
       },
       "engines": {
@@ -610,9 +610,9 @@
       }
     },
     "node_modules/@cspell/filetypes": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@cspell/filetypes/-/filetypes-10.1.1.tgz",
-      "integrity": "sha512-sSREdKF4roC4QM2n0qUgv10W74nUO7CUhDTCz3Sd3mHlUM46WI8QqbAIZFNTm5U4SuVaVAmXzsZvM69O/rOjvQ==",
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@cspell/filetypes/-/filetypes-10.2.2.tgz",
+      "integrity": "sha512-UWuvbNb2rLUwClzX8V5dY2hmURlCzpyXlnUUQL3NM3eJrghSDaDmb7uqfCIiObg2F3+E/6z1dgx2QkcA0luYQQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -620,9 +620,9 @@
       }
     },
     "node_modules/@cspell/rpc": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@cspell/rpc/-/rpc-10.1.1.tgz",
-      "integrity": "sha512-sWQ++D8++6pAv8FSCfJOpc/t/yoK1r0xwcBb23SenOA9nvcmI7CwAp2FK2oByLnDTe+Bh6mQWtRRZSr3gfoGhQ==",
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@cspell/rpc/-/rpc-10.2.2.tgz",
+      "integrity": "sha512-pF4Ekt6eZZKCmdr3IqTtjfoc5UVMXI89HhCYCc4l+GRLjTDPjCX5ekuvy2asByI30NBJUETsNc6yVtmSKZ/9UQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -630,9 +630,9 @@
       }
     },
     "node_modules/@cspell/strong-weak-map": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@cspell/strong-weak-map/-/strong-weak-map-10.1.1.tgz",
-      "integrity": "sha512-s7PsRDfZO5J1dB0gtlaeNxwaibDUCYIFlbdzMawlUejR/UNrhDgDIr48OScoOt5SaUHijEVpFDkrWVyCs5R7oQ==",
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@cspell/strong-weak-map/-/strong-weak-map-10.2.2.tgz",
+      "integrity": "sha512-eXhJbPoPBzERBHncrZ02uNAS+cfvLKWGWbdaZ/R+sHZbbU3Sc4gnclQz+RRd2Vw3Q8Fra+o9ZLxAKFMB/ljvJw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -640,9 +640,9 @@
       }
     },
     "node_modules/@cspell/url": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@cspell/url/-/url-10.1.1.tgz",
-      "integrity": "sha512-5O2bZ5H/zPomc4qshTpfCbIltallsdQNwlw6j/Gl+eVElrlFsgc0kzuYJdk1BMnpA0ZXPXYH7XVKCGIKzLcr2g==",
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@cspell/url/-/url-10.2.2.tgz",
+      "integrity": "sha512-KC+Rzi9mExB1rzxoT3ysC98tGhiSbgkOXc6U8fbJmoggFswfwwJEzwa2NUNX75Thlty5ZzaPandLS4P0dh4kOA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -810,9 +810,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1141,29 +1141,29 @@
       }
     },
     "node_modules/cspell": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/cspell/-/cspell-10.1.1.tgz",
-      "integrity": "sha512-imoZaB1+9gHMyFFMDBY7VbtIdDwkRJXQjs3bIfo1H+AUJnw/vMxLwXk8mnPmH7ziw2m2kyGF+rPAVUE93VEAAA==",
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/cspell/-/cspell-10.2.2.tgz",
+      "integrity": "sha512-lQF469/Y3Fz5nlnQoAuA1ZDDheyCMNDyS3LBbAeoKL1gUKTDypH0qA6mqbp3KoZNicqGIxZoW3RoYkZ7v1tpZQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-json-reporter": "10.1.1",
-        "@cspell/cspell-performance-monitor": "10.1.1",
-        "@cspell/cspell-pipe": "10.1.1",
-        "@cspell/cspell-types": "10.1.1",
-        "@cspell/cspell-worker": "10.1.1",
-        "@cspell/dynamic-import": "10.1.1",
-        "@cspell/url": "10.1.1",
+        "@cspell/cspell-json-reporter": "10.2.2",
+        "@cspell/cspell-performance-monitor": "10.2.2",
+        "@cspell/cspell-pipe": "10.2.2",
+        "@cspell/cspell-types": "10.2.2",
+        "@cspell/cspell-worker": "10.2.2",
+        "@cspell/dynamic-import": "10.2.2",
+        "@cspell/url": "10.2.2",
         "ansi-regex": "^6.3.0",
         "chalk": "^6.0.0",
         "chalk-template": "^1.1.2",
         "commander": "^15.0.0",
-        "cspell-config-lib": "10.1.1",
-        "cspell-dictionary": "10.1.1",
-        "cspell-gitignore": "10.1.1",
-        "cspell-glob": "10.1.1",
-        "cspell-io": "10.1.1",
-        "cspell-lib": "10.1.1",
+        "cspell-config-lib": "10.2.2",
+        "cspell-dictionary": "10.2.2",
+        "cspell-gitignore": "10.2.2",
+        "cspell-glob": "10.2.2",
+        "cspell-io": "10.2.2",
+        "cspell-lib": "10.2.2",
         "fast-json-stable-stringify": "^2.1.0",
         "flatted": "^3.4.4",
         "semver": "^7.8.5",
@@ -1181,13 +1181,13 @@
       }
     },
     "node_modules/cspell-config-lib": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/cspell-config-lib/-/cspell-config-lib-10.1.1.tgz",
-      "integrity": "sha512-/AgOcOxO0jmAJCkShhaPQqSNrx+QUkEOncTf2uFnIx4/gRxFwiRZ0Zrv6PyHNBTC5vY82+qB6scT5Pj30n174A==",
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/cspell-config-lib/-/cspell-config-lib-10.2.2.tgz",
+      "integrity": "sha512-pVWQOXb6gYLx+JTNxhqWaI4qTtNXnMYtPWauQsjoHsjzQsrIeM8whhXpX5G/dt+7IriUrQNNoH1x+cCkbMQ4UA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-types": "10.1.1",
+        "@cspell/cspell-types": "10.2.2",
         "comment-json": "^5.0.0",
         "smol-toml": "^1.8.0",
         "yaml": "^2.9.0"
@@ -1197,16 +1197,16 @@
       }
     },
     "node_modules/cspell-dictionary": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-10.1.1.tgz",
-      "integrity": "sha512-94eW96hjAa3ASAjtmWkC1h1S7GLNHEoDftViilZ/nQzHxeYHp8kU73/0Jqjawr3tzfNvdKV0Bq/8zgeEp1LNrA==",
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-10.2.2.tgz",
+      "integrity": "sha512-UbdKjoiFabeJMax/CPxWU5/ut7AvQ7h/s0OgHRjDdX9do1uKdURvLhe6UlesP2w01krioAGi//ZkV1JCZOOOSg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-performance-monitor": "10.1.1",
-        "@cspell/cspell-pipe": "10.1.1",
-        "@cspell/cspell-types": "10.1.1",
-        "cspell-trie-lib": "10.1.1",
+        "@cspell/cspell-performance-monitor": "10.2.2",
+        "@cspell/cspell-pipe": "10.2.2",
+        "@cspell/cspell-types": "10.2.2",
+        "cspell-trie-lib": "10.2.2",
         "fast-equals": "^6.0.2"
       },
       "engines": {
@@ -1214,15 +1214,15 @@
       }
     },
     "node_modules/cspell-gitignore": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/cspell-gitignore/-/cspell-gitignore-10.1.1.tgz",
-      "integrity": "sha512-vYQjziKDH8qQzj/gHHJPKwmAqwfQIHBvyqukR0Uf1WzY1X08Ns9jMl5JDRUL7ffcosDYsReIhLxy2KJrxRkrng==",
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/cspell-gitignore/-/cspell-gitignore-10.2.2.tgz",
+      "integrity": "sha512-/l0nF5jBqnowXcIMbLDCjFE8sKM6lKs4NjMa87JjYiOCx/LqN3rusL/Dkumws/NB2o5NUxqDRtitiYxw7tWlvQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/url": "10.1.1",
-        "cspell-glob": "10.1.1",
-        "cspell-io": "10.1.1"
+        "@cspell/url": "10.2.2",
+        "cspell-glob": "10.2.2",
+        "cspell-io": "10.2.2"
       },
       "bin": {
         "cspell-gitignore": "bin.mjs"
@@ -1232,28 +1232,28 @@
       }
     },
     "node_modules/cspell-glob": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-10.1.1.tgz",
-      "integrity": "sha512-+xRfPD/KHU3JCMPK3Blt3AchW6KAzsyrNUdNns9mmkDRiej5Vl19kdN3eKh7B/0XoAKnX/v67tucCu/jr8MTug==",
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-10.2.2.tgz",
+      "integrity": "sha512-T1icxtdrv9QXETC0IQMBWPTNDxBYw4MPc0Z2iDPGFUjwWyYw2SBH8vC+S2HoXHt47BXg8Y2t6zbkPPkXlK1OzQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/url": "10.1.1",
-        "picomatch": "^4.0.5"
+        "@cspell/url": "10.2.2",
+        "picomatch": "^4.0.7"
       },
       "engines": {
         "node": ">=22.18.0"
       }
     },
     "node_modules/cspell-grammar": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-10.1.1.tgz",
-      "integrity": "sha512-mOHufusJEld/q8ZfC+AhequR515QIOHC0LdD1z6PU+Mpn3GRBGJBWK56iUwHH4XX935GsUMJFIQuOoMXXcbAsw==",
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-10.2.2.tgz",
+      "integrity": "sha512-GYLzoFT14FTuTmkwgzQzXInC1aUB/Wb7GzTrA7Gj8mrXFfHC/zJ1oTXufAY1fS9oGvYezvjb2LWPoMM+schmnA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-pipe": "10.1.1",
-        "@cspell/cspell-types": "10.1.1"
+        "@cspell/cspell-pipe": "10.2.2",
+        "@cspell/cspell-types": "10.2.2"
       },
       "bin": {
         "cspell-grammar": "bin.mjs"
@@ -1263,48 +1263,48 @@
       }
     },
     "node_modules/cspell-io": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-10.1.1.tgz",
-      "integrity": "sha512-Gcl2B2hKOJBqi+nf1ZnZ2XZj+VWN+AZLfQZR5dxxny3Ggy51vW8AfJX8lF8Ev/c559AkC5G7KkO2jkVuZ4SVsA==",
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-10.2.2.tgz",
+      "integrity": "sha512-ksMJwWNk2es4c9zv1yL85whDmwVM8gddRxLSRBCIqTxOUelpfE7498Ci8XvfUauWgbdHqlaTuEmCqSMzK3xIQw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-service-bus": "10.1.1",
-        "@cspell/url": "10.1.1"
+        "@cspell/cspell-service-bus": "10.2.2",
+        "@cspell/url": "10.2.2"
       },
       "engines": {
         "node": ">=22.18.0"
       }
     },
     "node_modules/cspell-lib": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-10.1.1.tgz",
-      "integrity": "sha512-jckdiCU/3pkvJ21G77R2fl93R6JjpYwP+wj8qQNUewYlTl9bdhMJi8xgLb4os7CJnHD5kA59ow8tNvh45d3zDw==",
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-10.2.2.tgz",
+      "integrity": "sha512-d9ElvCs34f5aoVEOr0aP2iqUQYjrgvETept3HIbp67cwxKLkhygO1F8Ce6vcQ+G9PiGM6DrCuwHq8zvqGbJ0LQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-bundled-dicts": "10.1.1",
-        "@cspell/cspell-performance-monitor": "10.1.1",
-        "@cspell/cspell-pipe": "10.1.1",
-        "@cspell/cspell-resolver": "10.1.1",
-        "@cspell/cspell-types": "10.1.1",
-        "@cspell/dynamic-import": "10.1.1",
-        "@cspell/filetypes": "10.1.1",
-        "@cspell/rpc": "10.1.1",
-        "@cspell/strong-weak-map": "10.1.1",
-        "@cspell/url": "10.1.1",
-        "cspell-config-lib": "10.1.1",
-        "cspell-dictionary": "10.1.1",
-        "cspell-glob": "10.1.1",
-        "cspell-grammar": "10.1.1",
-        "cspell-io": "10.1.1",
-        "cspell-trie-lib": "10.1.1",
+        "@cspell/cspell-bundled-dicts": "10.2.2",
+        "@cspell/cspell-performance-monitor": "10.2.2",
+        "@cspell/cspell-pipe": "10.2.2",
+        "@cspell/cspell-resolver": "10.2.2",
+        "@cspell/cspell-types": "10.2.2",
+        "@cspell/dynamic-import": "10.2.2",
+        "@cspell/filetypes": "10.2.2",
+        "@cspell/rpc": "10.2.2",
+        "@cspell/strong-weak-map": "10.2.2",
+        "@cspell/url": "10.2.2",
+        "cspell-config-lib": "10.2.2",
+        "cspell-dictionary": "10.2.2",
+        "cspell-glob": "10.2.2",
+        "cspell-grammar": "10.2.2",
+        "cspell-io": "10.2.2",
+        "cspell-trie-lib": "10.2.2",
         "env-paths": "^4.0.0",
         "gensequence": "^8.0.8",
         "import-fresh": "^4.0.0",
         "resolve-from": "^5.0.0",
-        "vscode-languageserver-textdocument": "^1.0.12",
-        "vscode-uri": "^3.1.0",
+        "vscode-languageserver-textdocument": "^1.0.14",
+        "vscode-uri": "^3.2.0",
         "xdg-basedir": "^5.1.0"
       },
       "engines": {
@@ -1312,16 +1312,16 @@
       }
     },
     "node_modules/cspell-trie-lib": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-10.1.1.tgz",
-      "integrity": "sha512-4ico1ebFl9lvP1Yr4pD+FxOYRS7Ct+ImV8v0KcEclxMixqNku4NoVP/CvmE1AyyVB3FN16fITN0vo3ZAR79PFw==",
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-10.2.2.tgz",
+      "integrity": "sha512-n+dscSwWLSWcN/tQhv2wJziX/AfPxRVffr6YkGOcVCov1YaL3XoWpR0f6Yk16281s231hUcLEPgcWzISTs09dw==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=22.18.0"
       },
       "peerDependencies": {
-        "@cspell/cspell-types": "10.1.1"
+        "@cspell/cspell-types": "10.2.2"
       }
     },
     "node_modules/debug": {
@@ -1610,9 +1610,9 @@
       "license": "MIT"
     },
     "node_modules/fast-equals": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-6.0.2.tgz",
-      "integrity": "sha512-sAjhj9ZhOxYCGiNMnZLaucOqf5ZeFnHNoKoAZiD9thhJ0N8RP85qJK759/97C/3L7NzzmGVB5uiX9AUpySZmUQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-6.0.3.tgz",
+      "integrity": "sha512-IECu4C0fFZFoUC2cA2rDaNUuVIfWIZMwh3tY+ng924vOuD9OaUFFrcIrVwCKbV7TJDkGmrHfhwZ7R0AnHfVhyw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -94,8 +94,8 @@
   "devDependencies": {
     "@modelcontextprotocol/sdk": "1.30.0",
     "@xmldom/xmldom": "0.9.12",
-    "ajv": "8.17.1",
-    "cspell": "10.1.1",
+    "ajv": "8.20.0",
+    "cspell": "10.2.2",
     "jsonc-parser": "3.3.1",
     "markdownlint-cli2": "0.23.2",
     "prettier": "3.9.6",


### PR DESCRIPTION
## Why

Script CI ran independent Node and heartbeat suites in sequence. Adding backend tools to early Docker layers also invalidated the remaining toolchain cache.

## What changed

- Run both complete script suites concurrently on Linux, macOS, and Windows. Retain both exit codes and logs.
- Install backend-only packages and Claude in a final Docker layer, preserving the original earlier toolchain layers.
- Correct the untyped trace comments: replay observes the caller's original box and context; internal unboxed final values remain unobserved.
- Incorporate #556 (ajv 8.20.0 and cspell 10.2.2) and #557 (deploy-pages 5.0.1). Both duplicate PRs are closed.

## Validation

All 46 checks on c3d8fc27d0de0b6a86d5cbc93c0819027738edf3 are terminal success or expected skips. No review findings remain; main CI is green.

All 15 final Unity/performance/contracts archives exactly match #558's test-entry/result multisets and summary counts. Unity retains 15,786 passes and 68 skips. Against original #555, every existing test entry remains and each runtime archive adds 12 passing cases. Local Unity MCP passes all 379 differential cases twice.

Linux/macOS pass 1,302 Node tests; Windows passes 1,262 with the same 40 skipped cases. Every platform passes 44 heartbeat assertions. Both devcontainer architecture builds and smoke suites pass.

## Controlled CI execution measurements

[Native script controls](https://github.com/Ambiguous-Interactive/DxMessaging/actions/runs/34202917409) run the exact final source serially, concurrently, concurrently, then serially on each platform. All four runs preserve every test name, outcome count, and skip state. Using the faster serial run minus the slower concurrent run gives:

| Platform | Conservative measured saving |
| --- | ---: |
| Linux x64 | 47.616 seconds |
| macOS ARM64 | 33.945 seconds |
| Windows x64 | 5.718 seconds |
| Total | 87.279 seconds |

The [native x64 build comparison](https://github.com/Ambiguous-Interactive/DxMessaging/actions/runs/34204435658) and local native ARM64 comparison pin the same base image and compare original #555 with this final source. Every changed final layer executes; warm controls reuse their layers. Charging the entire final transition builds, including export, costs 48.072 seconds on x64 and 24.645 on ARM64. Added backend checks and Unity cases bring the charged total to 73.348 seconds.

The controlled accounting therefore shows a conservative **13.931-second net execution-cost improvement**. Independent review verified exact inputs, cache markers, all test results, and the calculation. No successful measurement was discarded or rerun.

Raw hosted timings remain separate: matched job totals were 3,724 seconds originally and 3,817 seconds finally (+93 seconds, 2.5%). Queue-inclusive Unity completion was 15m07s versus 17m47s; performance was 20m29s versus 27m00s. These observations include cache and runner availability differences; the controlled result is not a guarantee that every CI run finishes sooner.

The first diagnostic build failed before measurement because the old PR commit was absent from fetched history. An explicit immutable-SHA fetch fixed setup; only that build was repeated. Its failure log is retained. The temporary diagnostic branch/worktree and local experiment image tags are removed; no diagnostic workflow changes enter this PR.

Advances bounded work for #506, #508, and #509. Independent remote restoration, native executable identity, internal untyped final-value observation, and the wider campaign requirements remain open.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are CI scheduling, Docker layer ordering, comment clarifications, and dev-tooling version pins—no runtime messaging behavior changes.
> 
> **Overview**
> **Script CI** now runs `node --test scripts/` and the Unity editor heartbeat PowerShell suite **in parallel** in one step (heartbeat in the background, Node in the foreground), waits on both, surfaces both logs, and fails if either exits non-zero. The separate heartbeat step is removed.
> 
> The **devcontainer image** moves `bubblewrap`, `socat`, and global `@anthropic-ai/claude-code` into a **final root layer** so churn on those backend-only installs does not invalidate earlier shared toolchain layers.
> 
> **Test-only comment updates** in `MessageBusTraceAdapter` clarify that untyped replay records the caller’s original boxed payload/context—not internal unboxed finals or extension-method boundaries.
> 
> **Dependency bumps:** `ajv` 8.20.0 and `cspell` 10.2.2 (`package.json` / lockfile). **Docs deploy** pins `actions/deploy-pages` to a newer v5 commit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3d8fc27d0de0b6a86d5cbc93c0819027738edf3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->