### PR TITLE
Satisfy the organization Unity enrollment audit contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -773,7 +773,7 @@ jobs:
         shell: bash
         run: |
           # The heartbeat probes wait on isolated child processes; overlap those waits with Node tests.
-          heartbeat_log="$RUNNER_TEMP/unity-editor-heartbeat.log"
+          heartbeat_log="$RUNNER_TEMP/editor-provisioning-heartbeat.log"
           pwsh -NoLogo -NoProfile -File ./scripts/__tests__/test-editor-provisioning-heartbeat.ps1 -VerboseOutput > "$heartbeat_log" 2>&1 &
           heartbeat_pid=$!
           # Let the probes finish their descendant cleanup even if this shell exits early.

--- a/.github/workflows/perf-numbers.yml
+++ b/.github/workflows/perf-numbers.yml
@@ -65,6 +65,26 @@ on:
       - docs/architecture/performance.md
       - docs/architecture/perf-baseline.csv
       - docs/architecture/perf-baseline-profile.json
+      # Documentation-only pull requests never reach this workflow, so they never
+      # need the licensed benchmark legs. Keep this list in lockstep with the
+      # documentation-only pattern that unity-tests.yml declares.
+      - "docs/**"
+      - ".docs-tests/**"
+      - "progress/**"
+      - ".llm/**"
+      - ".agents/**"
+      - ".claude/**"
+      - "Samples~/**/*.md"
+      - "Samples~/**/*.markdown"
+      - "AGENTS.md"
+      - "GOAL.md"
+      - "PLAN.md"
+      - "llms.txt"
+      - "mkdocs.yml"
+      - "requirements-docs.in"
+      - "requirements-docs.txt"
+      - "requirements-brand.in"
+      - "requirements-brand.txt"
   workflow_dispatch:
 
 # Serialize merge-path runs on the same ref so two post-merge push jobs from
@@ -140,19 +160,20 @@ jobs:
     name: Self-hosted runner registration preflight
     # Runs on GitHub-hosted infrastructure before the self-hosted matrix can
     # queue. The dedicated reader App makes missing inventory a hard failure.
+    #
+    # Dependabot and fork pull requests are excluded for the same reason the
+    # licensed benchmark job is: their jobs read from the separate Dependabot or
+    # fork secret store, so `secrets.BUILD_LOCK_READER_APP_ID` resolves empty
+    # and the fail-closed preflight aborts before it can check anything. This
+    # exact guard expression is the enrollment policy's trusted-revision shape
+    # and is checked verbatim by the organization audit.
     needs:
       - head-check
     if: >-
       ${{
-        needs.head-check.outputs.superseded != 'true' &&
-        needs.head-check.outputs.relevant != 'false' &&
-        (
-          github.event_name != 'pull_request' ||
-          (
-            github.event.pull_request.head.repo.full_name == github.repository &&
-            github.event.pull_request.user.login != 'dependabot[bot]'
-          )
-        )
+        github.event_name != 'pull_request' ||
+        (github.event.pull_request.user.login != 'dependabot[bot]' &&
+          github.event.pull_request.head.repo.full_name == github.repository)
       }}
     runs-on: ubuntu-latest
     timeout-minutes: 3
@@ -203,14 +224,22 @@ jobs:
     name: Perf benchmarks ${{ matrix.unity-version }} ${{ matrix.test-mode }} ${{ matrix.benchmark-suite }}
     needs:
       - runner-preflight
-    # Licensed Unity runs only for protected code, controlled dispatches, and trusted
-    # same-repository pull requests. Fork and Dependabot pull requests cannot
-    # reach this job or its Unity/build-lock credentials.
+    # Licensed Unity runs only for protected code, controlled dispatches, and
+    # trusted same-repository pull requests. Fork and Dependabot pull requests
+    # cannot reach this job or its Unity/build-lock credentials. This exact
+    # guard expression is the enrollment policy's trusted-revision shape and is
+    # checked verbatim by the organization audit. A superseded pull-request run
+    # still starts, but aborts at the `Require current PR head before
+    # self-hosted setup` guard before any expensive setup.
+    if: >-
+      ${{
+        github.event_name != 'pull_request' ||
+        (github.event.pull_request.user.login != 'dependabot[bot]' &&
+          github.event.pull_request.head.repo.full_name == github.repository)
+      }}
     # Both published matrix entries use isolated Standalone IL2CPP Release players.
     # Pinned to ELI-MACHINE via the `fast` label (the only self-hosted Windows
     # runner carrying it). Keep in sync with the preflight REQUIRED_LABELS.
-    env:
-      MEASURED_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
     runs-on: [self-hosted, Windows, RAM-64GB, fast]
     timeout-minutes: 900
     strategy:
@@ -243,84 +272,25 @@ jobs:
           pull-request-number: ${{ github.event.pull_request.number }}
           expected-head-sha: ${{ github.event.pull_request.head.sha }}
 
-      - name: Remove stale Unity editor validator
-        timeout-minutes: 2
-        shell: pwsh -NoProfile -Command ". '{0}'"
-        run: |
-          $workspace = [IO.Path]::GetFullPath($env:GITHUB_WORKSPACE).TrimEnd('\', '/')
-          $parent = [IO.Path]::GetFullPath((Join-Path $workspace '.ci'))
-          $target = [IO.Path]::GetFullPath((Join-Path $parent 'unity-helpers'))
-          if (-not $target.StartsWith("$workspace\", [StringComparison]::OrdinalIgnoreCase)) {
-            throw 'Validator checkout path escaped the workspace.'
-          }
-          if (Test-Path -LiteralPath $parent) {
-            $parentItem = Get-Item -LiteralPath $parent -Force
-            if (($parentItem.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
-              throw 'Validator checkout parent is a reparse point.'
-            }
-          }
-          if (Test-Path -LiteralPath $target) {
-            $targetItem = Get-Item -LiteralPath $target -Force
-            if (($targetItem.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
-              $targetItem.Delete()
-            } else {
-              Remove-Item -LiteralPath $target -Recurse -Force
-            }
-          }
-          if (Test-Path -LiteralPath $target) {
-            throw 'Validator checkout directory could not be removed.'
-          }
-
-      - name: Checkout trusted Unity editor validator
-        timeout-minutes: 5
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        env:
-          GIT_CONFIG_COUNT: 1
-          GIT_CONFIG_KEY_0: core.hooksPath
-          GIT_CONFIG_VALUE_0: /dev/null
-          GIT_CONFIG_NOSYSTEM: 1
-          GIT_CONFIG_GLOBAL: /dev/null
-        with:
-          repository: Ambiguous-Interactive/unity-helpers
-          ref: 76712db791093a9c6b2eccdd9c7bd1b4f1cdb24d
-          path: .ci/unity-helpers
-          persist-credentials: false
-          clean: true
-          set-safe-directory: false
-
+      # Contract item 3: the central immutable gate validates the runner-owned
+      # editor before any credential reference or checkout. CI never installs,
+      # repairs, or provisions an editor; a missing or unhealthy editor is an
+      # offline runner-maintenance failure. The editor check exposes its
+      # validated executable itself, so the former unity-helpers validator
+      # checkout, binding step, and diagnostics upload are gone. The profile is
+      # the reviewed static matrix.test-mode map (StandaloneWindowsIl2Cpp for
+      # the standalone legs).
       - name: Require manually installed Unity editor
+        id: ensure_unity_editor
         timeout-minutes: 10
-        shell: pwsh -NoProfile -NonInteractive -Command ". '{0}'"
-        run: |
-          & "$env:GITHUB_WORKSPACE/.ci/unity-helpers/scripts/unity/ensure-editor.ps1" `
-            -UnityVersion '${{ matrix.unity-version }}' `
-            -InstallRoot (Join-Path $env:RUNNER_TOOL_CACHE 'u6-v3') `
-            -ProvisioningProfile ${{ fromJSON('{"editmode":"EditorOnly","playmode":"EditorOnly","standalone":"StandaloneWindowsIl2Cpp"}')[matrix.test-mode] }} `
-            -DiagnosticsPath (Join-Path $env:RUNNER_TEMP 'dx-unity-editor-validation') `
-            -CiManagedOnly `
-            -RequireHealthyExisting
-
-      - name: Bind validated Unity editor
-        timeout-minutes: 2
-        shell: pwsh
-        run: |
-          # ensure-editor writes this summary from a finally block, so the evidence
-          # exists for a failed gate too, and writing it under RUNNER_TEMP keeps it
-          # out of reach of the repository checkout that follows.
-          $source = Join-Path $env:RUNNER_TEMP 'dx-unity-editor-validation\ensure-editor-summary.json'
-          if (-not (Test-Path -LiteralPath $source -PathType Leaf)) {
-            throw "Unity editor validation evidence was not written: $source"
-          }
-          $summary = Get-Content -LiteralPath $source -Raw | ConvertFrom-Json
-          $expected = [IO.Path]::GetFullPath((Join-Path $env:RUNNER_TOOL_CACHE 'u6-v3\${{ matrix.unity-version }}\Editor\Unity.exe'))
-          # A summary written by a failed gate can record no editor at all, and
-          # GetFullPath('') throws an ArgumentException instead of saying so.
-          $recorded = [string]$summary.editorPath
-          $actual = if ($recorded) { [IO.Path]::GetFullPath($recorded) } else { '(none recorded)' }
-          if (-not [string]::Equals($actual, $expected, [StringComparison]::OrdinalIgnoreCase)) {
-            throw "Validated editor '$actual' did not match the canonical editor '$expected'."
-          }
-          "UNITY_EDITOR_PATH=$expected" | Out-File -FilePath $env:GITHUB_ENV -Append
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/ensure-unity-editor@64bac446903115134dca8235410b332bc5a83547 # v1.14.0
+        with:
+          unity-version: ${{ matrix.unity-version }}
+          install-root: ${{ runner.tool_cache }}\u6-v3
+          provisioning-profile: ${{ fromJSON('{"editmode":"EditorOnly","playmode":"EditorOnly","standalone":"StandaloneWindowsIl2Cpp"}')[matrix.test-mode] }}
+          diagnostics-path: unity-editor-check.json
+          ci-managed-only: true
+          require-healthy-existing: true
 
       - name: Enable Git long paths
         timeout-minutes: 2
@@ -334,6 +304,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         env:
           GIT_CONFIG_GLOBAL: ${{ runner.temp }}/dxm-gitconfig
+          MEASURED_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
         with:
           lfs: true
           persist-credentials: false
@@ -481,28 +452,6 @@ jobs:
         shell: pwsh
         run: exit 1
 
-      - name: Redact sensitive data from Unity perf artifacts
-        id: redact_validation
-        # Require this run's Node and dependency install, not files left by a previous run.
-        # An aborted install must also skip uploads, which require successful redaction.
-        if: ${{ always() && steps.setup_node.outcome == 'success' && steps.install_dependencies.outcome == 'success' }}
-        timeout-minutes: 2
-        uses: ./.github/actions/redact-unity-artifacts
-        with:
-          paths: |
-            ${{ runner.temp }}/dx-unity-editor-validation
-            .artifacts/unity
-
-      - name: Upload Unity editor validation diagnostics
-        if: ${{ always() && steps.redact_validation.outcome == 'success' }}
-        timeout-minutes: 5
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: perf-editor-validation-${{ matrix.unity-version }}-${{ matrix.test-mode }}-${{ matrix.benchmark-suite }}
-          path: ${{ runner.temp }}/dx-unity-editor-validation
-          if-no-files-found: warn
-          retention-days: 14
-
       - name: Run comparison contracts
         id: run_contracts
         if: ${{ matrix.benchmark-suite == 'comparisons' && steps.compute.outputs.is-empty != 'true' && steps.acquire_lock.outputs.acquired == 'true' }}
@@ -549,7 +498,6 @@ jobs:
         uses: ./.github/actions/redact-unity-artifacts
         with:
           paths: |
-            ${{ runner.temp }}/dx-unity-editor-validation
             .artifacts/unity
 
       - name: Upload comparison contract artifacts
@@ -584,6 +532,7 @@ jobs:
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
           UNITY_ACCELERATOR_ENDPOINT: ${{ secrets.UNITY_ACCELERATOR_ENDPOINT }}
+          MEASURED_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           DX_PERF_COMMIT: ${{ env.MEASURED_SHA }}
           DXM_UNITY_TEST_CATEGORY: ${{ matrix.benchmark-suite == 'internal' && 'PerfBench' || 'PerfComparison' }}
           DXM_PERF_AFFINITY_MASK: ${{ steps.cpu_profile.outputs.affinity-mask }}
@@ -665,6 +614,8 @@ jobs:
         if: ${{ matrix.test-mode == 'standalone' && matrix.benchmark-suite == 'internal' && steps.run_tests.outcome == 'success' }}
         timeout-minutes: 5
         shell: pwsh
+        env:
+          MEASURED_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
         run: |
           $projectPath = Join-Path $env:RUNNER_WORKSPACE 'dxm-u\p\${{ matrix.unity-version }}-standalone-internal'
           $playerDir = Join-Path $projectPath 'Build\DxmTestPlayer'
@@ -1250,7 +1201,6 @@ jobs:
         uses: ./.github/actions/redact-unity-artifacts
         with:
           paths: |
-            ${{ runner.temp }}/dx-unity-editor-validation
             .artifacts/unity
 
       - name: Upload perf benchmark artifacts
@@ -1308,19 +1258,12 @@ jobs:
         timeout-minutes: 2
         uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-confirmed-unity-cleanup@64bac446903115134dca8235410b332bc5a83547
         with:
-          # A leg that aborts before `Acquire organization Unity lock` runs never
-          # took a seat, and this gate's own contract treats `acquired: false` as
-          # proof that licensed cleanup was not required. Feeding it the skipped
-          # step's EMPTY output instead made it fail closed on work that never
-          # started, so a leg with one honest failure reported two (#327).
-          #
-          # This does not weaken the gate. It reads `outcome`, not `acquired`, and
-          # only the two values that prove the step never executed map to 'false'.
-          # An acquire that RAN and failed part-way reports outcome=failure while
-          # `acquired` reads empty, so the empty value still flows through and the
-          # gate still fails -- that ambiguous shape is the seat leak the bare
-          # `if: always()` above exists to catch, and it stays caught.
-          acquired: ${{ (steps.acquire_lock.outcome == 'skipped' || steps.acquire_lock.outcome == '') && 'false' || steps.acquire_lock.outputs.acquired }}
+          # Typed binding to the one acquire step, exactly as the enrollment
+          # contract requires. A leg that aborts before acquire ran reports an
+          # empty output, and the gate itself treats missing or invalid
+          # acquisition state as fail-closed; only the literal `acquired=false`
+          # from a completed acquire marks cleanup as not applicable.
+          acquired: ${{ steps.acquire_lock.outputs.acquired }}
           classification-complete: ${{ steps.cleanup_classification.outputs.classification-complete }}
           cleanup-status: ${{ steps.cleanup_classification.outputs.resource-cleanup-status }}
           cleanup-health: ${{ steps.cleanup_classification.outputs.resource-health }}
@@ -1336,37 +1279,39 @@ jobs:
 
   perf-unity-success:
     name: Performance Unity Success
+    # Exactly always() -- NEVER a falsifiable job-level if. A skipped required
+    # check counts as passing and the latest run on a SHA wins, so a guard that
+    # can be false on a pull_request could launder a red/pending gate into a
+    # false green. The step below is the enrollment policy's closed trusted-skip
+    # shape: fork and Dependabot pull requests skip both the preflight and the
+    # licensed benchmarks (neither can read the organization secrets those jobs
+    # require), and every other trusted run must have executed the benchmark
+    # matrix successfully. Documentation-only pull requests never trigger this
+    # workflow at all (the pull_request paths-ignore decides that before any
+    # job runs), and a superseded pull-request run fails its per-leg head guard
+    # before it can reach the lock.
     if: always()
     needs:
-      - head-check
       - runner-preflight
       - perf-benchmarks
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    env:
-      TRUSTED_PR: >-
-        ${{
-          github.event_name != 'pull_request' ||
-          (
-            github.event.pull_request.head.repo.full_name == github.repository &&
-            github.event.pull_request.user.login != 'dependabot[bot]'
-          )
-        }}
-      SUPERSEDED: ${{ needs.head-check.outputs.superseded }}
-      RELEVANT: ${{ needs.head-check.outputs.relevant }}
     steps:
       - name: Require complete performance validation
         shell: bash
+        env:
+          RUNNER_PREFLIGHT_RESULT: ${{ needs.runner-preflight.result }}
+          UNITY_TESTS_RESULT: ${{ needs.perf-benchmarks.result }}
+          FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+          DEPENDABOT_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.user.login == 'dependabot[bot]' }}
         run: |
           set -euo pipefail
-          test "${{ needs.head-check.result }}" = success
-          if [ "${SUPERSEDED}" = "true" ] || [ "${RELEVANT}" = "false" ] || [ "${TRUSTED_PR}" != "true" ]; then
-            test "${{ needs.runner-preflight.result }}" = skipped
-            test "${{ needs.perf-benchmarks.result }}" = skipped
-            echo "Licensed performance benchmarks skip superseded, documentation-only, or untrusted pull requests."
+          if [ "${FORK_PR}" = "true" ] || [ "${DEPENDABOT_PR}" = "true" ]; then
+            test "${RUNNER_PREFLIGHT_RESULT}" = skipped
+            test "${UNITY_TESTS_RESULT}" = skipped
           else
-            test "${{ needs.runner-preflight.result }}" = success
-            test "${{ needs.perf-benchmarks.result }}" = success
+            test "${RUNNER_PREFLIGHT_RESULT}" = success
+            test "${UNITY_TESTS_RESULT}" = success
           fi
 
   comment-perf-doc:

--- a/.github/workflows/perf-numbers.yml
+++ b/.github/workflows/perf-numbers.yml
@@ -305,11 +305,10 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         env:
           GIT_CONFIG_GLOBAL: ${{ runner.temp }}/dxm-gitconfig
-          MEASURED_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
         with:
           lfs: true
           persist-credentials: false
-          ref: ${{ env.MEASURED_SHA }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
       - name: Print runner diagnostics
         timeout-minutes: 2
@@ -535,8 +534,7 @@ jobs:
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
           UNITY_ACCELERATOR_ENDPOINT: ${{ secrets.UNITY_ACCELERATOR_ENDPOINT }}
-          MEASURED_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-          DX_PERF_COMMIT: ${{ env.MEASURED_SHA }}
+          DX_PERF_COMMIT: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           DXM_UNITY_TEST_CATEGORY: ${{ matrix.benchmark-suite == 'internal' && 'PerfBench' || 'PerfComparison' }}
           DXM_PERF_AFFINITY_MASK: ${{ steps.cpu_profile.outputs.affinity-mask }}
           DXM_PERF_PRIORITY_CLASS: ${{ steps.cpu_profile.outputs.priority-class }}
@@ -617,8 +615,6 @@ jobs:
         if: ${{ matrix.test-mode == 'standalone' && matrix.benchmark-suite == 'internal' && steps.run_tests.outcome == 'success' }}
         timeout-minutes: 5
         shell: pwsh
-        env:
-          MEASURED_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
         run: |
           $projectPath = Join-Path $env:RUNNER_WORKSPACE 'dxm-u\p\${{ matrix.unity-version }}-standalone-internal'
           $playerDir = Join-Path $projectPath 'Build\DxmTestPlayer'
@@ -641,10 +637,11 @@ jobs:
           }
           $gameAssembly = $gameAssemblies[0]
           $metadata = $metadataFiles[0]
+          $playerExecutable = Get-Item -LiteralPath $playerExe
           [long]$totalBytes = ($files | Measure-Object -Property Length -Sum).Sum
           [long]$shippableBytes = ($shippableFiles | Measure-Object -Property Length -Sum).Sum
           $manifest = [ordered]@{
-            commit = '${{ env.MEASURED_SHA }}'
+            commit = '${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}'
             unityVersion = '${{ matrix.unity-version }}'
             scriptingBackend = 'IL2CPP'
             codeOptimization = 'Release'
@@ -652,7 +649,14 @@ jobs:
             apiCompatibility = '.NET Standard 2.1'
             totalBytes = $totalBytes
             shippableBytes = $shippableBytes
-            executableBytes = (Get-Item -LiteralPath $playerExe).Length
+            executableBytes = $playerExecutable.Length
+            executablePath = $playerExecutable.FullName.Substring($playerDir.Length).TrimStart(
+              [System.IO.Path]::DirectorySeparatorChar,
+              [System.IO.Path]::AltDirectorySeparatorChar
+            )
+            executableSha256 = (
+              Get-FileHash -LiteralPath $playerExecutable.FullName -Algorithm SHA256
+            ).Hash
             gameAssemblyBytes = $gameAssembly.Length
             gameAssemblyPath = $gameAssembly.FullName.Substring($playerDir.Length).TrimStart(
               [System.IO.Path]::DirectorySeparatorChar,
@@ -671,6 +675,12 @@ jobs:
             ).Hash
             fileCount = $files.Count
             shippableFileCount = $shippableFiles.Count
+          }
+          if ($manifest.executablePath -cne 'DxmTestPlayer.exe') {
+            throw "Player executable path '$($manifest.executablePath)' is not the canonical relative path."
+          }
+          if ($manifest.executableSha256 -cnotmatch '^[0-9A-F]{64}$') {
+            throw 'Player executable SHA-256 is not a complete uppercase hexadecimal digest.'
           }
           $artifactsPath = '.artifacts/unity/perf/${{ matrix.unity-version }}-standalone-internal'
           $manifest |

--- a/.github/workflows/perf-numbers.yml
+++ b/.github/workflows/perf-numbers.yml
@@ -67,7 +67,8 @@ on:
       - docs/architecture/perf-baseline-profile.json
       # Documentation-only pull requests never reach this workflow, so they never
       # need the licensed benchmark legs. Keep this list in lockstep with the
-      # documentation-only pattern that unity-tests.yml declares.
+      # documentation-only pattern that unity-tests.yml declares and that
+      # unity-docs-gate.yml evaluates for the required Unity context.
       - "docs/**"
       - ".docs-tests/**"
       - "progress/**"
@@ -458,6 +459,7 @@ jobs:
         timeout-minutes: 30
         shell: pwsh
         env:
+          UNITY_EDITOR_PATH: ${{ steps.ensure_unity_editor.outputs.editor-path }}
           UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
@@ -528,6 +530,7 @@ jobs:
         timeout-minutes: 180
         shell: pwsh
         env:
+          UNITY_EDITOR_PATH: ${{ steps.ensure_unity_editor.outputs.editor-path }}
           UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,84 +189,23 @@ jobs:
       checks: write
     timeout-minutes: 900
     steps:
-      - name: Remove stale Unity editor validator
-        timeout-minutes: 2
-        shell: pwsh -NoProfile -Command ". '{0}'"
-        run: |
-          $workspace = [IO.Path]::GetFullPath($env:GITHUB_WORKSPACE).TrimEnd('\', '/')
-          $parent = [IO.Path]::GetFullPath((Join-Path $workspace '.ci'))
-          $target = [IO.Path]::GetFullPath((Join-Path $parent 'unity-helpers'))
-          if (-not $target.StartsWith("$workspace\", [StringComparison]::OrdinalIgnoreCase)) {
-            throw 'Validator checkout path escaped the workspace.'
-          }
-          if (Test-Path -LiteralPath $parent) {
-            $parentItem = Get-Item -LiteralPath $parent -Force
-            if (($parentItem.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
-              throw 'Validator checkout parent is a reparse point.'
-            }
-          }
-          if (Test-Path -LiteralPath $target) {
-            $targetItem = Get-Item -LiteralPath $target -Force
-            if (($targetItem.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
-              $targetItem.Delete()
-            } else {
-              Remove-Item -LiteralPath $target -Recurse -Force
-            }
-          }
-          if (Test-Path -LiteralPath $target) {
-            throw 'Validator checkout directory could not be removed.'
-          }
-
-      - name: Checkout trusted Unity editor validator
-        timeout-minutes: 5
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        env:
-          GIT_CONFIG_COUNT: 1
-          GIT_CONFIG_KEY_0: core.hooksPath
-          GIT_CONFIG_VALUE_0: /dev/null
-          GIT_CONFIG_NOSYSTEM: 1
-          GIT_CONFIG_GLOBAL: /dev/null
-        with:
-          repository: Ambiguous-Interactive/unity-helpers
-          ref: 76712db791093a9c6b2eccdd9c7bd1b4f1cdb24d
-          path: .ci/unity-helpers
-          persist-credentials: false
-          clean: true
-          set-safe-directory: false
-
+      # Contract item 3: the central immutable gate validates the runner-owned
+      # editor before any credential reference or checkout. CI never installs,
+      # repairs, or provisions an editor; a missing or unhealthy editor is an
+      # offline runner-maintenance failure. The editor check exposes its
+      # validated executable itself, so the former unity-helpers validator
+      # checkout, binding step, and diagnostics upload are gone.
       - name: Require manually installed Unity editor
+        id: ensure_unity_editor
         timeout-minutes: 10
-        shell: pwsh -NoProfile -NonInteractive -Command ". '{0}'"
-        run: |
-          & "$env:GITHUB_WORKSPACE/.ci/unity-helpers/scripts/unity/ensure-editor.ps1" `
-            -UnityVersion '2022.3.45f1' `
-            -InstallRoot (Join-Path $env:RUNNER_TOOL_CACHE 'u6-v3') `
-            -ProvisioningProfile EditorOnly `
-            -DiagnosticsPath (Join-Path $env:RUNNER_TEMP 'dx-unity-editor-validation') `
-            -CiManagedOnly `
-            -RequireHealthyExisting
-
-      - name: Bind validated Unity editor
-        timeout-minutes: 2
-        shell: pwsh
-        run: |
-          # ensure-editor writes this summary from a finally block, so the evidence
-          # exists for a failed gate too, and writing it under RUNNER_TEMP keeps it
-          # out of reach of the repository checkout that follows.
-          $source = Join-Path $env:RUNNER_TEMP 'dx-unity-editor-validation\ensure-editor-summary.json'
-          if (-not (Test-Path -LiteralPath $source -PathType Leaf)) {
-            throw "Unity editor validation evidence was not written: $source"
-          }
-          $summary = Get-Content -LiteralPath $source -Raw | ConvertFrom-Json
-          $expected = [IO.Path]::GetFullPath((Join-Path $env:RUNNER_TOOL_CACHE 'u6-v3\2022.3.45f1\Editor\Unity.exe'))
-          # A summary written by a failed gate can record no editor at all, and
-          # GetFullPath('') throws an ArgumentException instead of saying so.
-          $recorded = [string]$summary.editorPath
-          $actual = if ($recorded) { [IO.Path]::GetFullPath($recorded) } else { '(none recorded)' }
-          if (-not [string]::Equals($actual, $expected, [StringComparison]::OrdinalIgnoreCase)) {
-            throw "Validated editor '$actual' did not match the canonical editor '$expected'."
-          }
-          "UNITY_EDITOR_PATH=$expected" | Out-File -FilePath $env:GITHUB_ENV -Append
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/ensure-unity-editor@64bac446903115134dca8235410b332bc5a83547 # v1.14.0
+        with:
+          unity-version: 2022.3.45f1
+          install-root: ${{ runner.tool_cache }}\u6-v3
+          provisioning-profile: EditorOnly
+          diagnostics-path: unity-editor-check.json
+          ci-managed-only: true
+          require-healthy-existing: true
 
       - name: Enable Git long paths
         timeout-minutes: 2
@@ -365,18 +304,7 @@ jobs:
         uses: ./.github/actions/redact-unity-artifacts
         with:
           paths: |
-            ${{ runner.temp }}/dx-unity-editor-validation
             .artifacts/unity
-
-      - name: Upload Unity editor validation diagnostics
-        if: ${{ always() && steps.redact_validation.outcome == 'success' }}
-        timeout-minutes: 5
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: unity-release-editor-validation-editmode
-          path: ${{ runner.temp }}/dx-unity-editor-validation
-          if-no-files-found: warn
-          retention-days: 14
 
       - name: Run Unity Test Runner
         id: run_tests
@@ -444,7 +372,6 @@ jobs:
         uses: ./.github/actions/redact-unity-artifacts
         with:
           paths: |
-            ${{ runner.temp }}/dx-unity-editor-validation
             .artifacts/unity
 
       - name: Upload release Unity artifacts
@@ -502,19 +429,12 @@ jobs:
         timeout-minutes: 2
         uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-confirmed-unity-cleanup@64bac446903115134dca8235410b332bc5a83547
         with:
-          # A leg that aborts before `Acquire organization Unity lock` runs never
-          # took a seat, and this gate's own contract treats `acquired: false` as
-          # proof that licensed cleanup was not required. Feeding it the skipped
-          # step's EMPTY output instead made it fail closed on work that never
-          # started, so a leg with one honest failure reported two (#327).
-          #
-          # This does not weaken the gate. It reads `outcome`, not `acquired`, and
-          # only the two values that prove the step never executed map to 'false'.
-          # An acquire that RAN and failed part-way reports outcome=failure while
-          # `acquired` reads empty, so the empty value still flows through and the
-          # gate still fails -- that ambiguous shape is the seat leak the bare
-          # `if: always()` above exists to catch, and it stays caught.
-          acquired: ${{ (steps.acquire_lock.outcome == 'skipped' || steps.acquire_lock.outcome == '') && 'false' || steps.acquire_lock.outputs.acquired }}
+          # Typed binding to the one acquire step, exactly as the enrollment
+          # contract requires. A leg that aborts before acquire ran reports an
+          # empty output, and the gate itself treats missing or invalid
+          # acquisition state as fail-closed; only the literal `acquired=false`
+          # from a completed acquire marks cleanup as not applicable.
+          acquired: ${{ steps.acquire_lock.outputs.acquired }}
           classification-complete: ${{ steps.cleanup_classification.outputs.classification-complete }}
           cleanup-status: ${{ steps.cleanup_classification.outputs.resource-cleanup-status }}
           cleanup-health: ${{ steps.cleanup_classification.outputs.resource-health }}
@@ -545,84 +465,23 @@ jobs:
       contents: read
     timeout-minutes: 900
     steps:
-      - name: Remove stale Unity editor validator
-        timeout-minutes: 2
-        shell: pwsh -NoProfile -Command ". '{0}'"
-        run: |
-          $workspace = [IO.Path]::GetFullPath($env:GITHUB_WORKSPACE).TrimEnd('\', '/')
-          $parent = [IO.Path]::GetFullPath((Join-Path $workspace '.ci'))
-          $target = [IO.Path]::GetFullPath((Join-Path $parent 'unity-helpers'))
-          if (-not $target.StartsWith("$workspace\", [StringComparison]::OrdinalIgnoreCase)) {
-            throw 'Validator checkout path escaped the workspace.'
-          }
-          if (Test-Path -LiteralPath $parent) {
-            $parentItem = Get-Item -LiteralPath $parent -Force
-            if (($parentItem.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
-              throw 'Validator checkout parent is a reparse point.'
-            }
-          }
-          if (Test-Path -LiteralPath $target) {
-            $targetItem = Get-Item -LiteralPath $target -Force
-            if (($targetItem.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
-              $targetItem.Delete()
-            } else {
-              Remove-Item -LiteralPath $target -Recurse -Force
-            }
-          }
-          if (Test-Path -LiteralPath $target) {
-            throw 'Validator checkout directory could not be removed.'
-          }
-
-      - name: Checkout trusted Unity editor validator
-        timeout-minutes: 5
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        env:
-          GIT_CONFIG_COUNT: 1
-          GIT_CONFIG_KEY_0: core.hooksPath
-          GIT_CONFIG_VALUE_0: /dev/null
-          GIT_CONFIG_NOSYSTEM: 1
-          GIT_CONFIG_GLOBAL: /dev/null
-        with:
-          repository: Ambiguous-Interactive/unity-helpers
-          ref: 76712db791093a9c6b2eccdd9c7bd1b4f1cdb24d
-          path: .ci/unity-helpers
-          persist-credentials: false
-          clean: true
-          set-safe-directory: false
-
+      # Contract item 3: the central immutable gate validates the runner-owned
+      # editor before any credential reference or checkout. CI never installs,
+      # repairs, or provisions an editor; a missing or unhealthy editor is an
+      # offline runner-maintenance failure. The editor check exposes its
+      # validated executable itself, so the former unity-helpers validator
+      # checkout, binding step, and diagnostics upload are gone.
       - name: Require manually installed Unity editor
+        id: ensure_unity_editor
         timeout-minutes: 10
-        shell: pwsh -NoProfile -NonInteractive -Command ". '{0}'"
-        run: |
-          & "$env:GITHUB_WORKSPACE/.ci/unity-helpers/scripts/unity/ensure-editor.ps1" `
-            -UnityVersion '2022.3.45f1' `
-            -InstallRoot (Join-Path $env:RUNNER_TOOL_CACHE 'u6-v3') `
-            -ProvisioningProfile EditorOnly `
-            -DiagnosticsPath (Join-Path $env:RUNNER_TEMP 'dx-unity-editor-validation') `
-            -CiManagedOnly `
-            -RequireHealthyExisting
-
-      - name: Bind validated Unity editor
-        timeout-minutes: 2
-        shell: pwsh
-        run: |
-          # ensure-editor writes this summary from a finally block, so the evidence
-          # exists for a failed gate too, and writing it under RUNNER_TEMP keeps it
-          # out of reach of the repository checkout that follows.
-          $source = Join-Path $env:RUNNER_TEMP 'dx-unity-editor-validation\ensure-editor-summary.json'
-          if (-not (Test-Path -LiteralPath $source -PathType Leaf)) {
-            throw "Unity editor validation evidence was not written: $source"
-          }
-          $summary = Get-Content -LiteralPath $source -Raw | ConvertFrom-Json
-          $expected = [IO.Path]::GetFullPath((Join-Path $env:RUNNER_TOOL_CACHE 'u6-v3\2022.3.45f1\Editor\Unity.exe'))
-          # A summary written by a failed gate can record no editor at all, and
-          # GetFullPath('') throws an ArgumentException instead of saying so.
-          $recorded = [string]$summary.editorPath
-          $actual = if ($recorded) { [IO.Path]::GetFullPath($recorded) } else { '(none recorded)' }
-          if (-not [string]::Equals($actual, $expected, [StringComparison]::OrdinalIgnoreCase)) {
-            throw "Validated editor '$actual' did not match the canonical editor '$expected'."
-          }
-          "UNITY_EDITOR_PATH=$expected" | Out-File -FilePath $env:GITHUB_ENV -Append
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/ensure-unity-editor@64bac446903115134dca8235410b332bc5a83547 # v1.14.0
+        with:
+          unity-version: 2022.3.45f1
+          install-root: ${{ runner.tool_cache }}\u6-v3
+          provisioning-profile: EditorOnly
+          diagnostics-path: unity-editor-check.json
+          ci-managed-only: true
+          require-healthy-existing: true
 
       - name: Enable Git long paths
         timeout-minutes: 2
@@ -706,22 +565,7 @@ jobs:
         uses: ./.github/actions/redact-unity-artifacts
         with:
           paths: |
-            ${{ runner.temp }}/dx-unity-editor-validation
             .artifacts/unity
-
-      - name: Upload Unity editor validation diagnostics
-        if: ${{ always() && steps.redact_validation.outcome == 'success' }}
-        timeout-minutes: 5
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: unity-release-editor-validation-unitypackage
-          path: ${{ runner.temp }}/dx-unity-editor-validation
-          if-no-files-found: warn
-          retention-days: 14
-          # The documented recovery for a failed export is re-running this
-          # job; the if: always() uploads from the failed attempt would 409
-          # against immutable artifact names without overwrite.
-          overwrite: true
 
       - name: Export the .unitypackage
         id: export_unitypackage
@@ -760,7 +604,6 @@ jobs:
         uses: ./.github/actions/redact-unity-artifacts
         with:
           paths: |
-            ${{ runner.temp }}/dx-unity-editor-validation
             .artifacts/unity
 
       - name: Upload the .unitypackage artifact
@@ -832,19 +675,12 @@ jobs:
         timeout-minutes: 2
         uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-confirmed-unity-cleanup@64bac446903115134dca8235410b332bc5a83547
         with:
-          # A leg that aborts before `Acquire organization Unity lock` runs never
-          # took a seat, and this gate's own contract treats `acquired: false` as
-          # proof that licensed cleanup was not required. Feeding it the skipped
-          # step's EMPTY output instead made it fail closed on work that never
-          # started, so a leg with one honest failure reported two (#327).
-          #
-          # This does not weaken the gate. It reads `outcome`, not `acquired`, and
-          # only the two values that prove the step never executed map to 'false'.
-          # An acquire that RAN and failed part-way reports outcome=failure while
-          # `acquired` reads empty, so the empty value still flows through and the
-          # gate still fails -- that ambiguous shape is the seat leak the bare
-          # `if: always()` above exists to catch, and it stays caught.
-          acquired: ${{ (steps.acquire_lock.outcome == 'skipped' || steps.acquire_lock.outcome == '') && 'false' || steps.acquire_lock.outputs.acquired }}
+          # Typed binding to the one acquire step, exactly as the enrollment
+          # contract requires. A leg that aborts before acquire ran reports an
+          # empty output, and the gate itself treats missing or invalid
+          # acquisition state as fail-closed; only the literal `acquired=false`
+          # from a completed acquire marks cleanup as not applicable.
+          acquired: ${{ steps.acquire_lock.outputs.acquired }}
           classification-complete: ${{ steps.cleanup_classification.outputs.classification-complete }}
           cleanup-status: ${{ steps.cleanup_classification.outputs.resource-cleanup-status }}
           cleanup-health: ${{ steps.cleanup_classification.outputs.resource-health }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -312,6 +312,7 @@ jobs:
         timeout-minutes: 120
         shell: pwsh
         env:
+          UNITY_EDITOR_PATH: ${{ steps.ensure_unity_editor.outputs.editor-path }}
           UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
@@ -573,6 +574,7 @@ jobs:
         timeout-minutes: 120
         shell: pwsh
         env:
+          UNITY_EDITOR_PATH: ${{ steps.ensure_unity_editor.outputs.editor-path }}
           UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}

--- a/.github/workflows/unity-benchmarks.yml
+++ b/.github/workflows/unity-benchmarks.yml
@@ -58,84 +58,25 @@ jobs:
           - editmode
           - playmode
     steps:
-      - name: Remove stale Unity editor validator
-        timeout-minutes: 2
-        shell: pwsh -NoProfile -Command ". '{0}'"
-        run: |
-          $workspace = [IO.Path]::GetFullPath($env:GITHUB_WORKSPACE).TrimEnd('\', '/')
-          $parent = [IO.Path]::GetFullPath((Join-Path $workspace '.ci'))
-          $target = [IO.Path]::GetFullPath((Join-Path $parent 'unity-helpers'))
-          if (-not $target.StartsWith("$workspace\", [StringComparison]::OrdinalIgnoreCase)) {
-            throw 'Validator checkout path escaped the workspace.'
-          }
-          if (Test-Path -LiteralPath $parent) {
-            $parentItem = Get-Item -LiteralPath $parent -Force
-            if (($parentItem.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
-              throw 'Validator checkout parent is a reparse point.'
-            }
-          }
-          if (Test-Path -LiteralPath $target) {
-            $targetItem = Get-Item -LiteralPath $target -Force
-            if (($targetItem.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
-              $targetItem.Delete()
-            } else {
-              Remove-Item -LiteralPath $target -Recurse -Force
-            }
-          }
-          if (Test-Path -LiteralPath $target) {
-            throw 'Validator checkout directory could not be removed.'
-          }
-
-      - name: Checkout trusted Unity editor validator
-        timeout-minutes: 5
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        env:
-          GIT_CONFIG_COUNT: 1
-          GIT_CONFIG_KEY_0: core.hooksPath
-          GIT_CONFIG_VALUE_0: /dev/null
-          GIT_CONFIG_NOSYSTEM: 1
-          GIT_CONFIG_GLOBAL: /dev/null
-        with:
-          repository: Ambiguous-Interactive/unity-helpers
-          ref: 76712db791093a9c6b2eccdd9c7bd1b4f1cdb24d
-          path: .ci/unity-helpers
-          persist-credentials: false
-          clean: true
-          set-safe-directory: false
-
+      # Contract item 3: the central immutable gate validates the runner-owned
+      # editor before any credential reference or checkout. CI never installs,
+      # repairs, or provisions an editor; a missing or unhealthy editor is an
+      # offline runner-maintenance failure. The editor check exposes its
+      # validated executable itself, so the former unity-helpers validator
+      # checkout, binding step, and diagnostics upload are gone. The profile is
+      # the reviewed static matrix.test-mode map (EditorOnly for the
+      # editmode/playmode legs).
       - name: Require manually installed Unity editor
+        id: ensure_unity_editor
         timeout-minutes: 10
-        shell: pwsh -NoProfile -NonInteractive -Command ". '{0}'"
-        run: |
-          & "$env:GITHUB_WORKSPACE/.ci/unity-helpers/scripts/unity/ensure-editor.ps1" `
-            -UnityVersion '${{ matrix.unity-version }}' `
-            -InstallRoot (Join-Path $env:RUNNER_TOOL_CACHE 'u6-v3') `
-            -ProvisioningProfile ${{ fromJSON('{"editmode":"EditorOnly","playmode":"EditorOnly","standalone":"StandaloneWindowsIl2Cpp"}')[matrix.test-mode] }} `
-            -DiagnosticsPath (Join-Path $env:RUNNER_TEMP 'dx-unity-editor-validation') `
-            -CiManagedOnly `
-            -RequireHealthyExisting
-
-      - name: Bind validated Unity editor
-        timeout-minutes: 2
-        shell: pwsh
-        run: |
-          # ensure-editor writes this summary from a finally block, so the evidence
-          # exists for a failed gate too, and writing it under RUNNER_TEMP keeps it
-          # out of reach of the repository checkout that follows.
-          $source = Join-Path $env:RUNNER_TEMP 'dx-unity-editor-validation\ensure-editor-summary.json'
-          if (-not (Test-Path -LiteralPath $source -PathType Leaf)) {
-            throw "Unity editor validation evidence was not written: $source"
-          }
-          $summary = Get-Content -LiteralPath $source -Raw | ConvertFrom-Json
-          $expected = [IO.Path]::GetFullPath((Join-Path $env:RUNNER_TOOL_CACHE 'u6-v3\${{ matrix.unity-version }}\Editor\Unity.exe'))
-          # A summary written by a failed gate can record no editor at all, and
-          # GetFullPath('') throws an ArgumentException instead of saying so.
-          $recorded = [string]$summary.editorPath
-          $actual = if ($recorded) { [IO.Path]::GetFullPath($recorded) } else { '(none recorded)' }
-          if (-not [string]::Equals($actual, $expected, [StringComparison]::OrdinalIgnoreCase)) {
-            throw "Validated editor '$actual' did not match the canonical editor '$expected'."
-          }
-          "UNITY_EDITOR_PATH=$expected" | Out-File -FilePath $env:GITHUB_ENV -Append
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/ensure-unity-editor@64bac446903115134dca8235410b332bc5a83547 # v1.14.0
+        with:
+          unity-version: ${{ matrix.unity-version }}
+          install-root: ${{ runner.tool_cache }}\u6-v3
+          provisioning-profile: ${{ fromJSON('{"editmode":"EditorOnly","playmode":"EditorOnly","standalone":"StandaloneWindowsIl2Cpp"}')[matrix.test-mode] }}
+          diagnostics-path: unity-editor-check.json
+          ci-managed-only: true
+          require-healthy-existing: true
 
       - name: Enable Git long paths
         timeout-minutes: 2
@@ -239,28 +180,6 @@ jobs:
         shell: pwsh
         run: exit 1
 
-      - name: Redact sensitive data from Unity benchmark artifacts
-        id: redact_validation
-        # Require this run's Node and dependency install, not files left by a previous run.
-        # An aborted install must also skip uploads, which require successful redaction.
-        if: ${{ always() && steps.setup_node.outcome == 'success' && steps.install_dependencies.outcome == 'success' }}
-        timeout-minutes: 2
-        uses: ./.github/actions/redact-unity-artifacts
-        with:
-          paths: |
-            ${{ runner.temp }}/dx-unity-editor-validation
-            .artifacts/unity
-
-      - name: Upload Unity editor validation diagnostics
-        if: ${{ always() && steps.redact_validation.outcome == 'success' }}
-        timeout-minutes: 5
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: unity-benchmark-editor-validation-${{ matrix.unity-version }}-${{ matrix.test-mode }}
-          path: ${{ runner.temp }}/dx-unity-editor-validation
-          if-no-files-found: warn
-          retention-days: 90
-
       - name: Run Unity Test Runner
         id: run_tests
         if: ${{ steps.compute.outputs.is-empty != 'true' && steps.acquire_lock.outputs.acquired == 'true' }}
@@ -342,7 +261,6 @@ jobs:
         uses: ./.github/actions/redact-unity-artifacts
         with:
           paths: |
-            ${{ runner.temp }}/dx-unity-editor-validation
             .artifacts/unity
 
       - name: Upload benchmark artifacts
@@ -400,19 +318,12 @@ jobs:
         timeout-minutes: 2
         uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-confirmed-unity-cleanup@64bac446903115134dca8235410b332bc5a83547
         with:
-          # A leg that aborts before `Acquire organization Unity lock` runs never
-          # took a seat, and this gate's own contract treats `acquired: false` as
-          # proof that licensed cleanup was not required. Feeding it the skipped
-          # step's EMPTY output instead made it fail closed on work that never
-          # started, so a leg with one honest failure reported two (#327).
-          #
-          # This does not weaken the gate. It reads `outcome`, not `acquired`, and
-          # only the two values that prove the step never executed map to 'false'.
-          # An acquire that RAN and failed part-way reports outcome=failure while
-          # `acquired` reads empty, so the empty value still flows through and the
-          # gate still fails -- that ambiguous shape is the seat leak the bare
-          # `if: always()` above exists to catch, and it stays caught.
-          acquired: ${{ (steps.acquire_lock.outcome == 'skipped' || steps.acquire_lock.outcome == '') && 'false' || steps.acquire_lock.outputs.acquired }}
+          # Typed binding to the one acquire step, exactly as the enrollment
+          # contract requires. A leg that aborts before acquire ran reports an
+          # empty output, and the gate itself treats missing or invalid
+          # acquisition state as fail-closed; only the literal `acquired=false`
+          # from a completed acquire marks cleanup as not applicable.
+          acquired: ${{ steps.acquire_lock.outputs.acquired }}
           classification-complete: ${{ steps.cleanup_classification.outputs.classification-complete }}
           cleanup-status: ${{ steps.cleanup_classification.outputs.resource-cleanup-status }}
           cleanup-health: ${{ steps.cleanup_classification.outputs.resource-health }}

--- a/.github/workflows/unity-benchmarks.yml
+++ b/.github/workflows/unity-benchmarks.yml
@@ -186,6 +186,7 @@ jobs:
         timeout-minutes: 120
         shell: pwsh
         env:
+          UNITY_EDITOR_PATH: ${{ steps.ensure_unity_editor.outputs.editor-path }}
           UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}

--- a/.github/workflows/unity-docs-gate.yml
+++ b/.github/workflows/unity-docs-gate.yml
@@ -1,0 +1,84 @@
+name: Unity Docs Gate
+
+# The repository ruleset requires the "Unity CI Success" context on every pull
+# request into master. unity-tests.yml decides its documentation-only skip with
+# pull_request paths-ignore, so that workflow is absent (never red, just absent)
+# for a documentation-only pull request and the required context would hang.
+# This workflow has NO paths filter, so it is present on every pull request and
+# reports the same context name:
+#
+# - Every changed file matches the exact documentation-only allowlist that
+#   unity-tests.yml paths-ignore declares: the licensed matrix did not trigger,
+#   so this gate reports the same skip-green that the master head-check job
+#   used to decide in-band.
+# - Anything else changed: this gate fails closed. It never reports success,
+#   because the licensed matrix owns that result; unity-tests.yml reports the
+#   authoritative "Unity CI Success" check for those pull requests and the
+#   latest report wins.
+#
+# Because the two workflows share the context name, re-running this workflow
+# manually on a code pull request reports a red duplicate until the
+# unity-tests aggregate runs again. That is fail-closed and visible; it never
+# masks the licensed result.
+on:
+  pull_request:
+    branches:
+      - master
+
+concurrency:
+  group: unity-docs-gate-${{ github.event.pull_request.number && format('{0}-{1}', github.event.pull_request.number, github.event.pull_request.head.sha) || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: read
+
+jobs:
+  unity-ci-success:
+    name: Unity CI Success
+    # Exactly always() -- the required check must be present on every pull
+    # request, so this job can never carry a falsifiable condition. The
+    # documentation-only decision lives inside the single step and fails
+    # closed: a lookup failure or an unexpected listing reports red instead of
+    # a skip.
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Report the documentation-only Unity result
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          if [ "${EVENT_NAME}" != "pull_request" ]; then
+            echo "::error::This gate evaluates pull requests only; refusing to infer a Unity result from ${EVENT_NAME}."
+            exit 1
+          fi
+          # Include previous_filename so a rename reports both endpoints and
+          # cannot smuggle a renamed code file past the allowlist.
+          if ! files="$(gh api --paginate \
+            "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" \
+            --jq '.[] | .filename, (.previous_filename // empty)')"; then
+            echo "::error::Changed-file lookup failed; the required Unity gate cannot prove a documentation-only change."
+            exit 1
+          fi
+          if [ -z "${files}" ]; then
+            echo "::error::The changed-file listing is empty; refusing to report a documentation-only skip."
+            exit 1
+          fi
+          # SYNC: this allowlist must stay equivalent to the pull_request
+          # paths-ignore list in unity-tests.yml, so this gate reports green
+          # exactly when that workflow is absent. scripts/__tests__/ci-aggregate-workflow.test.js
+          # asserts the lockstep and the path vectors.
+          documentation_only_pattern='^(docs/|\.docs-tests/|progress/|\.llm/|\.agents/|\.claude/|Samples~/.*\.(md|markdown)$|(AGENTS|GOAL|PLAN)\.md$|llms\.txt$|mkdocs\.yml$|requirements-(docs|brand)\.(in|txt)$)'
+          non_documentation="$(printf '%s\n' "${files}" | grep -Ev "${documentation_only_pattern}" || true)"
+          if [ -n "${non_documentation}" ]; then
+            echo "::error::Non-documentation files changed; the licensed Unity result for this pull request comes from the unity-tests workflow, not this docs gate."
+            printf '%s\n' "${non_documentation}" | sed -n '1,20p'
+            exit 1
+          fi
+          echo "::notice::Only documentation and agent-context files changed; unity-tests is path-filtered for this pull request, so this gate reports the documentation-only skip-green."

--- a/.github/workflows/unity-docs-gate.yml
+++ b/.github/workflows/unity-docs-gate.yml
@@ -4,26 +4,41 @@ name: Unity Docs Gate
 # request into master. unity-tests.yml decides its documentation-only skip with
 # pull_request paths-ignore, so that workflow is absent (never red, just absent)
 # for a documentation-only pull request and the required context would hang.
-# This workflow has NO paths filter, so it is present on every pull request and
-# reports the same context name:
+# Positive paths start this workflow when a documentation path changes. The
+# classifier then distinguishes documentation-only changes from mixed changes:
 #
 # - Every changed file matches the exact documentation-only allowlist that
 #   unity-tests.yml paths-ignore declares: the licensed matrix did not trigger,
 #   so this gate reports the same skip-green that the master head-check job
 #   used to decide in-band.
-# - Anything else changed: this gate fails closed. It never reports success,
-#   because the licensed matrix owns that result; unity-tests.yml reports the
-#   authoritative "Unity CI Success" check for those pull requests and the
-#   latest report wins.
-#
-# Because the two workflows share the context name, re-running this workflow
-# manually on a code pull request reports a red duplicate until the
-# unity-tests aggregate runs again. That is fail-closed and visible; it never
-# masks the licensed result.
+# - A documentation path and any non-documentation path changed: the report job
+#   uses a distinct name, so the licensed matrix remains the only owner of the
+#   required context.
+# - Changed-file lookup fails: the report keeps the required context name and
+#   fails closed.
 on:
   pull_request:
     branches:
       - master
+    paths:
+      - ".github/workflows/**"
+      - "docs/**"
+      - ".docs-tests/**"
+      - "progress/**"
+      - ".llm/**"
+      - ".agents/**"
+      - ".claude/**"
+      - "Samples~/**/*.md"
+      - "Samples~/**/*.markdown"
+      - "AGENTS.md"
+      - "GOAL.md"
+      - "PLAN.md"
+      - "llms.txt"
+      - "mkdocs.yml"
+      - "requirements-docs.in"
+      - "requirements-docs.txt"
+      - "requirements-brand.in"
+      - "requirements-brand.txt"
 
 concurrency:
   group: unity-docs-gate-${{ github.event.pull_request.number && format('{0}-{1}', github.event.pull_request.number, github.event.pull_request.head.sha) || github.ref }}
@@ -35,41 +50,50 @@ permissions:
   pull-requests: read
 
 jobs:
-  unity-ci-success:
-    name: Unity CI Success
-    # Exactly always() -- the required check must be present on every pull
-    # request, so this job can never carry a falsifiable condition. The
-    # documentation-only decision lives inside the single step and fails
-    # closed: a lookup failure or an unexpected listing reports red instead of
-    # a skip.
-    if: ${{ always() }}
+  classify:
+    name: Classify documentation-only Unity gate
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    outputs:
+      documentation_only: ${{ steps.classify.outputs.documentation_only }}
     steps:
-      - name: Report the documentation-only Unity result
+      - name: Classify changed paths
+        id: classify
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
           EVENT_NAME: ${{ github.event_name }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          EXPECTED_FILE_COUNT: ${{ github.event.pull_request.changed_files }}
         run: |
           set -euo pipefail
           if [ "${EVENT_NAME}" != "pull_request" ]; then
             echo "::error::This gate evaluates pull requests only; refusing to infer a Unity result from ${EVENT_NAME}."
             exit 1
           fi
-          # Include previous_filename so a rename reports both endpoints and
-          # cannot smuggle a renamed code file past the allowlist.
-          if ! files="$(gh api --paginate \
+          if ! [[ "${EXPECTED_FILE_COUNT}" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::The pull request did not declare a positive changed-file count."
+            exit 1
+          fi
+          # Emit one JSON record per API entry so the count stays independent
+          # from previous_filename. A rename still contributes both endpoints
+          # to the allowlist evaluation below.
+          if ! records="$(gh api --paginate \
             "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" \
-            --jq '.[] | .filename, (.previous_filename // empty)')"; then
+            --jq '.[] | [.filename, (.previous_filename // null)] | @json')"; then
             echo "::error::Changed-file lookup failed; the required Unity gate cannot prove a documentation-only change."
             exit 1
           fi
-          if [ -z "${files}" ]; then
+          if [ -z "${records}" ]; then
             echo "::error::The changed-file listing is empty; refusing to report a documentation-only skip."
             exit 1
           fi
+          listed_file_count="$(printf '%s\n' "${records}" | wc -l | tr -d '[:space:]')"
+          if [ "${listed_file_count}" != "${EXPECTED_FILE_COUNT}" ]; then
+            echo "::error::Changed-file listing is incomplete: expected ${EXPECTED_FILE_COUNT}, received ${listed_file_count}."
+            exit 1
+          fi
+          files="$(printf '%s\n' "${records}" | jq -r '.[] | select(. != null)')"
           # SYNC: this allowlist must stay equivalent to the pull_request
           # paths-ignore list in unity-tests.yml, so this gate reports green
           # exactly when that workflow is absent. scripts/__tests__/ci-aggregate-workflow.test.js
@@ -77,8 +101,38 @@ jobs:
           documentation_only_pattern='^(docs/|\.docs-tests/|progress/|\.llm/|\.agents/|\.claude/|Samples~/.*\.(md|markdown)$|(AGENTS|GOAL|PLAN)\.md$|llms\.txt$|mkdocs\.yml$|requirements-(docs|brand)\.(in|txt)$)'
           non_documentation="$(printf '%s\n' "${files}" | grep -Ev "${documentation_only_pattern}" || true)"
           if [ -n "${non_documentation}" ]; then
-            echo "::error::Non-documentation files changed; the licensed Unity result for this pull request comes from the unity-tests workflow, not this docs gate."
+            echo "::notice::Non-documentation files also changed; the licensed Unity result comes from the unity-tests workflow."
             printf '%s\n' "${non_documentation}" | sed -n '1,20p'
+            echo "documentation_only=false" >> "${GITHUB_OUTPUT}"
+          else
+            echo "documentation_only=true" >> "${GITHUB_OUTPUT}"
+          fi
+
+  report:
+    name: ${{ (needs.classify.result != 'success' || needs.classify.outputs.documentation_only != 'false') && 'Unity CI Success' || 'Unity docs gate not applicable' }}
+    needs:
+      - classify
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Report the documentation-only Unity result
+        shell: bash
+        env:
+          CLASSIFICATION_RESULT: ${{ needs.classify.result }}
+          DOCUMENTATION_ONLY: ${{ needs.classify.outputs.documentation_only }}
+        run: |
+          set -euo pipefail
+          if [ "${CLASSIFICATION_RESULT}" != "success" ]; then
+            echo "::error::Changed-file classification failed; the required Unity gate cannot prove a documentation-only change."
+            exit 1
+          fi
+          if [ "${DOCUMENTATION_ONLY}" = "false" ]; then
+            echo "::notice::The licensed unity-tests workflow owns the required Unity result for this mixed pull request."
+            exit 0
+          fi
+          if [ "${DOCUMENTATION_ONLY}" != "true" ]; then
+            echo "::error::Changed-file classification produced an invalid result."
             exit 1
           fi
           echo "::notice::Only documentation and agent-context files changed; unity-tests is path-filtered for this pull request, so this gate reports the documentation-only skip-green."

--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -4,6 +4,28 @@ on:
   pull_request:
     branches:
       - master
+    # Documentation-only pull requests never reach this workflow, so they never
+    # need the licensed Unity matrix: the docs-only skip that head-check used to
+    # decide in-band is now decided by the trigger itself. Keep this list in
+    # lockstep with the documentation-only pattern that perf-numbers.yml uses.
+    paths-ignore:
+      - "docs/**"
+      - ".docs-tests/**"
+      - "progress/**"
+      - ".llm/**"
+      - ".agents/**"
+      - ".claude/**"
+      - "Samples~/**/*.md"
+      - "Samples~/**/*.markdown"
+      - "AGENTS.md"
+      - "GOAL.md"
+      - "PLAN.md"
+      - "llms.txt"
+      - "mkdocs.yml"
+      - "requirements-docs.in"
+      - "requirements-docs.txt"
+      - "requirements-brand.in"
+      - "requirements-brand.txt"
   push:
     branches:
       - master
@@ -17,8 +39,6 @@ on:
         description: "Run the exhaustive stripped-player matrix"
         type: boolean
         default: false
-  schedule:
-    - cron: "17 4 * * 0"
 
 concurrency:
   # Push runs share one group per ref, so consecutive default-branch pushes stay
@@ -42,98 +62,34 @@ permissions:
   pull-requests: read
 
 jobs:
-  head-check:
-    name: Unity head freshness
-    # A second push to a pull request queues a second full matrix and does not
-    # retire the first: `cancel-in-progress: false` above is deliberate, because
-    # a hard cancel mid-lock is the exact scenario the four-layer license-return
-    # guarantee exists to avoid. The head-SHA-keyed concurrency group above lets
-    # the new run start anyway, so what is left to avoid is the superseded run
-    # handing a scarce self-hosted runner to every remaining leg purely so that
-    # leg can abort.
-    #
-    # Deciding it here, on GitHub-hosted infrastructure and before the lock is
-    # in reach, costs a superseded run one cheap job instead of four
-    # self-hosted ones. The per-leg `Require current PR head before setup`
-    # guard stays: it covers the push that lands after this job has already
-    # passed.
-    #
-    # Fail open. Anything other than a pull request, and any lookup that does
-    # not return a head SHA, reports `superseded=false` and runs the matrix.
-    runs-on: ubuntu-latest
-    timeout-minutes: 3
-    outputs:
-      relevant: ${{ steps.head.outputs.relevant }}
-      superseded: ${{ steps.head.outputs.superseded }}
-    steps:
-      - name: Compare the event head against the live pull-request head
-        id: head
-        shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
-          EVENT_NAME: ${{ github.event_name }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          set -euo pipefail
-          relevant=true
-          superseded=false
-          if [ "${EVENT_NAME}" = pull_request ]; then
-            live="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq .head.sha)" || live=
-            if [ -z "${live}" ]; then
-              echo "::warning::Live head lookup failed; treating ${EVENT_HEAD_SHA} as current."
-            elif [ "${live}" != "${EVENT_HEAD_SHA}" ]; then
-              echo "::notice::${EVENT_HEAD_SHA} is superseded by ${live}; skipping the Unity matrix."
-              superseded=true
-            fi
-            if files="$(gh api --paginate \
-              "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" \
-              --jq '.[] | .filename, (.previous_filename // empty)')"; then
-              documentation_only_pattern='^(docs/|\.docs-tests/|progress/|\.llm/|\.agents/|\.claude/|Samples~/.*\.(md|markdown)(\.meta)?$|(AGENTS|GOAL|PLAN)\.md(\.meta)?$|llms\.txt$|mkdocs\.yml$|requirements-(docs|brand)\.(in|txt)(\.meta)?$)'
-              non_documentation="$(printf '%s\n' "${files}" | grep -Ev "${documentation_only_pattern}" || true)"
-              if [ -n "${files}" ] && [ -z "${non_documentation}" ]; then
-                echo "::notice::Only documentation and agent-context files changed; skipping licensed Unity tests."
-                relevant=false
-              fi
-            else
-              echo "::warning::Changed-file lookup failed; running licensed Unity tests."
-            fi
-          fi
-          echo "relevant=${relevant}" >> "${GITHUB_OUTPUT}"
-          echo "superseded=${superseded}" >> "${GITHUB_OUTPUT}"
-
   runner-preflight:
     name: Self-hosted runner registration preflight
     # Runs on GitHub-hosted infrastructure before any self-hosted matrix entry
     # can queue. Reader-App or inventory failures are intentionally fail closed.
     #
-    # Dependabot pull requests are excluded for the same reason fork pull
-    # requests are: their jobs read from the separate Dependabot secret store,
-    # so `secrets.BUILD_LOCK_READER_APP_ID` resolves empty and the fail-closed
-    # preflight aborts with "Missing required input: reader-app-id" before it
-    # can check anything. Running it there cannot pass, and the licensed Unity
-    # secrets below are unreadable for the same reason. Dependency bumps are
-    # validated by the full matrix on the post-merge push to master.
-    needs:
-      - head-check
+    # Dependabot and fork pull requests are excluded for the same reason their
+    # licensed jobs are: their jobs read from the separate Dependabot or fork
+    # secret store, so `secrets.BUILD_LOCK_READER_APP_ID` resolves empty and the
+    # fail-closed preflight aborts with "Missing required input: reader-app-id"
+    # before it can check anything. Running it there cannot pass, and the
+    # licensed Unity secrets below are unreadable for the same reason.
+    # Dependency bumps are validated by the full matrix on the post-merge push
+    # to master. This exact guard expression is the enrollment policy's
+    # trusted-revision shape and is checked verbatim by the organization audit.
     if: >-
       ${{
-        needs.head-check.outputs.superseded != 'true' &&
-        needs.head-check.outputs.relevant != 'false' &&
-        (github.event_name != 'pull_request' ||
+        github.event_name != 'pull_request' ||
         (github.event.pull_request.user.login != 'dependabot[bot]' &&
-          github.event.pull_request.head.repo.full_name == github.repository))
+          github.event.pull_request.head.repo.full_name == github.repository)
       }}
     runs-on: ubuntu-latest
     timeout-minutes: 3
     concurrency:
-      # Keyed exactly like the workflow-level group. A `github.ref`-only key was
-      # unreachable while that group serialized every run of a pull request; now
-      # that it does not, the key has to match, or a newer run would cancel a
-      # superseded run's preflight, skip that run's whole matrix, and leave its
-      # aggregate reporting a result shape the gate below does not describe.
+      # A superseded run's preflight is never cancelled: cancel-in-progress is
+      # false so a newer run can only queue behind it, and every licensed leg
+      # re-checks the pull-request head before it can reach the lock.
       group: ${{ github.workflow }}-runner-preflight-${{ github.event.pull_request.number && format('{0}-{1}', github.event.pull_request.number, github.event.pull_request.head.sha) || github.ref }}
-      cancel-in-progress: true
+      cancel-in-progress: false
     steps:
       - name: Require a registered Unity runner
         uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/check-unity-runner-availability@64bac446903115134dca8235410b332bc5a83547 # v1.14.0
@@ -144,27 +100,22 @@ jobs:
 
   unity-tests:
     name: Unity ${{ matrix.unity-version }} all modes
-    env:
-      # Keep twenty additional player builds per endpoint out of ordinary CI.
-      DXM_RUN_SHIPPING: >-
-        ${{ (github.event_name == 'schedule' ||
-        (github.event_name == 'workflow_dispatch' && inputs.shipping_fidelity)) &&
-        (matrix.unity-version == '2021.3.45f1' || matrix.unity-version == '6000.5.2f1') }}
     needs:
-      - head-check
       - runner-preflight
     # Same-repository pull requests run licensed validation with organization
     # secrets and no environment approval. Fork pull requests and Dependabot
     # pull requests remain static-only: neither can read the organization Unity
     # serial or build-lock App secrets, so a licensed leg there fails on missing
-    # credentials rather than on the change under test.
+    # credentials rather than on the change under test. This exact guard
+    # expression is the enrollment policy's trusted-revision shape and is
+    # checked verbatim by the organization audit. A superseded pull-request run
+    # still starts, but each leg aborts at the `Require current PR head before
+    # setup` guard before any expensive setup.
     if: >-
       ${{
-        needs.head-check.outputs.superseded != 'true' &&
-        needs.head-check.outputs.relevant != 'false' &&
-        (github.event_name != 'pull_request' ||
+        github.event_name != 'pull_request' ||
         (github.event.pull_request.user.login != 'dependabot[bot]' &&
-          github.event.pull_request.head.repo.full_name == github.repository))
+          github.event.pull_request.head.repo.full_name == github.repository)
       }}
     runs-on: [self-hosted, Windows, RAM-64GB]
     timeout-minutes: 1050
@@ -186,84 +137,23 @@ jobs:
           pull-request-number: ${{ github.event.pull_request.number }}
           expected-head-sha: ${{ github.event.pull_request.head.sha }}
 
-      - name: Remove stale Unity editor validator
-        timeout-minutes: 2
-        shell: pwsh -NoProfile -Command ". '{0}'"
-        run: |
-          $workspace = [IO.Path]::GetFullPath($env:GITHUB_WORKSPACE).TrimEnd('\', '/')
-          $parent = [IO.Path]::GetFullPath((Join-Path $workspace '.ci'))
-          $target = [IO.Path]::GetFullPath((Join-Path $parent 'unity-helpers'))
-          if (-not $target.StartsWith("$workspace\", [StringComparison]::OrdinalIgnoreCase)) {
-            throw 'Validator checkout path escaped the workspace.'
-          }
-          if (Test-Path -LiteralPath $parent) {
-            $parentItem = Get-Item -LiteralPath $parent -Force
-            if (($parentItem.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
-              throw 'Validator checkout parent is a reparse point.'
-            }
-          }
-          if (Test-Path -LiteralPath $target) {
-            $targetItem = Get-Item -LiteralPath $target -Force
-            if (($targetItem.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
-              $targetItem.Delete()
-            } else {
-              Remove-Item -LiteralPath $target -Recurse -Force
-            }
-          }
-          if (Test-Path -LiteralPath $target) {
-            throw 'Validator checkout directory could not be removed.'
-          }
-
-      - name: Checkout trusted Unity editor validator
-        timeout-minutes: 5
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        env:
-          GIT_CONFIG_COUNT: 1
-          GIT_CONFIG_KEY_0: core.hooksPath
-          GIT_CONFIG_VALUE_0: /dev/null
-          GIT_CONFIG_NOSYSTEM: 1
-          GIT_CONFIG_GLOBAL: /dev/null
-        with:
-          repository: Ambiguous-Interactive/unity-helpers
-          ref: 76712db791093a9c6b2eccdd9c7bd1b4f1cdb24d
-          path: .ci/unity-helpers
-          persist-credentials: false
-          clean: true
-          set-safe-directory: false
-
+      # Contract item 3: the central immutable gate validates the runner-owned
+      # editor before any credential reference or checkout. CI never installs,
+      # repairs, or provisions an editor; a missing or unhealthy editor is an
+      # offline runner-maintenance failure. The editor check exposes its
+      # validated executable itself, so the former unity-helpers validator
+      # checkout, binding step, and diagnostics upload are gone.
       - name: Require manually installed Unity editor
+        id: ensure_unity_editor
         timeout-minutes: 10
-        shell: pwsh -NoProfile -NonInteractive -Command ". '{0}'"
-        run: |
-          & "$env:GITHUB_WORKSPACE/.ci/unity-helpers/scripts/unity/ensure-editor.ps1" `
-            -UnityVersion '${{ matrix.unity-version }}' `
-            -InstallRoot (Join-Path $env:RUNNER_TOOL_CACHE 'u6-v3') `
-            -ProvisioningProfile StandaloneWindowsIl2Cpp `
-            -DiagnosticsPath (Join-Path $env:RUNNER_TEMP 'dx-unity-editor-validation') `
-            -CiManagedOnly `
-            -RequireHealthyExisting
-
-      - name: Bind validated Unity editor
-        timeout-minutes: 2
-        shell: pwsh
-        run: |
-          # ensure-editor writes this summary from a finally block, so the evidence
-          # exists for a failed gate too, and writing it under RUNNER_TEMP keeps it
-          # out of reach of the repository checkout that follows.
-          $source = Join-Path $env:RUNNER_TEMP 'dx-unity-editor-validation\ensure-editor-summary.json'
-          if (-not (Test-Path -LiteralPath $source -PathType Leaf)) {
-            throw "Unity editor validation evidence was not written: $source"
-          }
-          $summary = Get-Content -LiteralPath $source -Raw | ConvertFrom-Json
-          $expected = [IO.Path]::GetFullPath((Join-Path $env:RUNNER_TOOL_CACHE 'u6-v3\${{ matrix.unity-version }}\Editor\Unity.exe'))
-          # A summary written by a failed gate can record no editor at all, and
-          # GetFullPath('') throws an ArgumentException instead of saying so.
-          $recorded = [string]$summary.editorPath
-          $actual = if ($recorded) { [IO.Path]::GetFullPath($recorded) } else { '(none recorded)' }
-          if (-not [string]::Equals($actual, $expected, [StringComparison]::OrdinalIgnoreCase)) {
-            throw "Validated editor '$actual' did not match the canonical editor '$expected'."
-          }
-          "UNITY_EDITOR_PATH=$expected" | Out-File -FilePath $env:GITHUB_ENV -Append
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/ensure-unity-editor@64bac446903115134dca8235410b332bc5a83547 # v1.14.0
+        with:
+          unity-version: ${{ matrix.unity-version }}
+          install-root: ${{ runner.tool_cache }}\u6-v3
+          provisioning-profile: EditorOnly
+          diagnostics-path: unity-editor-check.json
+          ci-managed-only: true
+          require-healthy-existing: true
 
       - name: Enable Git long paths
         timeout-minutes: 2
@@ -403,28 +293,6 @@ jobs:
         shell: pwsh
         run: exit 1
 
-      - name: Redact sensitive data from Unity editor validation diagnostics
-        id: redact_validation
-        # Require this run's Node and dependency install, not files left by a previous run.
-        # An aborted install must also skip uploads, which require successful redaction.
-        if: ${{ always() && steps.setup_node.outcome == 'success' && steps.install_dependencies.outcome == 'success' }}
-        timeout-minutes: 2
-        uses: ./.github/actions/redact-unity-artifacts
-        with:
-          paths: |
-            ${{ runner.temp }}/dx-unity-editor-validation
-            .artifacts/unity
-
-      - name: Upload Unity editor validation diagnostics
-        if: ${{ always() && steps.redact_validation.outcome == 'success' }}
-        timeout-minutes: 5
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: unity-editor-validation-${{ matrix.unity-version }}-all-modes
-          path: ${{ runner.temp }}/dx-unity-editor-validation
-          if-no-files-found: warn
-          retention-days: 14
-
       - name: Run Unity Test Runner
         id: run_editmode
         if: ${{ !cancelled() && steps.compute.outputs.is-empty != 'true' && steps.acquire_lock.outputs.acquired == 'true' }}
@@ -520,7 +388,9 @@ jobs:
           ${{
             !cancelled() &&
             steps.acquire_lock.outputs.acquired == 'true' &&
-            env.DXM_RUN_SHIPPING == 'true'
+            github.event_name == 'workflow_dispatch' &&
+            inputs.shipping_fidelity &&
+            (matrix.unity-version == '2021.3.45f1' || matrix.unity-version == '6000.5.2f1')
           }}
         continue-on-error: true
         timeout-minutes: 150
@@ -568,7 +438,12 @@ jobs:
           label: Unity ${{ matrix.unity-version }} standalone
 
       - name: Dump shipping-fidelity log tail on failure or cancellation
-        if: ${{ env.DXM_RUN_SHIPPING == 'true' && (steps.run_shipping.outcome == 'failure' || cancelled()) }}
+        if: >-
+          ${{
+            (github.event_name == 'workflow_dispatch' && inputs.shipping_fidelity &&
+            (matrix.unity-version == '2021.3.45f1' || matrix.unity-version == '6000.5.2f1')) &&
+            (steps.run_shipping.outcome == 'failure' || cancelled())
+          }}
         timeout-minutes: 5
         uses: ./.github/actions/dump-unity-log-tail
         with:
@@ -642,7 +517,6 @@ jobs:
         uses: ./.github/actions/redact-unity-artifacts
         with:
           paths: |
-            ${{ runner.temp }}/dx-unity-editor-validation
             .artifacts/unity
 
       # Content-addressed retention for issue #508. The manifest names every evidence
@@ -651,7 +525,12 @@ jobs:
       # Redaction runs first so no sensitive data can be sealed into a bundle.
       - name: Seal shipping-fidelity evidence bundle
         id: seal_shipping
-        if: ${{ env.DXM_RUN_SHIPPING == 'true' && steps.run_shipping.outcome == 'success' }}
+        if: >-
+          ${{
+            github.event_name == 'workflow_dispatch' && inputs.shipping_fidelity &&
+            (matrix.unity-version == '2021.3.45f1' || matrix.unity-version == '6000.5.2f1') &&
+            steps.run_shipping.outcome == 'success'
+          }}
         timeout-minutes: 5
         shell: pwsh
         run: |
@@ -704,7 +583,9 @@ jobs:
             always() &&
             !cancelled() &&
             steps.acquire_lock.outputs.acquired == 'true' &&
-            env.DXM_RUN_SHIPPING == 'true'
+            github.event_name == 'workflow_dispatch' &&
+            inputs.shipping_fidelity &&
+            (matrix.unity-version == '2021.3.45f1' || matrix.unity-version == '6000.5.2f1')
           }}
         timeout-minutes: 10
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -732,7 +613,7 @@ jobs:
           STANDALONE_EMPTY: ${{ steps.compute_standalone.outputs.is-empty }}
           STANDALONE_RUN: ${{ steps.run_standalone.outcome }}
           STANDALONE_VERIFY: ${{ steps.verify_standalone.outcome }}
-          SHIPPING_REQUIRED: ${{ env.DXM_RUN_SHIPPING }}
+          SHIPPING_REQUIRED: ${{ github.event_name == 'workflow_dispatch' && inputs.shipping_fidelity && (matrix.unity-version == '2021.3.45f1' || matrix.unity-version == '6000.5.2f1') }}
           SHIPPING_RUN: ${{ steps.run_shipping.outcome }}
         run: |
           $failures = @()
@@ -772,7 +653,10 @@ jobs:
           tool-cache: ${{ runner.tool_cache }}
           unity-email: ${{ secrets.UNITY_EMAIL }}
           unity-password: ${{ secrets.UNITY_PASSWORD }}
-          evidence-suffix: unity-tests-${{ matrix.unity-version }}-all-modes
+          # The enrollment contract requires a literal evidence suffix; the
+          # matrix leg is already identified by the acquire holder identity,
+          # and each leg owns a private RUNNER_TEMP.
+          evidence-suffix: unity-tests-all-modes
 
       - name: Classify Unity cleanup evidence
         id: cleanup_classification
@@ -807,19 +691,12 @@ jobs:
         timeout-minutes: 2
         uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-confirmed-unity-cleanup@64bac446903115134dca8235410b332bc5a83547
         with:
-          # A leg that aborts before `Acquire organization Unity lock` runs never
-          # took a seat, and this gate's own contract treats `acquired: false` as
-          # proof that licensed cleanup was not required. Feeding it the skipped
-          # step's EMPTY output instead made it fail closed on work that never
-          # started, so a leg with one honest failure reported two (#327).
-          #
-          # This does not weaken the gate. It reads `outcome`, not `acquired`, and
-          # only the two values that prove the step never executed map to 'false'.
-          # An acquire that RAN and failed part-way reports outcome=failure while
-          # `acquired` reads empty, so the empty value still flows through and the
-          # gate still fails -- that ambiguous shape is the seat leak the bare
-          # `if: always()` above exists to catch, and it stays caught.
-          acquired: ${{ (steps.acquire_lock.outcome == 'skipped' || steps.acquire_lock.outcome == '') && 'false' || steps.acquire_lock.outputs.acquired }}
+          # Typed binding to the one acquire step, exactly as the enrollment
+          # contract requires. A leg that aborts before acquire ran reports an
+          # empty output, and the gate itself treats missing or invalid
+          # acquisition state as fail-closed; only the literal `acquired=false`
+          # from a completed acquire marks cleanup as not applicable.
+          acquired: ${{ steps.acquire_lock.outputs.acquired }}
           classification-complete: ${{ steps.cleanup_classification.outputs.classification-complete }}
           cleanup-status: ${{ steps.cleanup_classification.outputs.resource-cleanup-status }}
           cleanup-health: ${{ steps.cleanup_classification.outputs.resource-health }}
@@ -835,94 +712,42 @@ jobs:
 
   # Single aggregate gate so branch protection can require ONE "Unity CI Success"
   # context instead of the individual matrix and preflight contexts.
+  #
+  # Exactly always() -- NEVER a falsifiable job-level if. A skipped required
+  # check counts as passing and the latest run on a SHA wins, so a guard that
+  # can be false on a pull_request could launder a red/pending gate into a
+  # false green. The step below is the enrollment policy's closed trusted-skip
+  # shape: fork and Dependabot pull requests skip both the preflight and the
+  # licensed matrix (neither can read the organization secrets those jobs
+  # require), and every other trusted run must have executed Unity
+  # successfully. Documentation-only pull requests never trigger this workflow
+  # at all (the pull_request paths-ignore decides that before any job runs),
+  # and a superseded pull-request run fails its per-leg head guard before it
+  # can reach the lock.
   unity-ci-success:
     name: Unity CI Success
     permissions:
       actions: read
     needs:
-      - head-check
       - runner-preflight
       - unity-tests
-    # Exactly always() -- NEVER a falsifiable job-level if. A skipped required
-    # check counts as passing and the latest run on a SHA wins, so a guard that
-    # can be false on a pull_request could launder a red/pending gate into a
-    # false green. The step below validates the four intentional skip shapes:
-    # documentation-only, fork, and Dependabot PRs skip both licensed jobs
-    # (the latter two cannot read the organization secrets those jobs require),
-    # and a superseded head
-    # skips them because the run for the current head is the one that counts.
-    # A superseded run cannot launder anything -- branch protection reads only
-    # the checks on the current head -- but it still has to report its shape
-    # rather than go absent. head-check itself is never allowed to skip or
-    # fail: it is what decides which of the two branches applies. Every other
-    # run must execute Unity successfully.
     if: ${{ always() }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - name: Verify Unity CI result shape
-        id: result_shape
         shell: bash
         env:
-          HEAD_CHECK_RESULT: ${{ needs.head-check.result }}
           RUNNER_PREFLIGHT_RESULT: ${{ needs.runner-preflight.result }}
           UNITY_TESTS_RESULT: ${{ needs.unity-tests.result }}
-          RELEVANT: ${{ needs.head-check.outputs.relevant }}
-          SUPERSEDED: ${{ needs.head-check.outputs.superseded }}
           FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
           DEPENDABOT_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.user.login == 'dependabot[bot]' }}
         run: |
           set -euo pipefail
-          test "${HEAD_CHECK_RESULT}" = success
-          if [ "${SUPERSEDED}" = "true" ] || [ "${RELEVANT}" = "false" ] || [ "${FORK_PR}" = "true" ] || [ "${DEPENDABOT_PR}" = "true" ]; then
+          if [ "${FORK_PR}" = "true" ] || [ "${DEPENDABOT_PR}" = "true" ]; then
             test "${RUNNER_PREFLIGHT_RESULT}" = skipped
             test "${UNITY_TESTS_RESULT}" = skipped
           else
             test "${RUNNER_PREFLIGHT_RESULT}" = success
             test "${UNITY_TESTS_RESULT}" = success
           fi
-
-      # The licensed runner may disappear before any always-run cleanup step.
-      # Report from this hosted job; metadata describes the boundary, not its cause.
-      - name: Report unsuccessful Unity legs
-        if: ${{ failure() && steps.result_shape.outcome == 'failure' }}
-        timeout-minutes: 2
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
-        with:
-          script: |
-            const messages = [];
-            const report = (message) => { core.error(message); messages.push(message); };
-            try {
-              const attempt = Number(process.env.GITHUB_RUN_ATTEMPT);
-              if (!Number.isSafeInteger(attempt) || attempt < 1) throw new Error('Invalid run attempt');
-              const jobs = await github.paginate('GET /repos/{owner}/{repo}/actions/runs/{run_id}/attempts/{attempt_number}/jobs', {
-                ...context.repo, run_id: context.runId, attempt_number: attempt, per_page: 100
-              });
-              if (!Array.isArray(jobs) || jobs.some((job) => !job || job.run_id !== context.runId ||
-                  !Number.isSafeInteger(job.id) || job.id < 1 || typeof job.name !== 'string')) {
-                throw new Error('Invalid job metadata');
-              }
-              // Include the historical per-mode names so retained runs remain diagnosable.
-              const legs = jobs.filter((job) => /^Unity \d+\.\d+\.\d+[abfp]\d+ (all modes|editmode|playmode|standalone)$/.test(job.name) && job.conclusion !== 'success');
-              if (!legs.length) report('No unsuccessful Unity leg was returned for this attempt. Inspect the head freshness and runner preflight jobs; the result-shape gate remains failed.');
-              for (const job of legs) {
-                const steps = job.steps ?? [];
-                if (!Array.isArray(steps) || steps.some((step) => !step || typeof step.name !== 'string' ||
-                    !Number.isSafeInteger(step.number) || step.number < 1)) throw new Error('Invalid step metadata');
-                const ordered = [...steps].sort((a, b) => a.number - b.number);
-                const failed = ordered.find((step) => step.conclusion === 'failure');
-                const completed = ordered.filter((step) => step.status === 'completed' && step.conclusion && step.conclusion !== 'skipped').at(-1);
-                const unfinished = ordered.find((step) => step.conclusion === null);
-                const describe = (step) => step ? `${step.number}: ${step.name}` : 'none recorded';
-                const url = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}/job/${job.id}`;
-                report(`${job.name}; job ${job.id}; runner ${job.runner_name || 'unassigned'}; ${job.status}/${job.conclusion || 'unknown'}. ${url}\n` +
-                  `Failed step: ${describe(failed)}. Last completed step: ${describe(completed)}.\n` +
-                  (ordered.length ? `First step without a recorded conclusion: ${describe(unfinished)}.` : 'Step metadata is unavailable; the execution boundary is unknown.') +
-                  (unfinished ? '\nSome steps have no recorded conclusion. Inspect the runner service Runner/Worker logs for this job time window; the cause is unknown.' : ''));
-              }
-            } catch {
-              report('Unity leg diagnostics are unavailable because the exact-attempt jobs API or its metadata could not be read. ' +
-                'The result-shape gate remains failed; inspect the run and runner service logs.');
-            }
-            const escape = (value) => value.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
-            await core.summary.addRaw(`<pre>${escape(messages.join('\n\n'))}</pre>`).write();

--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -290,7 +290,9 @@ jobs:
         uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@64bac446903115134dca8235410b332bc5a83547 # v1.14.0
         with:
           lock-name: wallstop-organization-builds
-          holder-id-suffix: ${{ matrix.unity-version }}-all-modes
+          # Every matrix axis is part of the holder identity, so each expanded
+          # leg owns a distinct lock holder.
+          holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}-all-modes
           runner-id: ${{ runner.name }}
           github-token: ${{ github.token }}
           pull-request-number: ${{ github.event.pull_request.number }}
@@ -694,7 +696,7 @@ jobs:
         uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@64bac446903115134dca8235410b332bc5a83547 # v1.14.0
         with:
           lock-name: wallstop-organization-builds
-          holder-id-suffix: ${{ matrix.unity-version }}-all-modes
+          holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}-all-modes
           runner-id: ${{ runner.name }}
           resource-cleanup-status: ${{ steps.cleanup_classification.outputs.resource-cleanup-status }}
           resource-health: ${{ steps.cleanup_classification.outputs.resource-health }}

--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -6,8 +6,11 @@ on:
       - master
     # Documentation-only pull requests never reach this workflow, so they never
     # need the licensed Unity matrix: the docs-only skip that head-check used to
-    # decide in-band is now decided by the trigger itself. Keep this list in
-    # lockstep with the documentation-only pattern that perf-numbers.yml uses.
+    # decide in-band is now decided by the trigger itself. The required
+    # "Unity CI Success" context still reports for those pull requests through
+    # unity-docs-gate.yml, which evaluates the same closed documentation-only
+    # allowlist. Keep this list in lockstep with that workflow and with the
+    # documentation-only pattern that perf-numbers.yml uses.
     paths-ignore:
       - "docs/**"
       - ".docs-tests/**"
@@ -128,6 +131,15 @@ jobs:
           - 2022.3.45f1
           - 6000.3.16f1
           - 6000.5.2f1
+        # Every leg of this job also builds the standalone IL2CPP player, so the
+        # reviewed static map keeps the editor gate verifying the
+        # StandaloneWindowsIl2Cpp payload at gate time. A literal EditorOnly
+        # profile here would let a leg reach the organization lock without the
+        # IL2CPP modules its player build needs (#333). The enrollment audit
+        # accepts exactly this map expression, keyed by a literal test-mode
+        # axis, and no other dynamic form.
+        test-mode:
+          - standalone
     steps:
       - name: Require current PR head before setup
         timeout-minutes: 2
@@ -140,9 +152,10 @@ jobs:
       # Contract item 3: the central immutable gate validates the runner-owned
       # editor before any credential reference or checkout. CI never installs,
       # repairs, or provisions an editor; a missing or unhealthy editor is an
-      # offline runner-maintenance failure. The editor check exposes its
-      # validated executable itself, so the former unity-helpers validator
-      # checkout, binding step, and diagnostics upload are gone.
+      # offline runner-maintenance failure. The gate exposes the validated
+      # executable through its editor-path output, and every Unity-consuming
+      # step below binds it as UNITY_EDITOR_PATH step env, so the licensed work
+      # runs the exact editor the gate validated.
       - name: Require manually installed Unity editor
         id: ensure_unity_editor
         timeout-minutes: 10
@@ -150,7 +163,7 @@ jobs:
         with:
           unity-version: ${{ matrix.unity-version }}
           install-root: ${{ runner.tool_cache }}\u6-v3
-          provisioning-profile: EditorOnly
+          provisioning-profile: ${{ fromJSON('{"editmode":"EditorOnly","playmode":"EditorOnly","standalone":"StandaloneWindowsIl2Cpp"}')[matrix.test-mode] }}
           diagnostics-path: unity-editor-check.json
           ci-managed-only: true
           require-healthy-existing: true
@@ -300,6 +313,7 @@ jobs:
         timeout-minutes: 90
         shell: pwsh
         env:
+          UNITY_EDITOR_PATH: ${{ steps.ensure_unity_editor.outputs.editor-path }}
           UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
@@ -328,6 +342,7 @@ jobs:
         timeout-minutes: 90
         shell: pwsh
         env:
+          UNITY_EDITOR_PATH: ${{ steps.ensure_unity_editor.outputs.editor-path }}
           UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
@@ -356,6 +371,7 @@ jobs:
         timeout-minutes: 150
         shell: pwsh
         env:
+          UNITY_EDITOR_PATH: ${{ steps.ensure_unity_editor.outputs.editor-path }}
           UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
@@ -377,7 +393,7 @@ jobs:
             -ReleaseCodeOptimization `
             -ReleasePlayerBuild
 
-      # Weekly or explicitly requested runs cover semantic and 1/16/256/1000-message
+      # Explicitly requested dispatch runs cover semantic and 1/16/256/1000-message
       # shipping topologies at every stripping level on the endpoint editors. Keep the
       # group last because each cell builds another IL2CPP player, and the
       # central cleanup action below returns the final activation before the
@@ -396,6 +412,7 @@ jobs:
         timeout-minutes: 150
         shell: pwsh
         env:
+          UNITY_EDITOR_PATH: ${{ steps.ensure_unity_editor.outputs.editor-path }}
           UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
@@ -721,9 +738,10 @@ jobs:
   # licensed matrix (neither can read the organization secrets those jobs
   # require), and every other trusted run must have executed Unity
   # successfully. Documentation-only pull requests never trigger this workflow
-  # at all (the pull_request paths-ignore decides that before any job runs),
-  # and a superseded pull-request run fails its per-leg head guard before it
-  # can reach the lock.
+  # (the pull_request paths-ignore decides that before any job runs), and for
+  # those runs unity-docs-gate.yml reports the same "Unity CI Success" context
+  # green, so the required check never goes absent. A superseded pull-request
+  # run fails its per-leg head guard before it can reach the lock.
   unity-ci-success:
     name: Unity CI Success
     permissions:

--- a/Tests/Runtime/Core/DifferentialBusTraceTests.cs
+++ b/Tests/Runtime/Core/DifferentialBusTraceTests.cs
@@ -366,7 +366,8 @@ namespace DxMessaging.Tests.Runtime.Core
                         ? new BusTraceOperation(BusTraceOperationKind.EmitUntyped, value: 17)
                         : new BusTraceOperation(BusTraceOperationKind.Remove),
                     new BusTraceOperation(BusTraceOperationKind.EmitUntyped, value: 29),
-                }
+                },
+                generatorVersion: 10
             );
             IReadOnlyList<BusTraceObservation> untyped = DifferentialBusTrace.Replay(
                 sequence,
@@ -385,7 +386,8 @@ namespace DxMessaging.Tests.Runtime.Core
                             )
                             : operation
                     )
-                    .ToArray()
+                    .ToArray(),
+                generatorVersion: 10
             );
             IReadOnlyList<BusTraceObservation> typed = DifferentialBusTrace.Replay(
                 typedSequence,
@@ -554,7 +556,7 @@ namespace DxMessaging.Tests.Runtime.Core
 
         [Test]
         public void GeneratorVersionPinsKnownSeedPrefix(
-            [Values(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)] int version
+            [Values(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)] int version
         )
         {
             BusTraceSequence sequence = DifferentialBusTrace.Generate(
@@ -565,11 +567,19 @@ namespace DxMessaging.Tests.Runtime.Core
             );
             Assert.That(
                 BusTraceSequence.GeneratorVersion,
-                Is.EqualTo(10),
+                Is.EqualTo(11),
                 "Changing generation requires a new version and a reviewed replay fixture."
             );
             CollectionAssert.AreEqual(
-                version >= 8
+                version == 11
+                        ? new[]
+                        {
+                            "Register(token=0,context=0,value=0,priority=0)[handleSlot=0,sourceHandleSlot=-1]",
+                            "DuplicateRegistration(token=0,context=0,value=0,priority=0)[handleSlot=1,sourceHandleSlot=0]",
+                            "CopyHandle(token=0,context=0,value=0,priority=0)[handleSlot=2,sourceHandleSlot=0]",
+                            "EmitUntyped(token=0,context=0,value=0,priority=0)",
+                        }
+                    : version >= 8
                         ? new[]
                         {
                             "Register(token=0,context=0,value=0,priority=0)[handleSlot=0,sourceHandleSlot=-1]",
@@ -828,6 +838,11 @@ namespace DxMessaging.Tests.Runtime.Core
             }
         }
 
+        /// <remarks>
+        /// Investigation (2026-09-08): this historical shrinker fixture implicitly adopted
+        /// generator v11 while asserting v10. Pinning v10 preserves the replay identity that
+        /// the assertion and saved diagnostic report are designed to verify.
+        /// </remarks>
         [Test]
         public void GlobalOverrideAliasMutationIsDetectedAndShrunk(
             [ValueSource(typeof(MessageScenarios), nameof(MessageScenarios.AllKinds))]
@@ -863,7 +878,8 @@ namespace DxMessaging.Tests.Runtime.Core
                         BusTraceOperationKind.DisposeGlobalOverride,
                         leaseSlot: 1
                     ),
-                }
+                },
+                generatorVersion: 10
             );
             BusTraceMismatch EvaluateOverride(BusTraceSequence input) =>
                 DifferentialBusTrace.Compare(
@@ -941,6 +957,58 @@ namespace DxMessaging.Tests.Runtime.Core
                     report + $", length={length}"
                 );
             }
+        }
+
+        [Test]
+        public void VersionElevenIntegratesUntypedEmissionsWithoutChangingLegacyGeneration(
+            [ValueSource(typeof(MessageScenarios), nameof(MessageScenarios.AllKinds))]
+                MessageScenario scenario
+        )
+        {
+            BusTraceSequence legacy = DifferentialBusTrace.Generate(scenario, 17, 256, 10);
+            BusTraceSequence current = DifferentialBusTrace.Generate(scenario, 17, 256, 11);
+            string report = $"kind={scenario.Kind}";
+            Assert.That(DifferentialBusTrace.IsValid(current), Is.True, report);
+            Assert.That(
+                legacy.Operations.Any(operation =>
+                    operation.Kind == BusTraceOperationKind.EmitUntyped
+                ),
+                Is.False,
+                report
+            );
+            Assert.That(
+                current.Operations.Any(operation =>
+                    operation.Kind == BusTraceOperationKind.EmitUntyped
+                ),
+                Is.True,
+                report
+            );
+            Assert.That(
+                current.Operations.Any(operation => operation.Kind == BusTraceOperationKind.Emit),
+                Is.True,
+                report
+            );
+            Assert.That(current.Operations.Count, Is.EqualTo(legacy.Operations.Count), report);
+            int emitOrdinal = 0;
+            for (int index = 0; index < current.Operations.Count; ++index)
+            {
+                BusTraceOperation expected = legacy.Operations[index];
+                BusTraceOperation actual = current.Operations[index];
+                BusTraceOperationKind expectedKind =
+                    expected.Kind == BusTraceOperationKind.Emit && emitOrdinal++ % 2 == 0
+                        ? BusTraceOperationKind.EmitUntyped
+                        : expected.Kind;
+                Assert.That(
+                    OperationFingerprint(actual),
+                    Is.EqualTo(OperationFingerprint(expected, expectedKind)),
+                    report + $", index={index}"
+                );
+            }
+            CollectionAssert.AreEqual(
+                current.Operations,
+                DifferentialBusTrace.Generate(scenario, 17, 256, 11).Operations,
+                report
+            );
         }
 
         [Test]
@@ -1579,7 +1647,7 @@ namespace DxMessaging.Tests.Runtime.Core
                     .Cast<BusTraceOperationKind>()
                     .Where(kind =>
                         !DifferentialBusTrace.IsGlobalOverride(kind)
-                        && !DifferentialBusTrace.IsSupplementary(kind)
+                        && kind != BusTraceOperationKind.EmitUntyped
                     ),
                 kinds,
                 "Version eight must retain every existing operation and add duplicates/copies."
@@ -2034,7 +2102,7 @@ namespace DxMessaging.Tests.Runtime.Core
                     .Cast<BusTraceOperationKind>()
                     .Where(kind =>
                         !DifferentialBusTrace.IsGlobalOverride(kind)
-                        && !DifferentialBusTrace.IsSupplementary(kind)
+                        && kind != BusTraceOperationKind.EmitUntyped
                     ),
                 all,
                 "Version nine retains the full operation vocabulary."
@@ -3029,7 +3097,7 @@ namespace DxMessaging.Tests.Runtime.Core
             [ValueSource(typeof(MessageScenarios), nameof(MessageScenarios.AllKinds))]
                 MessageScenario scenario,
             [Values(17, 42)] int seed,
-            [Values(3, 4, 5, 6, 7, 8, 9, 10)] int version
+            [Values(3, 4, 5, 6, 7, 8, 9, 10, 11)] int version
         )
         {
             BusTraceSequence sequence = DifferentialBusTrace.Generate(
@@ -3623,7 +3691,7 @@ namespace DxMessaging.Tests.Runtime.Core
         }
 
         [TestCase(0)]
-        [TestCase(11)]
+        [TestCase(BusTraceSequence.GeneratorVersion + 1)]
         public void UnsupportedGeneratorVersionsAreRejected(int version)
         {
             Assert.Throws<ArgumentOutOfRangeException>(
@@ -3631,6 +3699,16 @@ namespace DxMessaging.Tests.Runtime.Core
                 $"version={version}: unsupported provenance must be rejected."
             );
         }
+
+        private static string OperationFingerprint(
+            BusTraceOperation operation,
+            BusTraceOperationKind? kind = null
+        ) =>
+            $"{kind ?? operation.Kind}|{operation.Token}|{operation.Context}|{operation.Value}|"
+            + $"{operation.Priority}|{operation.KindOffset}|{operation.NestedToken}|{operation.Depth}|"
+            + $"{operation.HandleToken}|{operation.HandlerToken}|{operation.HandlerActive}|"
+            + $"{operation.HandleSlot}|{operation.SourceHandleSlot}|{operation.LeaseSlot}|"
+            + operation.SourceLeaseSlot;
 
         [Test]
         public void IndependentOperationMutantsAreDetectedAndShrunk(

--- a/Tests/Runtime/TestUtilities/DifferentialBusTrace.cs
+++ b/Tests/Runtime/TestUtilities/DifferentialBusTrace.cs
@@ -135,7 +135,7 @@ namespace DxMessaging.Tests.Runtime
     /// <summary>Immutable, versioned replay inputs; a seed identifies the original generator sequence.</summary>
     internal sealed class BusTraceSequence
     {
-        internal const int GeneratorVersion = 10;
+        internal const int GeneratorVersion = 11;
         internal const int HandleSlotCount = 8;
         internal const int TokenCount = 4;
         internal const int MaxOperations = 256;
@@ -281,6 +281,10 @@ namespace DxMessaging.Tests.Runtime
             if (length < 0 || length > BusTraceSequence.MaxOperations)
             {
                 throw new ArgumentOutOfRangeException(nameof(length));
+            }
+            if (generatorVersion == 11)
+            {
+                return GenerateUntypedEmissions(scenario, seed, length);
             }
             if (generatorVersion == 10)
             {
@@ -505,15 +509,50 @@ namespace DxMessaging.Tests.Runtime
             return new BusTraceSequence(scenario, seed, operations, 10);
         }
 
+        private static BusTraceSequence GenerateUntypedEmissions(
+            MessageScenario scenario,
+            uint seed,
+            int length
+        )
+        {
+            BusTraceSequence previous = GenerateGlobalOverrides(scenario, seed, length);
+            List<BusTraceOperation> operations = new(previous.Operations.Count);
+            int emitIndex = 0;
+            foreach (BusTraceOperation operation in previous.Operations)
+            {
+                if (operation.Kind != BusTraceOperationKind.Emit || emitIndex++ % 2 != 0)
+                {
+                    operations.Add(operation);
+                    continue;
+                }
+                operations.Add(
+                    new BusTraceOperation(
+                        BusTraceOperationKind.EmitUntyped,
+                        operation.Token,
+                        operation.Context,
+                        operation.Value,
+                        operation.Priority,
+                        operation.KindOffset,
+                        operation.NestedToken,
+                        operation.Depth,
+                        operation.HandleToken,
+                        operation.HandlerToken,
+                        operation.HandlerActive,
+                        operation.HandleSlot,
+                        operation.SourceHandleSlot,
+                        operation.LeaseSlot,
+                        operation.SourceLeaseSlot
+                    )
+                );
+            }
+            return new BusTraceSequence(scenario, seed, operations, 11);
+        }
+
         internal static bool IsGlobalOverride(BusTraceOperationKind kind) =>
             kind == BusTraceOperationKind.AcquireGlobalOverride
             || kind == BusTraceOperationKind.CopyGlobalOverride
             || kind == BusTraceOperationKind.DisposeGlobalOverride
             || kind == BusTraceOperationKind.ReplaceGlobalBus;
-
-        /// <summary>Hand-written supplementary operations that no versioned generator emits.</summary>
-        internal static bool IsSupplementary(BusTraceOperationKind kind) =>
-            kind == BusTraceOperationKind.EmitUntyped;
 
         // Only logical issuance and alias dependencies are modeled, never the production
         // override stack, physical slots, generations, current bus, or dispatch results.

--- a/docs/runbooks/required-checks.md
+++ b/docs/runbooks/required-checks.md
@@ -82,29 +82,43 @@ every context present without allowing skipped dependencies in `CI Success`.
 ### Unity CI Success
 
 [`unity-tests.yml`](https://github.com/Ambiguous-Interactive/DxMessaging/blob/master/.github/workflows/unity-tests.yml)
-hosts the Unity correctness gate. Its `pull_request` trigger has no `paths:`
-filter, so the workflow always starts. Three shapes skip the licensed matrix,
-and each is validated rather than assumed:
+hosts the Unity correctness gate. Its `pull_request` trigger is filtered by
+`paths-ignore`, so a documentation-only pull request never starts the licensed
+matrix. Three shapes skip the licensed work, and each is validated rather than
+assumed:
 
+- **A documentation-only pull request.** Every changed file matches the closed
+  documentation-only allowlist in `paths-ignore`, so the workflow is absent
+  rather than running an empty matrix.
 - **A fork pull request.**
 - **A Dependabot pull request.** Both read from a different secret store, so the
   Unity serial and the build-lock App credentials resolve empty and a licensed
   leg would fail on missing credentials rather than on the change under test.
-- **A superseded head.** `concurrency` on this workflow sets
-  `cancel-in-progress: false` on purpose, because hard-cancelling a run that
-  holds the organization build lock is the scenario the license-return guarantee
-  exists to prevent. The group is keyed by pull-request head SHA so that policy
-  does not also queue the current head behind a superseded run: push runs keep
-  the `github.ref` key and stay serialized, pull-request runs partition per head,
-  and every job-level group in the file uses the same key. Nothing is cancelled,
-  and licensed work stays mutually exclusive through the organization build lock.
-  On top of that, the `head-check` job compares the event's head SHA against the
-  live pull-request head on `ubuntu-latest`, before the lock is in reach, and
-  publishes a `superseded` output that both licensed jobs gate on, so a
-  superseded run costs one cheap hosted job instead of four self-hosted ones. It
-  fails open: a lookup that returns no SHA runs the full matrix. The per-leg
-  `Require current PR head before setup` guard still covers a push that lands
-  after `head-check` has already passed.
+
+A required check must be present, never absent, so the documentation-only shape
+needs a reporter:
+[`unity-docs-gate.yml`](https://github.com/Ambiguous-Interactive/DxMessaging/blob/master/.github/workflows/unity-docs-gate.yml)
+triggers on every pull request into `master` with no paths filter and posts the
+same `Unity CI Success` context. Its single step lists the changed files via
+`gh api .../files` (including `previous_filename` for renames), fails closed on
+a lookup failure or an empty listing, reports success only when every changed
+file matches the exact `paths-ignore` allowlist, and reports red for anything
+else. The licensed result for those pull requests stays owned by
+`unity-tests.yml`. Re-running the docs gate manually on a code pull request
+posts a red duplicate until the Unity aggregate runs again; that is visible and
+fail-closed. `scripts/__tests__/ci-aggregate-workflow.test.js` asserts the
+lockstep between the allowlist and the gate's pattern.
+
+The `concurrency` setting keeps `cancel-in-progress: false` on purpose, because
+hard-cancelling a run that holds the organization build lock is the scenario the
+license-return guarantee exists to prevent. The group is keyed by pull-request
+head SHA so that policy does not also queue the current head behind a superseded
+run: push runs keep the `github.ref` key and stay serialized, pull-request runs
+partition per head, and every job-level group in the file uses the same key.
+Nothing is cancelled, and licensed work stays mutually exclusive through the
+organization build lock. A superseded pull-request run still starts, but each
+leg aborts at the `Require current PR head before setup` guard before any
+expensive setup, so a superseded run costs seconds instead of a license seat.
 
 The required Unity check name is the stable aggregate:
 
@@ -113,15 +127,15 @@ Unity CI Success
 ```
 
 `Unity CI Success` has `if: ${{ always() }}` and no job-level condition that can
-be false. Its one step reads the results of `head-check`, `runner-preflight`,
-and the `unity-tests` matrix, requires `head-check` itself to have succeeded,
-and then asserts that both licensed jobs are `skipped` for exactly the three
-shapes above and `success` otherwise. `re-actors/alls-green` and blanket
-allowed-skip lists are rejected by `scripts/validate-unity-pr-policy.py`, which
-also byte-pins that step's script and runs it against a truth table.
+be false. Its one step reads the results of `runner-preflight`
+and the `unity-tests` matrix and asserts that both are `skipped` for exactly the
+fork and Dependabot shapes above and `success` otherwise. That step is the
+enrollment policy's closed trusted-skip shape, byte-validated by
+`scripts/__tests__/ci-aggregate-workflow.test.js` against a truth table.
+Blanket allowed-skip lists and `re-actors/alls-green` stay rejected.
 
 Do **not** require the expanded matrix job names (`Unity <version> all modes`),
-`Unity head freshness`, or `Self-hosted runner registration preflight`. When a
+or `Self-hosted runner registration preflight`. When a
 job-level `if:` skips a matrix before expansion, GitHub can report only one
 skipped check with the literal name
 `Unity ${{ matrix.unity-version }} all modes`, so requiring the

--- a/scripts/__tests__/ci-aggregate-workflow.test.js
+++ b/scripts/__tests__/ci-aggregate-workflow.test.js
@@ -9,6 +9,9 @@ const { spawnSync } = require("node:child_process");
 const { walkFiles } = require("../lib/repo-files.js");
 const {
   UNITY_LOCK_WINDOWS,
+  UNITY_EDITOR_PROFILES,
+  UNITY_EDITOR_CONSUMERS,
+  DOCS_ONLY_PATH_IGNORES,
   STATIC_CHILD_JOBS,
   CORRECTNESS_CATEGORY_FILTERS
 } = require("./workflow-test-vectors.json");
@@ -39,10 +42,11 @@ function resolveLockActionPin(actionNames) {
   return { sha: [...shas.keys()][0], comment: [...comments][0] || "" };
 }
 
-// Acquire, preflight, and the PR-head guard ship in the build-lock release.
-// Return/classify/release/require-confirmed carry the centralized cleanup policy.
+// Acquire, the editor gate, preflight, and the PR-head guard ship in the
+// build-lock release. Return/classify/release/require-confirmed carry the
+// centralized cleanup policy.
 // prettier-ignore
-const [LOCK_ACTION_PIN, CLEANUP_POLICY_PIN] = [["check-unity-runner-availability", "acquire-build-lock", "release-build-lock", "require-current-pr-head"], ["return-unity-license", "classify-unity-cleanup-evidence", "require-confirmed-unity-cleanup"]].map((group) => resolveLockActionPin(group));
+const [LOCK_ACTION_PIN, CLEANUP_POLICY_PIN] = [["check-unity-runner-availability", "acquire-build-lock", "release-build-lock", "require-current-pr-head", "ensure-unity-editor"], ["return-unity-license", "classify-unity-cleanup-evidence", "require-confirmed-unity-cleanup"]].map((group) => resolveLockActionPin(group));
 const LOCK_ACTION_SHA = LOCK_ACTION_PIN.sha;
 const ACQUIRE_ACTION_SHA = LOCK_ACTION_PIN.sha;
 const CLEANUP_POLICY_SHA = CLEANUP_POLICY_PIN.sha;
@@ -523,6 +527,13 @@ test("every Unity lock window releases with explicit cleanup proof", () => {
     assert.equal(count, UNITY_LOCK_WINDOWS.length, action);
   }
 
+  // The central editor gate exposes the validated executable through its
+  // editor-path output. The invocation invariant: every Unity-consuming step
+  // binds that output as UNITY_EDITOR_PATH step env, so licensed work runs the
+  // exact editor the gate validated (the former "Bind validated Unity editor"
+  // run step became this typed output binding).
+  const editorPathBinding = "${{ steps.ensure_unity_editor.outputs.editor-path }}";
+
   for (const [file, jobId, licensedWorkName, emptyAware] of UNITY_LOCK_WINDOWS) {
     const label = `${file}:${jobId}`;
     const licensedCondition = `${file === "perf-numbers.yml" ? "success\\(\\) && " : ""}${file === "unity-tests.yml" ? "!cancelled\\(\\) && " : ""}${emptyAware ? "steps\\.compute\\.outputs\\.is-empty != 'true' && " : ""}steps\\.acquire_lock\\.outputs\\.acquired == 'true'`;
@@ -545,7 +556,7 @@ test("every Unity lock window releases with explicit cleanup proof", () => {
     }
 
     // prettier-ignore
-    const lifecycleNames = ["Require manually installed Unity editor", "Bind validated Unity editor", "Validate Unity license secrets", "Acquire organization Unity lock", "Require acquired Unity lock", "Upload Unity editor validation diagnostics", licensedWorkName, "Return Unity license", "Classify Unity cleanup evidence", "Release organization Unity lock", "Require confirmed Unity cleanup"];
+    const lifecycleNames = ["Require manually installed Unity editor", "Validate Unity license secrets", "Acquire organization Unity lock", "Require acquired Unity lock", licensedWorkName, "Return Unity license", "Classify Unity cleanup evidence", "Release organization Unity lock", "Require confirmed Unity cleanup"];
     const positions = lifecycleNames.map((name) => job.indexOf(`      - name: ${name}`));
     const sortedPositions = [...positions].sort((a, b) => a - b);
     assert.ok(
@@ -555,15 +566,20 @@ test("every Unity lock window releases with explicit cleanup proof", () => {
     assert.deepEqual(positions, sortedPositions, `${label} lifecycle order`);
 
     // prettier-ignore
-    const [validationStep, bindingStep, credentialStep, acquireStep, requireStep, uploadStep, workStep, returnStep, classifyStep, releaseStep, gateStep] = lifecycleNames.map((name) => getStepBlock(job, name));
+    const [validationStep, credentialStep, acquireStep, requireStep, workStep, returnStep, classifyStep, releaseStep, gateStep] = lifecycleNames.map((name) => getStepBlock(job, name));
 
+    // The central immutable gate validates the runner-owned editor before any
+    // credential reference or checkout, stays success-dependent and
+    // failure-propagating, and refuses provisioning.
     // prettier-ignore
     const contracts = [
+      [validationStep, /\n        id: ensure_unity_editor\n/],
       [validationStep, /\n        timeout-minutes: 10\n/],
-      [validationStep, /shell: pwsh -NoProfile -NonInteractive -Command "\. '\{0\}'"/, `${label}: the gate must not inherit a runner profile`],
-      [validationStep, /\.ci\/unity-helpers\/scripts\/unity\/ensure-editor\.ps1[\s\S]*-InstallRoot \(Join-Path \$env:RUNNER_TOOL_CACHE 'u6-v3'\)[\s\S]*-DiagnosticsPath \(Join-Path \$env:RUNNER_TEMP 'dx-unity-editor-validation'\)[\s\S]*-CiManagedOnly[\s\S]*-RequireHealthyExisting/, `${label}: validation must pin the trusted editor root, refuse fallback installs, and write its evidence outside the workspace so a failed gate still uploads it`],
-      [bindingStep, /dx-unity-editor-validation\\ensure-editor-summary\.json'[\s\S]*ConvertFrom-Json[\s\S]*\[string\]::Equals\(\$actual, \$expected, \[StringComparison\]::OrdinalIgnoreCase\)[\s\S]*UNITY_EDITOR_PATH=\$expected/, `${label}: bind must read the preserved evidence, prove the canonical editor, then export the path`],
-      [uploadStep, /path: \$\{\{ runner\.temp \}\}\/dx-unity-editor-validation\n/, `${label}: evidence upload must not depend on a step that may never run`],
+      [validationStep, new RegExp(`uses: ${escapeRegExp(LOCK_ACTION_PREFIX)}ensure-unity-editor@${LOCK_ACTION_SHA}([\\s\\n]|#)`)],
+      [validationStep, /install-root: \$\{\{ runner\.tool_cache \}\}\\u6-v3\n/, `${label}: the gate must pin the trusted editor root`],
+      [validationStep, /diagnostics-path: unity-editor-check\.json\n/, `${label}: the gate must write its diagnostics contract path`],
+      [validationStep, /ci-managed-only: true\n[\s\S]*require-healthy-existing: true\n/, `${label}: the gate must refuse fallback installs`],
+      [validationStep, new RegExp(`provisioning-profile: ${escapeRegExp(UNITY_EDITOR_PROFILES[file])}\\n`), `${label}: the gate must use the reviewed provisioning profile`],
       [credentialStep, /uses: \.\/\.github\/actions\/validate-unity-license/],
       [acquireStep, /\n        id: acquire_lock\n/],
       [requireStep, /\n        if: \$\{\{ steps\.acquire_lock\.outputs\.acquired != 'true' \}\}\n[\s\S]*\n        run: exit 1\n/],
@@ -577,13 +593,32 @@ test("every Unity lock window releases with explicit cleanup proof", () => {
       [gateStep, /\n        if: always\(\)\n        timeout-minutes: 2\n/],
       [gateStep, /classification-complete: \$\{\{ steps\.cleanup_classification\.outputs\.classification-complete \}\}/],
       [gateStep, /release-outcome: \$\{\{ steps\.release_unity_lock\.outcome \}\}/],
-      [getStepBlock(job, "Checkout trusted Unity editor validator"), /GIT_CONFIG_NOSYSTEM: 1[\s\S]*GIT_CONFIG_GLOBAL: \/dev\/null[\s\S]*repository: Ambiguous-Interactive\/unity-helpers[\s\S]*path: \.ci\/unity-helpers[\s\S]*persist-credentials: false[\s\S]*clean: true[\s\S]*set-safe-directory: false/, `${label}: isolated validator checkout must use the trusted closed shape`],
       ...(["perf-numbers.yml", "unity-benchmarks.yml", "unity-tests.yml"].includes(file) || jobId === "unity-checks" ? [[workStep, /-UnityInstallRoot \(Join-Path \$env:RUNNER_TOOL_CACHE 'u6-v3'\)/, `${label}: licensed work and central return must use the same trusted editor root`]] : [])
     ];
     for (const [actual, contract, message] of contracts) assert.match(actual, contract, message);
 
-    assert.doesNotMatch(validationStep, /\n {8}if:|\b(?:install-modules|uninstall)\b/i, label);
+    assert.doesNotMatch(validationStep, /\n        if:/, `${label}: the editor gate must keep GitHub's implicit success chain`);
+    assert.doesNotMatch(validationStep, /\n        continue-on-error:/, `${label}: the editor gate must propagate failure`);
     assert.doesNotMatch(returnStep, /continue-on-error:/);
+
+    // Invocation invariant: the validated editor output reaches every
+    // Unity-consuming step as UNITY_EDITOR_PATH, in gate-then-consume order.
+    const parsedSteps = YAML.parse(job)[jobId].steps;
+    const gateIndex = parsedSteps.findIndex((step) => step.id === "ensure_unity_editor");
+    assert.ok(gateIndex >= 0, `${label}: editor gate step must exist`);
+    const consumers = UNITY_EDITOR_CONSUMERS.find(
+      ([candidateFile, candidateJobId]) => candidateFile === file && candidateJobId === jobId
+    );
+    assert.ok(consumers, `${label}: the contract must declare its Unity-consuming steps`);
+    for (const consumerId of consumers[2]) {
+      const consumerIndex = parsedSteps.findIndex((step) => step.id === consumerId);
+      assert.ok(consumerIndex > gateIndex, `${label}:${consumerId} must follow the editor gate`);
+      assert.equal(
+        parsedSteps[consumerIndex].env.UNITY_EDITOR_PATH,
+        editorPathBinding,
+        `${label}:${consumerId} must run the editor the gate validated`
+      );
+    }
 
     const acquireHolder = /holder-id-suffix: (.+)\n/.exec(acquireStep);
     const releaseHolder = /holder-id-suffix: (.+)\n/.exec(releaseStep);
@@ -637,131 +672,96 @@ test("Unity CI defers every post-activation return to the central action", () =>
 });
 
 test("licensed PR workflows fail closed and skip only documented non-code paths", () => {
-  for (const [file, aggregateId] of [
-    ["unity-tests.yml", "unity-ci-success"],
-    ["perf-numbers.yml", "perf-unity-success"]
-  ]) {
-    const source = readWorkflow(file);
-    const head = getJobBlock(source, "head-check", file);
-    const preflight = getJobBlock(source, "runner-preflight", file);
-    const aggregate = getJobBlock(source, aggregateId, file);
-    assert.match(head, /relevant: \$\{\{ steps\.head\.outputs\.relevant \}\}/);
-    assert.match(head, /Changed-file lookup failed; running licensed/);
-    assert.match(head, /echo "relevant=\$\{relevant\}" >> "\$\{GITHUB_OUTPUT\}"/);
-    const pattern = /documentation_only_pattern='([^']+)'/.exec(head);
-    const allowed = new RegExp(pattern?.[1] ?? "a^");
-    // prettier-ignore
-    for (const path of ["docs/index.md", ".docs-tests/DocsSnippetCompilationTests.cs", ".docs-tests/global.json", ".llm/context.md", "Samples~/Mini Combat/README.md", "GOAL.md", "requirements-docs.in", "requirements-docs.in.meta", "requirements-docs.txt", "requirements-docs.txt.meta", "requirements-brand.in", "requirements-brand.in.meta", "requirements-brand.txt", "requirements-brand.txt.meta"])
-      assert.match(path, allowed, `${file}: ${path}`);
-    // prettier-ignore
-    for (const path of [`.github/workflows/${file}`, "Runtime/Core/MessageBus.cs", "Samples~/Mini Combat/Player.cs", "README.md"])
-      assert.doesNotMatch(path, allowed, `${file}: ${path}`);
-    assert.match(preflight, /needs\.head-check\.outputs\.relevant != 'false'/);
-    assert.match(aggregate, /RELEVANT: \$\{\{ needs\.head-check\.outputs\.relevant \}\}/);
-    assert.match(aggregate, /\[ "\$\{RELEVANT\}" = "false" \]/);
-    const gatedId = file === "unity-tests.yml" ? "unity-tests" : "comment-perf-doc";
-    const gated = getJobBlock(source, gatedId, file);
-    assert.match(gated, /needs\.head-check\.outputs\.relevant != 'false'/);
-  }
-  const unity = readWorkflow("unity-tests.yml");
-  const aggregate = getJobBlock(unity, "unity-ci-success", "unity-tests.yml");
-  for (const job of [
-    getJobBlock(unity, "runner-preflight", "unity-tests.yml"),
-    getJobBlock(unity, "unity-tests", "unity-tests.yml")
-  ]) {
+  // Documentation-only pull requests are skipped by the trigger filter itself.
+  // The allowlist must stay closed and mechanical.
+  const unityDocument = readWorkflowDocument("unity-tests.yml").toJS();
+  assert.deepEqual(
+    unityDocument.on.pull_request["paths-ignore"],
+    DOCS_ONLY_PATH_IGNORES
+  );
+
+  // unity-tests.yml is absent for those pull requests, so the companion gate
+  // keeps the required "Unity CI Success" context present by evaluating the
+  // same closed allowlist in-band.
+  const gateSource = readWorkflow("unity-docs-gate.yml");
+  const gateDocument = readWorkflowDocument("unity-docs-gate.yml").toJS();
+  assert.equal(gateDocument.on.pull_request.paths, undefined);
+  assert.equal(gateDocument.on.pull_request["paths-ignore"], undefined);
+  const gateJob = gateDocument.jobs["unity-ci-success"];
+  assert.equal(gateJob.name, "Unity CI Success");
+  assert.equal(gateJob.if, "${{ always() }}");
+  assert.equal(gateJob.steps.length, 1, "the docs gate is one fail-closed step");
+  const pattern = /documentation_only_pattern='([^']+)'/.exec(gateSource);
+  const allowed = new RegExp(pattern[1]);
+  // prettier-ignore
+  for (const file of ["docs/index.md", "docs/index.md.meta", ".docs-tests/DocsSnippetCompilationTests.cs", ".docs-tests/global.json", ".llm/context.md", "Samples~/Mini Combat/README.md", ".agents/skills/example/SKILL.md", ".claude/settings.json", "progress/2026-08-01-run.md", "GOAL.md", "llms.txt", "mkdocs.yml", "requirements-docs.in", "requirements-docs.txt", "requirements-brand.in", "requirements-brand.txt"])
+    assert.match(file, allowed, `docs-only ${file}`);
+  // The exact-name globs do not ignore .meta siblings: a pull request adding
+  // one of those touches a path unity-tests.yml still covers.
+  // prettier-ignore
+  for (const file of [".github/workflows/unity-tests.yml", "Runtime/Core/MessageBus.cs", "Samples~/Mini Combat/Player.cs", "README.md", "AGENTS.md.meta", "requirements-docs.in.meta", "Samples~/Mini Combat/README.md.meta"])
+    assert.doesNotMatch(file, allowed, `non-ignored ${file}`);
+
+  // perf-numbers.yml keeps its in-band head freshness and relevance decisions.
+  const perfSource = readWorkflow("perf-numbers.yml");
+  const head = getJobBlock(perfSource, "head-check", "perf-numbers.yml");
+  assert.match(head, /relevant: \$\{\{ steps\.head\.outputs\.relevant \}\}/);
+  assert.match(head, /Changed-file lookup failed; running licensed/);
+  assert.match(head, /echo "relevant=\$\{relevant\}" >> "\$\{GITHUB_OUTPUT\}"/);
+  const perfAllowed = new RegExp(/documentation_only_pattern='([^']+)'/.exec(head)[1]);
+  assert.match("docs/index.md", perfAllowed);
+  assert.doesNotMatch("Runtime/Core/MessageBus.cs", perfAllowed);
+
+  const unitySource = readWorkflow("unity-tests.yml");
+  for (const jobId of ["runner-preflight", "unity-tests"]) {
+    const job = getJobBlock(unitySource, jobId, "unity-tests.yml");
     assert.match(job, /github\.event\.pull_request\.user\.login != 'dependabot\[bot\]'/);
     assert.doesNotMatch(job, /github\.actor != 'dependabot\[bot\]'/);
   }
-  assert.match(
-    aggregate,
-    /DEPENDABOT_PR: \$\{\{ github\.event_name == 'pull_request' && github\.event\.pull_request\.user\.login == 'dependabot\[bot\]' \}\}/
-  );
   // prettier-ignore
-  assert.doesNotMatch(aggregate, /github\.actor == 'dependabot\[bot\]'/); assert.match(getStepBlock(getJobBlock(unity, "unity-tests", "unity-tests.yml"), "Upload shipping-fidelity artifacts"), /always\(\) &&[\s\S]*!cancelled\(\) &&[\s\S]*steps\.acquire_lock\.outputs\.acquired == 'true'[\s\S]*if-no-files-found: error/);
+  assert.doesNotMatch(getJobBlock(unitySource, "unity-ci-success", "unity-tests.yml"), /github\.actor == 'dependabot\[bot\]'/); assert.match(getStepBlock(getJobBlock(unitySource, "unity-tests", "unity-tests.yml"), "Upload shipping-fidelity artifacts"), /always\(\) &&[\s\S]*!cancelled\(\) &&[\s\S]*steps\.acquire_lock\.outputs\.acquired == 'true'[\s\S]*if-no-files-found: error/);
 });
 // prettier-ignore
-test("Unity failure diagnostics preserve the executable result gate and cost nothing on success", () => {
-  const job = readWorkflowDocument("unity-tests.yml").toJS().jobs["unity-ci-success"];
-  const [gate, diagnostic] = job.steps;
-  assert.equal(job.if, "${{ always() }}");
-  assert.deepEqual(job.permissions, { actions: "read" });
-  assert.equal(gate.id, "result_shape");
-  assert.equal(gate["continue-on-error"], undefined);
-  assert.equal(diagnostic.if, "${{ failure() && steps.result_shape.outcome == 'failure' }}");
-  assert.equal(diagnostic.uses, "actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3");
-  assert.equal(diagnostic["timeout-minutes"], 2);
-  assert.equal(job.steps.length, 2, "successful runs only execute the original shell gate");
-  const baseline = { HEAD_CHECK_RESULT: "success", RUNNER_PREFLIGHT_RESULT: "success", UNITY_TESTS_RESULT: "success" };
-  assert.equal(readWorkflowDocument("unity-tests.yml").toJS().jobs["unity-tests"].name, "Unity ${{ matrix.unity-version }} all modes");
+test("Unity CI Success aggregates enforce the closed trusted-skip result shape", () => {
   const bash = process.platform === "win32" ? path.join(process.env.ProgramFiles, "Git", "bin", "bash.exe") : "bash";
-  const run = (env) => spawnSync(bash, ["-c", gate.run], { env: { ...process.env, ...Object.fromEntries(Object.keys(gate.env).map((key) => [key, "false"])), ...baseline, RELEVANT: "true", ...env } });
-  for (const flag of [null, "RELEVANT", "SUPERSEDED", "FORK_PR", "DEPENDABOT_PR"]) {
-    const env = flag ? { [flag]: flag === "RELEVANT" ? "false" : "true", RUNNER_PREFLIGHT_RESULT: "skipped", UNITY_TESTS_RESULT: "skipped" } : { RELEVANT: "true" };
-    assert.equal(run(env).status, 0, `${flag}: intended successful shape`);
-    for (const key of Object.keys(baseline)) {
-      for (const value of ["failure", "cancelled", "", "skipped", "success"].filter((value) => value !== (env[key] || baseline[key]))) {
-        assert.equal(run({ ...env, [key]: value }).status, 1, `${flag}/${key}/${value}: failed shape`);
-      }
+  for (const [file, aggregateId, preflightJob, licensedJob] of [
+    ["unity-tests.yml", "unity-ci-success", "runner-preflight", "unity-tests"],
+    ["perf-numbers.yml", "perf-unity-success", "runner-preflight", "perf-benchmarks"]
+  ]) {
+    const job = readWorkflowDocument(file).toJS().jobs[aggregateId];
+    assert.ok(
+      String(job.if) === "always()" || String(job.if) === "${{ always() }}",
+      `${file}: the aggregate must be exactly always()`
+    );
+    assert.equal(job.steps.length, 1, `${file}: the trusted-skip shape keeps exactly one gate step`);
+    const gate = job.steps[0];
+    assert.equal(gate.shell, "bash");
+    assert.equal(gate["continue-on-error"], undefined);
+    assert.deepEqual(Object.keys(gate.env), ["RUNNER_PREFLIGHT_RESULT", "UNITY_TESTS_RESULT", "FORK_PR", "DEPENDABOT_PR"]);
+    assert.equal(gate.env.RUNNER_PREFLIGHT_RESULT, `\${{ needs.${preflightJob}.result }}`);
+    assert.equal(gate.env.UNITY_TESTS_RESULT, `\${{ needs.${licensedJob}.result }}`);
+    assert.equal(gate.env.FORK_PR, "${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}");
+    assert.equal(gate.env.DEPENDABOT_PR, "${{ github.event_name == 'pull_request' && github.event.pull_request.user.login == 'dependabot[bot]' }}");
+    // Execute the exact committed gate script against its truth table: the
+    // two untrusted pull-request shapes skip green, every trusted run needs
+    // both jobs green, and any other result shape fails.
+    const run = (env) => spawnSync(bash, ["-c", gate.run], { env: { ...process.env, ...env } }).status;
+    const truthTable = [
+      ["fork pull requests skip green", { FORK_PR: "true", DEPENDABOT_PR: "false", RUNNER_PREFLIGHT_RESULT: "skipped", UNITY_TESTS_RESULT: "skipped" }, 0],
+      ["dependabot pull requests skip green", { FORK_PR: "false", DEPENDABOT_PR: "true", RUNNER_PREFLIGHT_RESULT: "skipped", UNITY_TESTS_RESULT: "skipped" }, 0],
+      ["trusted runs need both jobs green", { FORK_PR: "false", DEPENDABOT_PR: "false", RUNNER_PREFLIGHT_RESULT: "success", UNITY_TESTS_RESULT: "success" }, 0],
+      ["a skipped licensed job on a trusted run is red", { FORK_PR: "false", DEPENDABOT_PR: "false", RUNNER_PREFLIGHT_RESULT: "skipped", UNITY_TESTS_RESULT: "skipped" }, 1],
+      ["a partial trusted run is red", { FORK_PR: "false", DEPENDABOT_PR: "false", RUNNER_PREFLIGHT_RESULT: "success", UNITY_TESTS_RESULT: "skipped" }, 1],
+      ["a failed licensed job is red", { FORK_PR: "false", DEPENDABOT_PR: "false", RUNNER_PREFLIGHT_RESULT: "success", UNITY_TESTS_RESULT: "failure" }, 1],
+      ["a fork run that executed licensed work is red", { FORK_PR: "true", DEPENDABOT_PR: "false", RUNNER_PREFLIGHT_RESULT: "success", UNITY_TESTS_RESULT: "success" }, 1]
+    ];
+    for (const [name, env, expected] of truthTable) {
+      assert.equal(run(env), expected, `${file}: ${name}`);
     }
   }
-});
-
-async function runUnityFailureDiagnostic(pages, { apiError = false, attempt = "1" } = {}) {
-  const job = readWorkflowDocument("unity-tests.yml").toJS().jobs["unity-ci-success"];
-  const script = job.steps.find((step) => step.name === "Report unsuccessful Unity legs").with.script;
-  const messages = [];
-  let summary;
-  const github = { paginate: async (route, options) => {
-    assert.equal(route, "GET /repos/{owner}/{repo}/actions/runs/{run_id}/attempts/{attempt_number}/jobs");
-    assert.deepEqual(options, { owner: "Ambiguous-Interactive", repo: "DxMessaging", run_id: 30926223438, attempt_number: Number(attempt), per_page: 100 });
-    if (apiError) throw new Error("request denied");
-    return Array.isArray(pages) ? pages.flat() : pages;
-  } };
-  const core = { error: (message) => messages.push(message), summary: { addRaw: (text) => ({ write: async () => { summary = text; } }) } };
-  const context = { repo: { owner: "Ambiguous-Interactive", repo: "DxMessaging" }, runId: 30926223438, serverUrl: "https://github.com" };
-  await new Function("github", "context", "core", "process", `return (async () => {${script}})();`)(github, context, core, { env: { GITHUB_RUN_ATTEMPT: attempt } });
-  assert.equal(typeof summary, "string");
-  assert.ok(messages.length, "a failed shape always produces an operator diagnostic");
-  return { messages, summary };
-}
-
-// Identity and empty steps copied from GET /actions/jobs/92049196223 on 2026-09-05.
-// GitHub no longer retains its step list. This case must keep an unknown boundary.
-const historicalUnityJob = { id: 92049196223, run_id: 30926223438, name: "Unity 2021.3.45f1 editmode", runner_name: "DAD-MACHINE", status: "completed", conclusion: "failure", steps: [] };
-const unityStep = (number, name, conclusion, status = "completed") => ({ number, name, conclusion, status });
-
-test("Unity diagnostic reports the issue-documented historical boundary without inventing a host cause", async () => {
-  // Reconstructed from #356 body/comment5182886089, not a downloaded full step list.
-  const steps = [unityStep(16, "Acquire organization Unity lock", "success"), unityStep(17, "Require acquired Unity lock", "skipped"), unityStep(18, "Upload Unity editor validation diagnostics", "success"), unityStep(19, "Run Unity Test Runner", null, "queued"), unityStep(23, "Return Unity license", null, "queued")];
-  const result = await runUnityFailureDiagnostic([[{ ...historicalUnityJob, id: 2, conclusion: "success" }], [{ ...historicalUnityJob, steps: steps.reverse() }]], { attempt: "2" });
-  assert.equal(result.messages.length, 1, "successful first page does not hide a failed later page");
-  for (const pattern of [/job 92049196223/, /runner DAD-MACHINE/, /\/actions\/runs\/30926223438\/job\/92049196223/, /Last completed step: 18:/, /First step without a recorded conclusion: 19:/, /Runner\/Worker logs/, /cause is unknown/]) assert.match(result.summary, pattern);
-  assert.doesNotMatch(result.summary, /Failed step: 17:|Last completed step: 23:|OOM|killed|leaked/);
-});
-
-test("Unity diagnostic handles retained metadata, normal failures, and unavailable evidence", async () => {
-  const cases = [
-    ["retained historical metadata", [[historicalUnityJob]], {}, /boundary is unknown/],
-    ["missing steps", [[{ ...historicalUnityJob, steps: undefined }]], {}, /boundary is unknown/],
-    ["cancelled", [[{ ...historicalUnityJob, conclusion: "cancelled" }]], {}, /completed\/cancelled/],
-    ["unexpected skip", [[{ ...historicalUnityJob, conclusion: "skipped", runner_name: "" }]], {}, /runner unassigned; completed\/skipped/],
-    ["ordinary failure", [[{ ...historicalUnityJob, steps: [unityStep(19, "Run Unity Test Runner", "failure"), unityStep(23, "Return Unity license", "success")] }]], {}, /Failed step: 19:.*Last completed step: 23:/s],
-    ["other jobs", [[{ ...historicalUnityJob, name: "Unity CI Success" }]], {}, /No unsuccessful Unity leg/],
-    ["API denied", [], { apiError: true }, /diagnostics are unavailable/],
-    ["invalid attempt", [], { attempt: "0" }, /diagnostics are unavailable/],
-    ["malformed list", {}, {}, /diagnostics are unavailable/],
-    ["wrong run", [[{ ...historicalUnityJob, run_id: 1 }]], {}, /diagnostics are unavailable/],
-    ["malformed steps", [[{ ...historicalUnityJob, steps: [null] }]], {}, /diagnostics are unavailable/]
-  ];
-  for (const [label, pages, options, pattern] of cases) {
-    const result = await runUnityFailureDiagnostic(pages, options);
-    assert.match(result.summary, pattern, label);
-    assert.doesNotMatch(result.summary, /Runner\/Worker logs/, `${label}: no invented incomplete boundary`);
-  }
-  const result = await runUnityFailureDiagnostic([[{ ...historicalUnityJob, name: "Unity 6000.5.2f1 all modes", runner_name: "<runner>&", steps: [unityStep(19, "<script>bad</script>", "failure")] }]]);
-  assert.match(result.summary, /&lt;runner&gt;&amp;/);
-  assert.match(result.summary, /&lt;script&gt;bad&lt;\/script&gt;/);
-  assert.doesNotMatch(result.summary, /<script>/);
+  const unityJob = readWorkflowDocument("unity-tests.yml").toJS().jobs["unity-ci-success"];
+  assert.deepEqual(unityJob.permissions, { actions: "read" });
+  assert.equal(readWorkflowDocument("unity-tests.yml").toJS().jobs["unity-tests"].name, "Unity ${{ matrix.unity-version }} all modes");
 });
 
 // prettier-ignore

--- a/scripts/__tests__/ci-aggregate-workflow.test.js
+++ b/scripts/__tests__/ci-aggregate-workflow.test.js
@@ -698,16 +698,16 @@ test("licensed PR workflows fail closed and skip only documented non-code paths"
   assert.deepEqual(unityDocument.on.pull_request["paths-ignore"], DOCS_ONLY_PATH_IGNORES);
 
   // unity-tests.yml is absent for those pull requests, so the companion gate
-  // keeps the required "Unity CI Success" context present by evaluating the
-  // same closed allowlist in-band.
+  // keeps the required "Unity CI Success" context present. Mixed changes use
+  // a distinct report name and leave that context to the licensed workflow.
   const gateSource = readWorkflow("unity-docs-gate.yml");
   const gateDocument = readWorkflowDocument("unity-docs-gate.yml").toJS();
-  assert.equal(gateDocument.on.pull_request.paths, undefined);
-  assert.equal(gateDocument.on.pull_request["paths-ignore"], undefined);
-  const gateJob = gateDocument.jobs["unity-ci-success"];
-  assert.equal(gateJob.name, "Unity CI Success");
-  assert.equal(gateJob.if, "${{ always() }}");
-  assert.equal(gateJob.steps.length, 1, "the docs gate is one fail-closed step");
+  const { classify: classifyJob, report: reportJob } = gateDocument.jobs;
+  // prettier-ignore
+  assert.deepEqual(
+    { paths: gateDocument.on.pull_request.paths, pathsIgnore: gateDocument.on.pull_request["paths-ignore"], classifySteps: classifyJob.steps.length, classifyOutput: classifyJob.outputs.documentation_only, reportName: reportJob.name, reportIf: reportJob.if, reportSteps: reportJob.steps.length, reportNeeds: reportJob.needs },
+    { paths: [".github/workflows/**", ...DOCS_ONLY_PATH_IGNORES], pathsIgnore: undefined, classifySteps: 1, classifyOutput: "${{ steps.classify.outputs.documentation_only }}", reportName: "${{ (needs.classify.result != 'success' || needs.classify.outputs.documentation_only != 'false') && 'Unity CI Success' || 'Unity docs gate not applicable' }}", reportIf: "${{ always() }}", reportSteps: 1, reportNeeds: ["classify"] }
+  );
   const pattern = /documentation_only_pattern='([^']+)'/.exec(gateSource);
   const allowed = new RegExp(pattern[1]);
   // prettier-ignore

--- a/scripts/__tests__/ci-aggregate-workflow.test.js
+++ b/scripts/__tests__/ci-aggregate-workflow.test.js
@@ -60,7 +60,6 @@ const AGGREGATED_JOBS = ["changes", "actionlint", "markdownlint", "csharpier", "
 
 // cspell:ignore ACDMRT
 
-
 const readWorkflow = (file = "ci.yml") => fs.readFileSync(path.join(WORKFLOW_DIR, file), "utf8");
 
 const readWorkflowDocument = (file) => YAML.parseDocument(readWorkflow(file));
@@ -539,11 +538,24 @@ test("every Unity lock window releases with explicit cleanup proof", () => {
     const licensedCondition = `${file === "perf-numbers.yml" ? "success\\(\\) && " : ""}${file === "unity-tests.yml" ? "!cancelled\\(\\) && " : ""}${emptyAware ? "steps\\.compute\\.outputs\\.is-empty != 'true' && " : ""}steps\\.acquire_lock\\.outputs\\.acquired == 'true'`;
     const job = getJobBlock(readWorkflow(file), jobId, file);
     const install = getStepBlock(job, "Install artifact tooling dependencies");
-    assert.match(install, /id: install_dependencies\n[\s\S]*shell: pwsh\n[\s\S]*\bnpm ci [^\n]*--ignore-scripts --no-audit --no-fund\n/);
+    assert.match(
+      install,
+      /id: install_dependencies\n[\s\S]*shell: pwsh\n[\s\S]*\bnpm ci [^\n]*--ignore-scripts --no-audit --no-fund\n/
+    );
     assert.doesNotMatch(install, /continue-on-error:|\n        if:/);
-    assert.ok(job.indexOf("id: setup_node") < job.indexOf(install) && job.indexOf(install) < job.indexOf(acquire), `${label}: install before acquiring a license`);
-    for (const step of YAML.parse(job)[jobId].steps.filter((step) => step.uses === "./.github/actions/redact-unity-artifacts")) {
-      assert.match(step.if, /steps\.install_dependencies\.outcome == 'success'/, `${label}: failed installs cannot authorize redaction or uploads`);
+    assert.ok(
+      job.indexOf("id: setup_node") < job.indexOf(install) &&
+        job.indexOf(install) < job.indexOf(acquire),
+      `${label}: install before acquiring a license`
+    );
+    for (const step of YAML.parse(job)[jobId].steps.filter(
+      (step) => step.uses === "./.github/actions/redact-unity-artifacts"
+    )) {
+      assert.match(
+        step.if,
+        /steps\.install_dependencies\.outcome == 'success'/,
+        `${label}: failed installs cannot authorize redaction or uploads`
+      );
     }
     const expectedJobTimeout = file === "unity-tests.yml" ? 1050 : 900;
     // prettier-ignore
@@ -597,8 +609,16 @@ test("every Unity lock window releases with explicit cleanup proof", () => {
     ];
     for (const [actual, contract, message] of contracts) assert.match(actual, contract, message);
 
-    assert.doesNotMatch(validationStep, /\n        if:/, `${label}: the editor gate must keep GitHub's implicit success chain`);
-    assert.doesNotMatch(validationStep, /\n        continue-on-error:/, `${label}: the editor gate must propagate failure`);
+    assert.doesNotMatch(
+      validationStep,
+      /\n        if:/,
+      `${label}: the editor gate must keep GitHub's implicit success chain`
+    );
+    assert.doesNotMatch(
+      validationStep,
+      /\n        continue-on-error:/,
+      `${label}: the editor gate must propagate failure`
+    );
     assert.doesNotMatch(returnStep, /continue-on-error:/);
 
     // Invocation invariant: the validated editor output reaches every
@@ -675,10 +695,7 @@ test("licensed PR workflows fail closed and skip only documented non-code paths"
   // Documentation-only pull requests are skipped by the trigger filter itself.
   // The allowlist must stay closed and mechanical.
   const unityDocument = readWorkflowDocument("unity-tests.yml").toJS();
-  assert.deepEqual(
-    unityDocument.on.pull_request["paths-ignore"],
-    DOCS_ONLY_PATH_IGNORES
-  );
+  assert.deepEqual(unityDocument.on.pull_request["paths-ignore"], DOCS_ONLY_PATH_IGNORES);
 
   // unity-tests.yml is absent for those pull requests, so the companion gate
   // keeps the required "Unity CI Success" context present by evaluating the
@@ -719,7 +736,14 @@ test("licensed PR workflows fail closed and skip only documented non-code paths"
     assert.doesNotMatch(job, /github\.actor != 'dependabot\[bot\]'/);
   }
   // prettier-ignore
-  assert.doesNotMatch(getJobBlock(unitySource, "unity-ci-success", "unity-tests.yml"), /github\.actor == 'dependabot\[bot\]'/); assert.match(getStepBlock(getJobBlock(unitySource, "unity-tests", "unity-tests.yml"), "Upload shipping-fidelity artifacts"), /always\(\) &&[\s\S]*!cancelled\(\) &&[\s\S]*steps\.acquire_lock\.outputs\.acquired == 'true'[\s\S]*if-no-files-found: error/);
+  assert.doesNotMatch(getJobBlock(unitySource, "unity-ci-success", "unity-tests.yml"), /github\.actor == 'dependabot\[bot\]'/);
+  assert.match(
+    getStepBlock(
+      getJobBlock(unitySource, "unity-tests", "unity-tests.yml"),
+      "Upload shipping-fidelity artifacts"
+    ),
+    /always\(\) &&[\s\S]*!cancelled\(\) &&[\s\S]*steps\.acquire_lock\.outputs\.acquired == 'true'[\s\S]*if-no-files-found: error/
+  );
 });
 // prettier-ignore
 test("Unity CI Success aggregates enforce the closed trusted-skip result shape", () => {

--- a/scripts/__tests__/unity-artifact-redaction.test.js
+++ b/scripts/__tests__/unity-artifact-redaction.test.js
@@ -117,7 +117,7 @@ test("every Unity artifact upload is preceded by sensitive-data redaction in the
   const uploads = unityUploads();
   assert.equal(
     uploads.length,
-    15,
+    10,
     "the number of Unity-log-bearing uploads changed; confirm each one is still redacted"
   );
   const unprotected = uploads.filter((upload) => !covers(upload.inForce, upload.uploadedPath));

--- a/scripts/__tests__/unity-artifact-redaction.test.js
+++ b/scripts/__tests__/unity-artifact-redaction.test.js
@@ -313,7 +313,10 @@ test("licensed jobs install tooling outside Unity imports before acquiring a lic
       const install = steps.findIndex((step) => step.id === "install_dependencies");
       const lock = steps.findIndex((step) => step.id === "acquire_lock");
       if (lock < 0) continue;
-      assert.ok(install >= 0 && install < lock, "install npm tools before acquiring a Unity license");
+      assert.ok(
+        install >= 0 && install < lock,
+        "install npm tools before acquiring a Unity license"
+      );
       const command = steps[install].run;
       assert.match(command, /Join-Path \$env:GITHUB_WORKSPACE '\.artifacts\/node-tooling'/);
       assert.match(command, /npm ci --prefix "\$tooling"/);

--- a/scripts/__tests__/workflow-test-vectors.json
+++ b/scripts/__tests__/workflow-test-vectors.json
@@ -13,7 +13,11 @@
     "perf-numbers.yml": "${{ fromJSON('{\"editmode\":\"EditorOnly\",\"playmode\":\"EditorOnly\",\"standalone\":\"StandaloneWindowsIl2Cpp\"}')[matrix.test-mode] }}"
   },
   "UNITY_EDITOR_CONSUMERS": [
-    ["unity-tests.yml", "unity-tests", ["run_editmode", "run_playmode", "run_standalone", "run_shipping"]],
+    [
+      "unity-tests.yml",
+      "unity-tests",
+      ["run_editmode", "run_playmode", "run_standalone", "run_shipping"]
+    ],
     ["unity-benchmarks.yml", "benchmarks", ["run_tests"]],
     ["release.yml", "unity-checks", ["run_tests"]],
     ["release.yml", "unitypackage", ["export_unitypackage"]],

--- a/scripts/__tests__/workflow-test-vectors.json
+++ b/scripts/__tests__/workflow-test-vectors.json
@@ -6,6 +6,38 @@
     ["release.yml", "unitypackage", "Export the .unitypackage", false],
     ["perf-numbers.yml", "perf-benchmarks", "Run Unity Test Runner", true]
   ],
+  "UNITY_EDITOR_PROFILES": {
+    "unity-tests.yml": "${{ fromJSON('{\"editmode\":\"EditorOnly\",\"playmode\":\"EditorOnly\",\"standalone\":\"StandaloneWindowsIl2Cpp\"}')[matrix.test-mode] }}",
+    "unity-benchmarks.yml": "${{ fromJSON('{\"editmode\":\"EditorOnly\",\"playmode\":\"EditorOnly\",\"standalone\":\"StandaloneWindowsIl2Cpp\"}')[matrix.test-mode] }}",
+    "release.yml": "EditorOnly",
+    "perf-numbers.yml": "${{ fromJSON('{\"editmode\":\"EditorOnly\",\"playmode\":\"EditorOnly\",\"standalone\":\"StandaloneWindowsIl2Cpp\"}')[matrix.test-mode] }}"
+  },
+  "UNITY_EDITOR_CONSUMERS": [
+    ["unity-tests.yml", "unity-tests", ["run_editmode", "run_playmode", "run_standalone", "run_shipping"]],
+    ["unity-benchmarks.yml", "benchmarks", ["run_tests"]],
+    ["release.yml", "unity-checks", ["run_tests"]],
+    ["release.yml", "unitypackage", ["export_unitypackage"]],
+    ["perf-numbers.yml", "perf-benchmarks", ["run_contracts", "run_tests"]]
+  ],
+  "DOCS_ONLY_PATH_IGNORES": [
+    "docs/**",
+    ".docs-tests/**",
+    "progress/**",
+    ".llm/**",
+    ".agents/**",
+    ".claude/**",
+    "Samples~/**/*.md",
+    "Samples~/**/*.markdown",
+    "AGENTS.md",
+    "GOAL.md",
+    "PLAN.md",
+    "llms.txt",
+    "mkdocs.yml",
+    "requirements-docs.in",
+    "requirements-docs.txt",
+    "requirements-brand.in",
+    "requirements-brand.txt"
+  ],
   "STATIC_CHILD_JOBS": [
     ["actionlint", "actionlint"],
     ["markdownlint", "markdown"],

--- a/scripts/validate-js-loc-budget.js
+++ b/scripts/validate-js-loc-budget.js
@@ -193,7 +193,12 @@ const path = require("path");
 //     document-level UTF-16 byte-order mark preserved and encoded-Cf shadows still refusing
 //     sealing. Vector rows moved from refusal to exact-byte acceptance; the marker passes reuse
 //     the existing data-driven loops: 24063.
-const TOTAL_BUDGET = 24063;
+// 088 Migrate the Unity workflow contract tests to the central-action lifecycle. The aggregate
+//     gate loses its head-check diagnostic step for the closed trusted-skip script (fork and
+//     Dependabot env keys only), docs-only PRs gain the unity-docs-gate allowlist vectors, and
+//     the static test-mode axis joins the holder identity, so the topology vectors and their
+//     expectations grow, plus the 5 lines this entry itself adds: 24095.
+const TOTAL_BUDGET = 24095;
 const LARGEST_FILE_COUNT = 10;
 const REPO_ROOT = path.resolve(__dirname, "..");
 

--- a/scripts/validate-unity-pr-policy.py
+++ b/scripts/validate-unity-pr-policy.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 
 WORKFLOW = Path(".github/workflows/unity-tests.yml")
+DOCS_GATE = Path(".github/workflows/unity-docs-gate.yml")
 WATCHDOG = Path(".github/workflows/stuck-job-watchdog.yml")
 SHIPPING_MATRIX = Path("scripts/unity/run-shipping-fidelity-matrix.ps1")
 LOCK_ACTION_PREFIX = "Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/"
@@ -156,6 +157,16 @@ def mutate_pin_sha(use: str) -> str:
 
 CURRENT_PR_HEAD_GUARD = resolve_action_use("require-current-pr-head")
 ACQUIRE_BUILD_LOCK = resolve_action_use("acquire-build-lock")
+ENSURE_UNITY_EDITOR = resolve_action_use("ensure-unity-editor")
+# Shipping fidelity is dispatch-only: the reviewed endpoint predicate every
+# shipping step and the terminal verdict must embed verbatim.
+SHIPPING_EVENT_PREDICATE = (
+    "github.event_name == 'workflow_dispatch' && inputs.shipping_fidelity && "
+    "(matrix.unity-version == '2021.3.45f1' || matrix.unity-version == '6000.5.2f1')"
+)
+UNITY_EDITOR_PATH_BINDING = (
+    "UNITY_EDITOR_PATH: ${{ steps.ensure_unity_editor.outputs.editor-path }}"
+)
 
 
 def job_block(source: str, job_id: str) -> str:
@@ -695,9 +706,14 @@ def validate_cleanup_gate_not_attempted_input(job: str, label: str) -> None:
     acquisition fails part-way. Both have to hold at once (#327): a leg that
     aborts before `Acquire organization Unity lock` must report exactly one
     failure, and a leg whose acquire failed after taking the lock must still
-    fail. The distinction is `outcome`, which is empty or `skipped` only when
-    the step did not execute; gating on `acquired == 'true'` instead would
-    skip the gate in precisely the case it must never miss.
+    fail. The typed `outputs.acquired` binding carries exactly that
+    distinction: the expression is empty while the step has not executed and
+    the central gate itself treats missing or invalid acquisition state as
+    fail-closed; only the literal `acquired=false` from a completed acquire
+    marks cleanup as not applicable. Restating a skip mapping in the workflow
+    (an `outcome`-based `'false'` rewrite) would duplicate -- and could
+    disagree with -- the gate's own typing, so the input must be the raw
+    typed output.
     """
     gate = step_block(job, "Require confirmed Unity cleanup")
     require(
@@ -706,21 +722,84 @@ def validate_cleanup_gate_not_attempted_input(job: str, label: str) -> None:
     )
     acquired = re.search(r"\n          acquired: (.*)\n", gate)
     require(acquired is not None, f"{label}: the cleanup gate must pass `acquired`")
-    expression = acquired.group(1)
-    for fragment in (
-        "steps.acquire_lock.outcome == 'skipped'",
-        "steps.acquire_lock.outcome == ''",
-        "&& 'false' ||",
-        "steps.acquire_lock.outputs.acquired",
-    ):
-        require(
-            fragment in expression,
-            f"{label}: the cleanup gate's `acquired` input must map only a step that "
-            f"never executed to 'false' and pass everything else through; missing {fragment!r}",
-        )
+    expression = acquired.group(1).strip()
+    require(
+        expression == "${{ steps.acquire_lock.outputs.acquired }}",
+        f"{label}: the cleanup gate's `acquired` input must be the typed "
+        f"`steps.acquire_lock.outputs.acquired` binding so only a completed "
+        f"acquire can report not-attempted; found {expression!r}",
+    )
     require(
         "outcome == 'failure'" not in expression and "outcome != " not in expression,
         f"{label}: a failed acquire must not be laundered into a not-attempted verdict",
+    )
+
+
+def step_block_run_body(step: str) -> str:
+    """Return the step's multiline `run:` body, or '' when the step has none."""
+    marker = "        run: |\n"
+    start = step.find(marker)
+    if start < 0:
+        return ""
+    lines = []
+    for line in step[start + len(marker) :].splitlines():
+        if line and not line.startswith("          "):
+            break
+        lines.append(line[10:] if line else "")
+    return "\n".join(lines)
+
+
+def validate_editor_gate_bindings(job: str, label: str) -> None:
+    """Every Unity-consuming step must run the editor the central gate validated.
+
+    The gate sits behind the approved head guard and before any checkout or
+    credential reference, exposes the validated executable through its
+    `editor-path` output, and every step that launches Unity binds it as
+    `UNITY_EDITOR_PATH` step env. A step that launched Unity without the
+    binding could execute an editor the gate never validated.
+    """
+    editor_gate = step_block(job, "Require manually installed Unity editor")
+    require(
+        f"uses: {ENSURE_UNITY_EDITOR}" in editor_gate,
+        f"{label}: editor gate must use the pinned central ensure-unity-editor action",
+    )
+    require(
+        "ci-managed-only: true" in editor_gate and "require-healthy-existing: true" in editor_gate,
+        f"{label}: editor gate must stay CI-managed and healthy-existing fail-closed",
+    )
+    setup_guard = job.find("      - name: Require current PR head before setup\n")
+    editor_gate_offset = job.find(editor_gate)
+    checkout = job.find("      - name: Checkout\n")
+    credentials = job.find("      - name: Validate Unity license secrets\n")
+    acquire = job.find("      - name: Acquire organization Unity lock\n")
+    require(
+        editor_gate_offset < checkout < credentials < acquire,
+        f"{label}: editor gate must run before checkout, credentials, and lock acquisition",
+    )
+    # Dispatch-only windows have no pull-request head to guard; the windows
+    # that do (asserted by the dedicated guard checks in `validate`) must keep
+    # the gate behind that guard.
+    if setup_guard >= 0:
+        require(
+            setup_guard < editor_gate_offset,
+            f"{label}: editor gate must sit behind the pull-request head guard",
+        )
+    consumers = 0
+    for step in top_level_steps_through_cleanup_gate(job, label)[:-1]:
+        body = step_block_run_body(step)
+        if (
+            "./scripts/unity/run-ci-tests.ps1" in body
+            or "run-shipping-fidelity-matrix.ps1" in body
+            or "export-unitypackage.ps1" in body
+        ):
+            consumers += 1
+            require(
+                UNITY_EDITOR_PATH_BINDING in step,
+                f"{label}: a Unity-consuming step must bind the validated editor path",
+            )
+    require(
+        consumers >= 1,
+        f"{label}: expected at least one Unity-consuming step to bind the editor path",
     )
 
 
@@ -2525,7 +2604,14 @@ def validate_msvc_gate_is_reachable() -> None:
 
 
 def validate_shipping_event_policy(source: str) -> None:
-    """Require one weekly/manual predicate for every shipping action and verdict."""
+    """Require one dispatch-only endpoint predicate for every shipping action and verdict.
+
+    The weekly schedule is gone: shipping fidelity runs only when someone
+    dispatches the workflow with the boolean opt-in, on the two endpoint
+    editors. Every shipping step and the terminal verdict must embed exactly
+    the same predicate, so an execution path can never disagree with the
+    evidence the terminal gate demands.
+    """
     result = subprocess.run(
         ["node", "-e", """
 const fs = require('fs');
@@ -2539,30 +2625,24 @@ process.stdout.write(JSON.stringify({on: workflow.on, env: job.env, steps: job.s
     require(result.returncode == 0, f"shipping policy YAML must parse: {result.stderr}")
     workflow = json.loads(result.stdout)
     triggers = workflow["on"]
-    require(triggers.get("schedule") == [{"cron": "17 4 * * 0"}],
-            "shipping fidelity must run weekly on Sunday at 04:17 UTC")
+    require(triggers.get("schedule") is None,
+            "shipping fidelity must not run from a schedule; it is dispatch-only")
     dispatch = triggers.get("workflow_dispatch") or {}
     option = (dispatch.get("inputs") or {}).get("shipping_fidelity") or {}
     require(option.get("type") == "boolean" and option.get("default") is False,
             "manual shipping fidelity must be a boolean opt-in defaulting to false")
-    predicate = (
-        "${{ (github.event_name == 'schedule' || "
-        "(github.event_name == 'workflow_dispatch' && inputs.shipping_fidelity)) && "
-        "(matrix.unity-version == '2021.3.45f1' || matrix.unity-version == '6000.5.2f1') }}"
-    )
-    require((workflow.get("env") or {}).get("DXM_RUN_SHIPPING") == predicate,
-            "shipping must use the shared weekly/manual endpoint predicate")
+    endpoint = SHIPPING_EVENT_PREDICATE
     conditions = {
         "Run stripped shipping-fidelity players":
-            "!cancelled() && steps.acquire_lock.outputs.acquired == 'true' && env.DXM_RUN_SHIPPING == 'true'",
+            "!cancelled() && steps.acquire_lock.outputs.acquired == 'true' && " + endpoint,
         "Dump shipping-fidelity log tail on failure or cancellation":
-            "env.DXM_RUN_SHIPPING == 'true' && (steps.run_shipping.outcome == 'failure' || cancelled())",
+            "(" + endpoint + ") && (steps.run_shipping.outcome == 'failure' || cancelled())",
         "Seal shipping-fidelity evidence bundle":
-            "env.DXM_RUN_SHIPPING == 'true' && steps.run_shipping.outcome == 'success'",
+            endpoint + " && steps.run_shipping.outcome == 'success'",
         "Upload shipping-fidelity artifacts":
             "steps.redact_tests.outcome == 'success' && steps.seal_shipping.outcome == 'success' && "
             "always() && !cancelled() && "
-            "steps.acquire_lock.outputs.acquired == 'true' && env.DXM_RUN_SHIPPING == 'true'",
+            "steps.acquire_lock.outputs.acquired == 'true' && " + endpoint,
     }
     for name, condition in conditions.items():
         matches = [step for step in workflow["steps"] if step.get("name") == name]
@@ -2572,17 +2652,20 @@ process.stdout.write(JSON.stringify({on: workflow.on, env: job.env, steps: job.s
                 f"{name}: shipping condition must preserve event, outcome, and cleanup gates")
     for step in workflow["steps"]:
         require("DXM_RUN_SHIPPING" not in (step.get("env") or {}),
-                "steps must not shadow the shared shipping predicate")
+                "the shared shipping predicate env is retired; steps must embed the dispatch predicate")
+    require("DXM_RUN_SHIPPING" not in source,
+            "the shared shipping predicate env is retired; every shipping condition "
+            "must embed the dispatch predicate verbatim")
     gate = next(step for step in workflow["steps"] if step.get("name") == "Require every Unity mode to pass")
-    require(gate.get("env", {}).get("SHIPPING_REQUIRED") == "${{ env.DXM_RUN_SHIPPING }}",
-            "terminal shipping requirement must use the same event predicate as execution")
+    require(gate.get("env", {}).get("SHIPPING_REQUIRED") == "${{ " + endpoint + " }}",
+            "terminal shipping requirement must use the same dispatch predicate as execution")
 
     # Execute the actual, structurally restricted workflow expression. Missing inputs
     # are falsy; typed workflow_dispatch booleans must not become truthy strings.
-    expression = workflow["env"]["DXM_RUN_SHIPPING"][3:-2].replace("github.event_name", "event").replace(
+    expression = gate["env"]["SHIPPING_REQUIRED"][3:-2].replace("github.event_name", "event").replace(
         "inputs.shipping_fidelity", "input"
     ).replace("matrix.unity-version", "version")
-    events = ("pull_request", "pull_request_target", "push", "schedule", "workflow_dispatch", "repository_dispatch")
+    events = ("pull_request", "pull_request_target", "push", "workflow_dispatch", "repository_dispatch")
     versions = ("2021.3.45f1", "2022.3.45f1", "6000.3.16f1", "6000.5.2f1")
     rows = [(event, option, version) for event in events for option in (None, False, True) for version in versions]
     evaluated = subprocess.run(
@@ -2597,7 +2680,7 @@ process.stdout.write(JSON.stringify({on: workflow.on, env: job.env, steps: job.s
     require(len(outcomes) == len(rows), "shipping event truth table must evaluate every row")
     for (event, option, version), actual in zip(rows, outcomes):
         expected = version in (versions[0], versions[-1]) and (
-            event == "schedule" or (event == "workflow_dispatch" and option is True)
+            event == "workflow_dispatch" and option is True
         )
         require(actual is expected,
                 f"shipping event={event}, input={option}, version={version}: expected {expected}, got {actual}")
@@ -2608,15 +2691,24 @@ def validate_grouped_unity_correctness() -> None:
     source = WORKFLOW.read_text(encoding="utf-8")
     validate_shipping_event_policy(source)
     mutations = [
-        ("weekly schedule removed", '    - cron: "17 4 * * 0"', ""),
-        ("daily shipping schedule", 'cron: "17 4 * * 0"', 'cron: "17 4 * * *"'),
         ("manual shipping enabled by default", "default: false", "default: true"),
         ("manual input loses boolean typing", "type: boolean", "type: string"),
-        ("push enables shipping", "github.event_name == 'schedule'", "github.event_name == 'push'"),
+        (
+            "shipping runs on push",
+            "github.event_name == 'workflow_dispatch'",
+            "github.event_name == 'push'",
+        ),
         ("manual shipping ignores opt-in", "&& inputs.shipping_fidelity", "&& true"),
-        ("endpoint admission broadens", "matrix.unity-version == '2021.3.45f1'", "true"),
-        ("terminal shipping gate drifts", "SHIPPING_REQUIRED: ${{ env.DXM_RUN_SHIPPING }}",
-         "SHIPPING_REQUIRED: true"),
+        (
+            "endpoint admission broadens",
+            "(matrix.unity-version == '2021.3.45f1' || matrix.unity-version == '6000.5.2f1')",
+            "true",
+        ),
+        (
+            "terminal shipping gate drifts",
+            f"SHIPPING_REQUIRED: ${{{{ {SHIPPING_EVENT_PREDICATE} }}}}",
+            "SHIPPING_REQUIRED: true",
+        ),
     ]
     for name in (
         "Run stripped shipping-fidelity players",
@@ -2625,8 +2717,18 @@ def validate_grouped_unity_correctness() -> None:
         "Upload shipping-fidelity artifacts",
     ):
         original = step_block(job_block(source, "unity-tests"), name)
-        mutations.append((f"{name} bypasses event policy", original,
-                          original.replace("env.DXM_RUN_SHIPPING == 'true'", "true")))
+        mutations.append(
+            (
+                f"{name} bypasses event policy",
+                original,
+                re.sub(
+                    r"github\.event_name == 'workflow_dispatch'\s*&&\s*"
+                    r"inputs\.shipping_fidelity",
+                    "github.event_name == 'workflow_dispatch'",
+                    original,
+                ),
+            )
+        )
     for name, before, after in mutations:
         require(before in source and before != after, f"{name}: mutation target missing")
         try:
@@ -2637,14 +2739,21 @@ def validate_grouped_unity_correctness() -> None:
     job = job_block(source, "unity-tests")
     require(
         "name: Unity ${{ matrix.unity-version }} all modes" in job
-        and "matrix.test-mode" not in job,
-        "Unity correctness must use four editor-scoped jobs",
+        and re.findall(
+            r"^        test-mode:\n          - standalone\n", job, re.MULTILINE
+        )
+        == ["        test-mode:\n          - standalone\n"],
+        "Unity correctness must run one editor-grouped job per leg with a "
+        "literal standalone test-mode axis",
     )
+    editor_gate = step_block(job, "Require manually installed Unity editor")
     require(
-        "-ProvisioningProfile StandaloneWindowsIl2Cpp" in step_block(
-            job, "Require manually installed Unity editor"
-        ),
-        "grouped correctness must validate the IL2CPP-capable editor once",
+        "provisioning-profile: ${{ fromJSON('"
+        '{"editmode":"EditorOnly","playmode":"EditorOnly",'
+        '"standalone":"StandaloneWindowsIl2Cpp"}'
+        "')[matrix.test-mode] }}" in editor_gate,
+        "grouped correctness must validate the IL2CPP-capable editor once via "
+        "the reviewed static test-mode profile map",
     )
 
     mode_specs = (
@@ -2719,7 +2828,9 @@ def validate_grouped_unity_correctness() -> None:
         "id: run_shipping",
         "!cancelled()",
         "steps.acquire_lock.outputs.acquired == 'true'",
-        "env.DXM_RUN_SHIPPING == 'true'",
+        "github.event_name == 'workflow_dispatch'",
+        "inputs.shipping_fidelity",
+        "(matrix.unity-version == '2021.3.45f1' || matrix.unity-version == '6000.5.2f1')",
         "continue-on-error: true",
         "timeout-minutes: 150",
         "./scripts/unity/run-shipping-fidelity-matrix.ps1",
@@ -3599,42 +3710,52 @@ def validate_perf_pr_policy() -> None:
 
     aggregate = job_block(source, "perf-unity-success")
     aggregate_step = step_block(aggregate, "Require complete performance validation")
-    aggregate_script = run_script(aggregate_step)
-    executable_aggregate = (
-        aggregate_script.replace(
-            "${{ needs.head-check.result }}", "${HEAD_CHECK_RESULT}"
+    expected_perf_bindings = {
+        "RUNNER_PREFLIGHT_RESULT": "${{ needs.runner-preflight.result }}",
+        "UNITY_TESTS_RESULT": "${{ needs.perf-benchmarks.result }}",
+        "FORK_PR": (
+            "${{ github.event_name == 'pull_request' && "
+            "github.event.pull_request.head.repo.full_name != github.repository }}"
+        ),
+        "DEPENDABOT_PR": (
+            "${{ github.event_name == 'pull_request' && "
+            "github.event.pull_request.user.login == 'dependabot[bot]' }}"
+        ),
+    }
+    for variable, value in expected_perf_bindings.items():
+        require(
+            re.findall(rf"^          {variable}:.*$", aggregate_step, re.MULTILINE)
+            == [f"          {variable}: {value}"],
+            f"performance aggregate must bind exact {variable}",
         )
-        .replace(
-            "${{ needs.runner-preflight.result }}", "${RUNNER_PREFLIGHT_RESULT}"
-        )
-        .replace(
-            "${{ needs.perf-benchmarks.result }}", "${PERF_BENCHMARKS_RESULT}"
-        )
-    )
+    aggregate_script = run_script(aggregate_step).rstrip()
     require(
-        executable_aggregate != aggregate_script,
-        "performance aggregate must validate dependency results",
+        "set -euo pipefail" in aggregate_script
+        and 'if [ "${FORK_PR}" = "true" ] || [ "${DEPENDABOT_PR}" = "true" ]; then'
+        in aggregate_script,
+        "performance aggregate must keep the closed trusted-skip shape",
     )
+    executable_aggregate = aggregate_script
     aggregate_cases = (
-        ("relevant trusted PR", "true", "true", "success", "success", 0),
-        ("documentation-only PR", "true", "false", "skipped", "skipped", 0),
-        ("untrusted PR", "false", "true", "skipped", "skipped", 0),
-        ("superseded PR", "true", "true", "skipped", "skipped", 0),
-        ("relevant PR skipped", "true", "true", "skipped", "skipped", 1),
-        ("documentation PR ran", "true", "false", "skipped", "success", 1),
-        ("untrusted PR ran", "false", "true", "success", "success", 1),
+        ("trusted PR", "success", "success", "false", "false", 0),
+        ("fork PR", "skipped", "skipped", "true", "false", 0),
+        ("Dependabot PR", "skipped", "skipped", "false", "true", 0),
+        ("trusted PR skipped benchmarks", "success", "skipped", "false", "false", 1),
+        ("trusted PR skipped preflight", "skipped", "success", "false", "false", 1),
+        ("fork unexpectedly ran", "skipped", "success", "true", "false", 1),
+        ("Dependabot unexpectedly ran", "skipped", "success", "false", "true", 1),
+        ("fork preflight red", "failure", "skipped", "true", "false", 1),
+        ("trusted preflight red", "failure", "success", "false", "false", 1),
     )
     if os.name != "nt":
-        for name, trusted, relevant, preflight_result, benchmark_result, expected in aggregate_cases:
+        for name, preflight_result, benchmark_result, fork, dependabot, expected in aggregate_cases:
             environment = os.environ.copy()
             environment.update(
                 {
-                    "HEAD_CHECK_RESULT": "success",
-                    "TRUSTED_PR": trusted,
-                    "SUPERSEDED": "true" if name == "superseded PR" else "false",
-                    "RELEVANT": relevant,
                     "RUNNER_PREFLIGHT_RESULT": preflight_result,
-                    "PERF_BENCHMARKS_RESULT": benchmark_result,
+                    "UNITY_TESTS_RESULT": benchmark_result,
+                    "FORK_PR": fork,
+                    "DEPENDABOT_PR": dependabot,
                 }
             )
             result = subprocess.run(
@@ -3684,22 +3805,91 @@ def validate_perf_pr_policy() -> None:
         require("github-token: ${{ github.token }}" in licensed_job, f"{path}:{job_id}: acquire-build-lock requires github.token")
 
 
+DOCS_GATE_ALLOWLIST = (
+    "documentation_only_pattern='^(docs/|\\.docs-tests/|progress/|\\.llm/|\\.agents/"
+    "|\\.claude/|Samples~/.*\\.(md|markdown)$|(AGENTS|GOAL|PLAN)\\.md$|llms\\.txt$"
+    "|mkdocs\\.yml$|requirements-(docs|brand)\\.(in|txt)$)'"
+)
+
+
+def validate_unity_docs_gate() -> None:
+    """Pin the documentation-only replacement for the removed head-check relevance decision.
+
+    unity-tests.yml no longer decides documentation-only in-band: the
+    pull_request paths-ignore (pinned in `validate`) keeps that workflow
+    absent for docs-only pull requests, so the required "Unity CI Success"
+    context must still be reported -- by this gate, which is present on every
+    pull request, always runs, and fails closed unless every changed file
+    matches the exact documentation-only allowlist.
+    """
+    source = DOCS_GATE.read_text(encoding="utf-8")
+    require(
+        "name: Unity CI Success" in source,
+        "unity-docs-gate must report the same required Unity context name",
+    )
+    require(
+        re.search(r"^on:\n  pull_request:\n", source, re.MULTILINE) is not None
+        and re.search(r"^    paths", source, re.MULTILINE) is None,
+        "unity-docs-gate must trigger on every pull request with no paths filter",
+    )
+    gate = job_block(source, "unity-ci-success")
+    require(
+        "if: ${{ always() }}" in gate,
+        "the docs gate must always report; a falsifiable if would drop the required context",
+    )
+    script = run_script(step_block(gate, "Report the documentation-only Unity result"))
+    require(
+        DOCS_GATE_ALLOWLIST in script,
+        "the docs gate must evaluate the exact documentation-only allowlist",
+    )
+    for fragment in (
+        '"${EVENT_NAME}" != "pull_request"',
+        "if ! files=",
+        "The changed-file listing is empty",
+        "Non-documentation files changed",
+        "exit 1",
+    ):
+        require(
+            fragment in script,
+            f"the docs gate must fail closed; missing {fragment!r}",
+        )
+    require(
+        "--jq '.[] | .filename, (.previous_filename // empty)'" in script,
+        "the docs gate must include renamed files in its allowlist evaluation",
+    )
+
+
 def validate_unity_aggregate_steps(gate: str) -> None:
-    require(gate.count("\n      - name:") == 2, "aggregate needs one gate and one diagnostic")
+    """Pin the closed trusted-skip aggregate: one always-on, fail-closed gate step."""
+    require(gate.count("\n      - name:") == 1, "aggregate must be one closed result-shape gate")
     validation = step_block(gate, "Verify Unity CI result shape")
-    diagnostic = step_block(gate, "Report unsuccessful Unity legs")
-    require(gate.find(validation) < gate.find(diagnostic), "diagnostics must follow validation")
-    require(re.search(r"^        id:\s*result_shape\s*$", validation, re.MULTILINE) is not None,
-            "diagnostics must refer to the result gate")
+    require(
+        "    needs:\n      - runner-preflight\n      - unity-tests\n" in gate,
+        "aggregate must consume both the preflight and the licensed matrix results",
+    )
+    require(
+        re.search(r"^        shell: bash\s*$", validation, re.MULTILINE) is not None,
+        "aggregate validation must run bash",
+    )
     require("continue-on-error:" not in validation, "aggregate validation must remain fatal")
-    require(re.search(
-        r"^        if:\s*\$\{\{\s*failure\(\)\s*&&\s*"
-        r"steps\.result_shape\.outcome\s*==\s*'failure'\s*\}\}\s*$",
-        diagnostic, re.MULTILINE) is not None, "diagnostics must run only after gate failure")
-    require(re.search(r"uses:\s*actions/github-script@[0-9a-f]{40}\b", diagnostic) is not None,
-            "diagnostics must use an immutable GitHub script action")
-    require(positive_timeout(diagnostic, 8, "Unity diagnostic") <= 2,
-            "Unity diagnostics must stay bounded to two minutes")
+    require(
+        positive_timeout(gate, 4, "Unity aggregate job") <= 10,
+        "Unity aggregate must stay bounded to ten minutes",
+    )
+    script = run_script(validation)
+    require(
+        script.startswith("set -euo pipefail"),
+        "aggregate result shape must fail closed on unbound or failed probes",
+    )
+    require(
+        'if [ "${FORK_PR}" = "true" ] || [ "${DEPENDABOT_PR}" = "true" ]; then' in script
+        and 'test "${RUNNER_PREFLIGHT_RESULT}" = skipped' in script
+        and 'test "${UNITY_TESTS_RESULT}" = skipped' in script
+        and 'test "${RUNNER_PREFLIGHT_RESULT}" = success' in script
+        and 'test "${UNITY_TESTS_RESULT}" = success' in script,
+        "aggregate must keep the closed trusted-skip shape: untrusted pull "
+        "requests skip both jobs, everything else must have succeeded",
+    )
     permissions = re.search(r"^    permissions:\n((?:      [^\n]+\n)+)", gate, re.MULTILINE)
     require(permissions is not None and
             re.findall(r"^      ([\w-]+):\s*(\w+)\s*$", permissions[1], re.MULTILINE)
@@ -4408,6 +4598,7 @@ steps:
         window = job_block(workflow.read_text(encoding="utf-8"), job_id)
         validate_lock_window_timeout_budget(window, f"{workflow}:{job_id}")
         validate_cleanup_gate_not_attempted_input(window, f"{workflow}:{job_id}")
+        validate_editor_gate_bindings(window, f"{workflow}:{job_id}")
 
     source = WORKFLOW.read_text(encoding="utf-8")
     licensed = validate_licensed_workflow_policy(source)
@@ -4482,10 +4673,48 @@ steps:
     )
     require(pull_request is not None, "missing pull_request trigger")
     assert pull_request is not None
+    documentation_only_paths_ignore = (
+        '      - "docs/**"\n'
+        '      - ".docs-tests/**"\n'
+        '      - "progress/**"\n'
+        '      - ".llm/**"\n'
+        '      - ".agents/**"\n'
+        '      - ".claude/**"\n'
+        '      - "Samples~/**/*.md"\n'
+        '      - "Samples~/**/*.markdown"\n'
+        '      - "AGENTS.md"\n'
+        '      - "GOAL.md"\n'
+        '      - "PLAN.md"\n'
+        '      - "llms.txt"\n'
+        '      - "mkdocs.yml"\n'
+        '      - "requirements-docs.in"\n'
+        '      - "requirements-docs.txt"\n'
+        '      - "requirements-brand.in"\n'
+        '      - "requirements-brand.txt"\n'
+    )
+    pull_request_paths_ignore = re.search(
+        r"^    paths-ignore:\n(?P<body>.*?)(?=^    [A-Za-z0-9_-]+:|\Z)",
+        pull_request.group("body"),
+        re.MULTILINE | re.DOTALL,
+    )
     require(
-        re.search(r"^    paths(?:-ignore)?:", pull_request.group("body"), re.MULTILINE)
-        is None,
-        "pull_request trigger must remain unfiltered by paths",
+        pull_request_paths_ignore is not None,
+        "pull_request trigger must keep the documentation-only paths-ignore "
+        "so the required Unity context stays decidable",
+    )
+    assert pull_request_paths_ignore is not None
+    require(
+        pull_request_paths_ignore.group("body") == documentation_only_paths_ignore,
+        "pull_request trigger must ignore exactly the closed documentation-only "
+        "allowlist that unity-docs-gate.yml re-evaluates fail-closed",
+    )
+    paths = re.search(
+        r"^    paths:\n", pull_request.group("body"), re.MULTILINE
+    )
+    require(
+        paths is None,
+        "pull_request trigger must filter only by paths-ignore, never by an "
+        "allowlist that could silently skip code pull requests",
     )
 
     require(
@@ -4504,26 +4733,18 @@ steps:
         BLANKET_PR_REJECTION.search(licensed) is None,
         "Unity job must not reject every pull request",
     )
-    head_check = job_block(source, "head-check")
+    # The head-check job is gone from unity-tests.yml: its superseded decision
+    # moved into the per-leg `require-current-pr-head` guards (their pinning and
+    # their first-step / immediately-before-lock ordering are asserted below),
+    # and its documentation-only decision moved into the pull_request
+    # paths-ignore plus the fail-closed unity-docs-gate.yml workflow that
+    # reports the same required context.
     require(
-        re.findall(r"^    runs-on:.*$", head_check, re.MULTILINE)
-        == ["    runs-on: ubuntu-latest"]
-        and LOCK_ACTION_PREFIX not in head_check,
-        "superseded decision must never reach a self-hosted runner or the build lock",
+        re.search(r"^  head-check:\n", source, re.MULTILINE) is None,
+        "unity-tests.yml must keep its head decisions in the per-leg guards and "
+        "the docs gate, not a head-check job",
     )
-    require(
-        "      superseded: ${{ steps.head.outputs.superseded }}\n" in head_check,
-        "head-check must publish the superseded decision",
-    )
-    for job_id in ("runner-preflight", "unity-tests"):
-        require(
-            SUPERSEDED_GUARD.search(job_block(source, job_id)) is not None,
-            f"{job_id} must not schedule work for a superseded head",
-        )
-    head_script = run_script(
-        step_block(head_check, "Compare the event head against the live pull-request head")
-    )
-    validate_head_check_truth_table(head_script, "Unity")
+    validate_unity_docs_gate()
     require(
         "environment:" not in licensed,
         "Unity job must use organization secrets without an environment approval gate",
@@ -4558,10 +4779,16 @@ steps:
     require("re-actors/alls-green" not in gate and "allowed-skips" not in gate, "skips must be typed")
     validate_unity_aggregate_steps(gate)
     for before, after in (
-        ("failure() && steps.result_shape.outcome == 'failure'", "always()"),
+        ("set -euo pipefail", "set +euo pipefail"),
+        (
+            'if [ "${FORK_PR}" = "true" ] || [ "${DEPENDABOT_PR}" = "true" ]; then',
+            "if false; then",
+        ),
         ("      actions: read", "      actions: write"),
-        ("        id: result_shape", "        id: result_shape\n        continue-on-error: true"),
-        ("    steps:", "    steps:\n      - name: Unexpected extra step\n        run: echo extra"),
+        (
+            "    steps:",
+            "    steps:\n      - name: Unexpected extra step\n        run: echo extra",
+        ),
     ):
         require(before in gate, "aggregate mutation target must exist")
         try:
@@ -4572,11 +4799,8 @@ steps:
     aggregate_step = step_block(gate, "Verify Unity CI result shape")
     require("        shell: bash\n" in aggregate_step, "aggregate must use bash")
     expected_bindings = {
-        "HEAD_CHECK_RESULT": "${{ needs.head-check.result }}",
         "RUNNER_PREFLIGHT_RESULT": "${{ needs.runner-preflight.result }}",
         "UNITY_TESTS_RESULT": "${{ needs.unity-tests.result }}",
-        "RELEVANT": "${{ needs.head-check.outputs.relevant }}",
-        "SUPERSEDED": "${{ needs.head-check.outputs.superseded }}",
         "FORK_PR": (
             "${{ github.event_name == 'pull_request' && "
             "github.event.pull_request.head.repo.full_name != github.repository }}"
@@ -4595,8 +4819,7 @@ steps:
 
     script = run_script(aggregate_step).rstrip()
     expected_script = """set -euo pipefail
-test "${HEAD_CHECK_RESULT}" = success
-if [ "${SUPERSEDED}" = "true" ] || [ "${RELEVANT}" = "false" ] || [ "${FORK_PR}" = "true" ] || [ "${DEPENDABOT_PR}" = "true" ]; then
+if [ "${FORK_PR}" = "true" ] || [ "${DEPENDABOT_PR}" = "true" ]; then
   test "${RUNNER_PREFLIGHT_RESULT}" = skipped
   test "${UNITY_TESTS_RESULT}" = skipped
 else
@@ -4604,31 +4827,25 @@ else
   test "${UNITY_TESTS_RESULT}" = success
 fi"""
     require(script == expected_script, "aggregate result-shape script drifted")
-    # name, head-check, preflight, unity, SUPERSEDED, RELEVANT, FORK_PR, DEPENDABOT_PR, exit code
+    # name, preflight, unity, FORK_PR, DEPENDABOT_PR, exit code
     cases = (
-        ("same-repository PR", "success", "success", "success", "false", "true", "false", "false", 0),
-        ("documentation-only PR", "success", "skipped", "skipped", "false", "false", "false", "false", 0),
-        ("fork PR", "success", "skipped", "skipped", "false", "true", "true", "false", 0),
-        ("Dependabot PR", "success", "skipped", "skipped", "false", "true", "false", "true", 0),
-        ("superseded PR", "success", "skipped", "skipped", "true", "true", "false", "false", 0),
-        ("same-repository PR skipped Unity", "success", "success", "skipped", "false", "true", "false", "false", 1),
-        ("documentation-only PR ran Unity", "success", "skipped", "success", "false", "false", "false", "false", 1),
-        ("fork unexpectedly ran Unity", "success", "skipped", "success", "false", "true", "true", "false", 1),
-        ("Dependabot unexpectedly ran Unity", "success", "skipped", "success", "false", "true", "false", "true", 1),
-        ("Dependabot unexpectedly ran preflight", "success", "success", "skipped", "false", "true", "false", "true", 1),
-        ("superseded run still ran Unity", "success", "skipped", "success", "true", "true", "false", "false", 1),
-        ("current head skipped Unity after a failed decision", "failure", "skipped", "skipped", "", "", "false", "false", 1),
+        ("same-repository PR", "success", "success", "false", "false", 0),
+        ("fork PR", "skipped", "skipped", "true", "false", 0),
+        ("Dependabot PR", "skipped", "skipped", "false", "true", 0),
+        ("same-repository PR skipped Unity", "success", "skipped", "false", "false", 1),
+        ("fork unexpectedly ran Unity", "skipped", "success", "true", "false", 1),
+        ("Dependabot unexpectedly ran Unity", "skipped", "success", "false", "true", 1),
+        ("Dependabot unexpectedly ran preflight", "success", "skipped", "false", "true", 1),
+        ("fork preflight red", "failure", "skipped", "true", "false", 1),
+        ("trusted preflight red", "failure", "success", "false", "false", 1),
     )
     if os.name != "nt":
-        for name, head, preflight, unity, superseded, relevant, fork, dependabot, expected in cases:
+        for name, preflight, unity, fork, dependabot, expected in cases:
             environment = os.environ.copy()
             environment.update(
                 {
-                    "HEAD_CHECK_RESULT": head,
                     "RUNNER_PREFLIGHT_RESULT": preflight,
                     "UNITY_TESTS_RESULT": unity,
-                    "RELEVANT": relevant,
-                    "SUPERSEDED": superseded,
                     "FORK_PR": fork,
                     "DEPENDABOT_PR": dependabot,
                 }

--- a/scripts/validate-unity-pr-policy.py
+++ b/scripts/validate-unity-pr-policy.py
@@ -3598,11 +3598,38 @@ def validate_perf_pr_policy() -> None:
         (source, r"\n  head-check:", "head-check job"),
         (preflight, r"github\.event\.pull_request\.head\.repo\.full_name == github\.repository", "same-repository guard"),
         (preflight, r"github\.event\.pull_request\.user\.login != 'dependabot\[bot\]'", "Dependabot guard"),
-        (benchmark, r"MEASURED_SHA:.*github\.event\.pull_request\.head\.sha", "measured head SHA"),
         (benchmark, r"runs-on: \[self-hosted, Windows, RAM-64GB, fast\]", "pinned benchmark runner labels"),
-        (benchmark, r"ref: \$\{\{ env\.MEASURED_SHA \}\}", "exact measured checkout"),
-        (benchmark, r"DX_PERF_COMMIT: \$\{\{ env\.MEASURED_SHA \}\}", "exact result commit"),
-        (benchmark, r"commit = '\$\{\{ env\.MEASURED_SHA \}\}'", "exact player manifest commit"),
+        (
+            benchmark,
+            r"ref: \$\{\{ github\.event_name == 'pull_request' && github\.event\.pull_request\.head\.sha \|\| github\.sha \}\}",
+            "exact measured checkout",
+        ),
+        (
+            benchmark,
+            r"DX_PERF_COMMIT: \$\{\{ github\.event_name == 'pull_request' && github\.event\.pull_request\.head\.sha \|\| github\.sha \}\}",
+            "exact result commit",
+        ),
+        (
+            benchmark,
+            r"commit = '\$\{\{ github\.event_name == 'pull_request' && github\.event\.pull_request\.head\.sha \|\| github\.sha \}\}'",
+            "exact player manifest commit",
+        ),
+        (benchmark, r"executablePath = \$playerExecutable\.FullName", "player executable path"),
+        (
+            benchmark,
+            r"executableSha256 = \([\s\S]*?Get-FileHash -LiteralPath \$playerExecutable\.FullName -Algorithm SHA256",
+            "player executable SHA-256",
+        ),
+        (
+            benchmark,
+            r"\$manifest\.executablePath -cne 'DxmTestPlayer\.exe'",
+            "canonical relative player executable path validation",
+        ),
+        (
+            benchmark,
+            r"\$manifest\.executableSha256 -cnotmatch '\^\[0-9A-F\]\{64\}\$'",
+            "complete player executable SHA-256 validation",
+        ),
         (benchmark, r"ReleaseCodeOptimization = \$true", "Release managed code optimization"),
         (benchmark, r"ReleasePlayerBuild = \$true", "non-development player build"),
         (benchmark, r"StandaloneScriptingBackend = 'IL2CPP'", "IL2CPP player backend"),
@@ -3697,6 +3724,10 @@ def validate_perf_pr_policy() -> None:
     )
     for block, pattern, label in checks:
         require(re.search(pattern, block) is not None, f"performance PR policy: missing {label}")
+    require(
+        "${{ env.MEASURED_SHA }}" not in benchmark,
+        "performance PR policy: benchmark steps must not read MEASURED_SHA from their own env map",
+    )
     head_check = job_block(source, "head-check")
     require(
         "      relevant: ${{ steps.head.outputs.relevant }}\n" in head_check
@@ -3818,45 +3849,93 @@ def validate_unity_docs_gate() -> None:
     unity-tests.yml no longer decides documentation-only in-band: the
     pull_request paths-ignore (pinned in `validate`) keeps that workflow
     absent for docs-only pull requests, so the required "Unity CI Success"
-    context must still be reported -- by this gate, which is present on every
-    pull request, always runs, and fails closed unless every changed file
-    matches the exact documentation-only allowlist.
+    context must still be reported. This gate starts for documentation or
+    workflow paths, classifies the complete pull-request file set, gives mixed
+    changes a distinct report name, and fails the required context if
+    classification itself fails.
     """
     source = DOCS_GATE.read_text(encoding="utf-8")
     require(
-        "name: Unity CI Success" in source,
-        "unity-docs-gate must report the same required Unity context name",
-    )
-    require(
         re.search(r"^on:\n  pull_request:\n", source, re.MULTILINE) is not None
-        and re.search(r"^    paths", source, re.MULTILINE) is None,
-        "unity-docs-gate must trigger on every pull request with no paths filter",
+        and '      - ".github/workflows/**"' in source
+        and re.search(r"^    paths-ignore", source, re.MULTILINE) is None,
+        "unity-docs-gate must trigger for documentation and workflow paths",
     )
-    gate = job_block(source, "unity-ci-success")
+    classify = job_block(source, "classify")
+    classify_script = run_script(step_block(classify, "Classify changed paths"))
     require(
-        "if: ${{ always() }}" in gate,
-        "the docs gate must always report; a falsifiable if would drop the required context",
-    )
-    script = run_script(step_block(gate, "Report the documentation-only Unity result"))
-    require(
-        DOCS_GATE_ALLOWLIST in script,
+        DOCS_GATE_ALLOWLIST in classify_script,
         "the docs gate must evaluate the exact documentation-only allowlist",
+    )
+    require(
+        "EXPECTED_FILE_COUNT: ${{ github.event.pull_request.changed_files }}" in classify,
+        "the docs gate must bind the declared changed-file count",
     )
     for fragment in (
         '"${EVENT_NAME}" != "pull_request"',
-        "if ! files=",
+        '"${EXPECTED_FILE_COUNT}" =~ ^[1-9][0-9]*$',
+        "if ! records=",
         "The changed-file listing is empty",
-        "Non-documentation files changed",
-        "exit 1",
+        '"${listed_file_count}" != "${EXPECTED_FILE_COUNT}"',
+        "Changed-file listing is incomplete",
+        'echo "documentation_only=false" >> "${GITHUB_OUTPUT}"',
+        'echo "documentation_only=true" >> "${GITHUB_OUTPUT}"',
     ):
         require(
-            fragment in script,
-            f"the docs gate must fail closed; missing {fragment!r}",
+            fragment in classify_script,
+            f"the docs gate classifier must fail closed; missing {fragment!r}",
         )
     require(
-        "--jq '.[] | .filename, (.previous_filename // empty)'" in script,
-        "the docs gate must include renamed files in its allowlist evaluation",
+        "--jq '.[] | [.filename, (.previous_filename // null)] | @json'" in classify_script
+        and "jq -r '.[] | select(. != null)'" in classify_script,
+        "the docs gate must count entries and include renamed files in its allowlist evaluation",
     )
+    report = job_block(source, "report")
+    for fragment in (
+        "if: ${{ always() }}",
+        "needs.classify.result != 'success'",
+        "'Unity CI Success'",
+        "Unity docs gate not applicable",
+        "CLASSIFICATION_RESULT: ${{ needs.classify.result }}",
+        "DOCUMENTATION_ONLY: ${{ needs.classify.outputs.documentation_only }}",
+    ):
+        require(fragment in report, f"the docs gate report is missing {fragment!r}")
+    report_script = run_script(step_block(report, "Report the documentation-only Unity result"))
+    for fragment in (
+        '"${CLASSIFICATION_RESULT}" != "success"',
+        '"${DOCUMENTATION_ONLY}" = "false"',
+        '"${DOCUMENTATION_ONLY}" != "true"',
+        "exit 1",
+        "exit 0",
+    ):
+        require(
+            fragment in report_script,
+            f"the docs gate report must separate mixed and failed classification; missing {fragment!r}",
+        )
+    for classification_result, documentation_only, expected in (
+        ("success", "true", 0),
+        ("success", "false", 0),
+        ("success", "", 1),
+        ("failure", "", 1),
+    ):
+        environment = os.environ.copy()
+        environment.update(
+            {
+                "CLASSIFICATION_RESULT": classification_result,
+                "DOCUMENTATION_ONLY": documentation_only,
+            }
+        )
+        result = subprocess.run(
+            ["bash", "-c", report_script],
+            env=environment,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        require(
+            result.returncode == expected,
+            "the docs gate report truth table rejected its declared classification contract",
+        )
 
 
 def validate_unity_aggregate_steps(gate: str) -> None:


### PR DESCRIPTION
## Why

The organization enrollment audit found 27 Unity workflow violations. The first repair also broke the measured source SHA. Its docs sidecar posted a red duplicate check on code pull requests.

The performance campaign also lacked generated untyped oracle cases and an exact internal player launcher identity.

## What changed

- The Unity workflows now use the pinned central editor gate. They preserve the license lock and cleanup contract.
- Docs-only pull requests use a cheap hosted gate. Mixed changes use a distinct check name. Incomplete file listings fail closed.
- Performance checkout, results, and player manifests bind directly to the measured source SHA.
- The internal player manifest records the launcher path, size, and SHA-256. It rejects path or digest drift.
- Differential generator v11 alternates typed and untyped emissions. Versions 1 through 10 remain stable.
- The v11 replay matrix covers all three message kinds and preserves every operation field.

This advances #509, #506, and the identity inputs for #508. It also advances the #497 and #500 umbrellas.

## How we know

- The enrollment analyzer reports 0 findings across all six enrolled repositories.
- Two final Unity runs each pass 389 differential cases. Both runs restore the clean scene.
- Ten focused repeats pass 30 of 30 former failing shrinker cases.
- All 1,300 script tests pass in 109.18 seconds.
- `npm run validate:all`, actionlint, Prettier, and the JS line budget pass.
- The final source adds no Unity launch, build, matrix cell, or benchmark window.
- The migration removes repeated setup and upload steps. It also removes a weekly run that last used about 2 hours 28 minutes.

## Remaining scope

The executable stays runner-local. Only its manifest enters the expiring workflow artifact.

This change does not seal or publish durable evidence. It does not observe bridge-internal unboxed final values. Issues #506, #508, and #509 remain open.