### PR TITLE
Preserve backend files when launcher installation fails

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -117,11 +117,14 @@ gateway endpoint, and unset the raw provider key after transferring it to
 | `AI_BACKENDS_CONTAINER_MODE`          | `auto` (`auto`, `yes`, `no`)              | both Claude launchers |
 | `CLAUDE_GATEWAY_SUBPROCESS_ENV_SCRUB` | `auto` (`auto`, `0`, `1`)                 | both Claude launchers |
 
-Reinstall the launchers manually after moving the checkout:
+After moving the checkout, remove the four stale launcher symlinks from their installation
+directory. Then reinstall them:
 
 ```bash
 bash .devcontainer/ai-backends.sh install
 ```
+
+The installer refuses dangling symlinks because it cannot prove who created them.
 
 ### Claude subprocess isolation
 

--- a/.devcontainer/ai-backends.sh
+++ b/.devcontainer/ai-backends.sh
@@ -10,6 +10,7 @@ readonly ZAI_RESPONSES_URL="https://api.z.ai/api/v1"
 readonly ZAI_ANTHROPIC_URL="https://api.z.ai/api/anthropic"
 readonly OPENROUTER_RESPONSES_URL="https://openrouter.ai/api/v1"
 readonly OPENROUTER_ANTHROPIC_URL="https://openrouter.ai/api"
+declare -a installed_launcher_paths=()
 
 die() {
     printf '[ai-backends] ERROR: %s\n' "$*" >&2
@@ -49,13 +50,24 @@ resolve_openrouter_key() {
     die "Set OPENROUTER_API_KEY before launching an OpenRouter backend."
 }
 
+validate_codex_profile_path() {
+    local profile_path="$1"
+    if [ -L "${profile_path}" ] || { [ -e "${profile_path}" ] && [ ! -f "${profile_path}" ]; }; then
+        die "Refusing unsupported Codex profile path: ${profile_path}"
+    fi
+}
+
 install_codex_zai_profile() {
-    local codex_home catalog_file catalog_path_toml catalog_tmp profile_tmp
-    codex_home="${CODEX_HOME:-${HOME}/.codex}"
+    local catalog_config_home codex_home catalog_file catalog_path_toml catalog_tmp profile_tmp
+    codex_home="${1:-${CODEX_HOME:-${HOME}/.codex}}"
+    catalog_config_home="${2:-${codex_home}}"
     catalog_file="${codex_home}/${PROFILE_ZAI}-models.json"
     local profile_file="${codex_home}/${PROFILE_ZAI}.config.toml"
-    catalog_path_toml="${catalog_file//\\/\\\\}"
+    catalog_path_toml="${catalog_config_home}/${PROFILE_ZAI}-models.json"
+    catalog_path_toml="${catalog_path_toml//\\/\\\\}"
     catalog_path_toml="${catalog_path_toml//\"/\\\"}"
+    validate_codex_profile_path "${catalog_file}"
+    validate_codex_profile_path "${profile_file}"
 
     mkdir -p "${codex_home}"
     chmod 700 "${codex_home}"
@@ -142,8 +154,9 @@ TOML
 
 install_codex_openrouter_profile() {
     local codex_home profile_tmp
-    codex_home="${CODEX_HOME:-${HOME}/.codex}"
+    codex_home="${1:-${CODEX_HOME:-${HOME}/.codex}}"
     local profile_file="${codex_home}/${PROFILE_OPENROUTER}.config.toml"
+    validate_codex_profile_path "${profile_file}"
 
     mkdir -p "${codex_home}"
     chmod 700 "${codex_home}"
@@ -184,48 +197,234 @@ TOML
     trap - RETURN
 }
 
-install_launchers() {
-    local bin_dir codex_command launcher script_path target
-    if [ -n "${AI_BACKENDS_BIN_DIR:-}" ]; then
-        bin_dir="${AI_BACKENDS_BIN_DIR}"
-    elif case ":${PATH}:" in *":${HOME}/.local/bin:"*) true ;; *) false ;; esac; then
-        bin_dir="${HOME}/.local/bin"
-    else
-        codex_command="$(command -v codex || true)"
-        if [ -n "${codex_command}" ] && [ -w "$(dirname "${codex_command}")" ]; then
-            bin_dir="$(dirname "${codex_command}")"
-        else
-            bin_dir="${HOME}/.local/bin"
-        fi
-    fi
-    script_path="$(realpath "${BASH_SOURCE[0]}")"
-    mkdir -p "${bin_dir}"
+validate_codex_profile_destinations() {
+    local codex_home="$1" profile_path
+    for profile_path in \
+        "${codex_home}/${PROFILE_ZAI}-models.json" \
+        "${codex_home}/${PROFILE_ZAI}.config.toml" \
+        "${codex_home}/${PROFILE_OPENROUTER}.config.toml"; do
+        validate_codex_profile_path "${profile_path}"
+    done
+}
 
-    # Validate every destination first so a refusal cannot leave a partially
-    # applied install behind.
-    for launcher in codex-zai claude-zai codex-openrouter claude-openrouter; do
-        target="${bin_dir}/${launcher}"
-        if [ -e "${target}" ] && [ ! -L "${target}" ]; then
-            die "Refusing to replace non-symlink launcher: ${target}"
+verify_codex_profile_destinations() {
+    local codex_home="$1" profile_path
+    for profile_path in \
+        "${codex_home}/${PROFILE_ZAI}-models.json" \
+        "${codex_home}/${PROFILE_ZAI}.config.toml" \
+        "${codex_home}/${PROFILE_OPENROUTER}.config.toml"; do
+        if [ ! -f "${profile_path}" ] || [ -L "${profile_path}" ]; then
+            printf '[ai-backends] ERROR: Codex profile was not installed as a regular file: %s\n' \
+                "${profile_path}" >&2
+            return 1
         fi
-        if [ -L "${target}" ] && [ -e "${target}" ]; then
-            # Own earlier launchers may dangle after a repository move; a symlink
-            # that still resolves to some other live file is not ours to replace.
-            if [ "$(realpath "${target}")" != "${script_path}" ]; then
-                die "Refusing to replace launcher symlink pointing elsewhere: ${target}"
-            fi
+    done
+}
+
+restore_codex_profiles() {
+    local backup_dir codex_home="$2" name restore_failed=0 staged_home="$1"
+    local -a names=(
+        "${PROFILE_ZAI}-models.json"
+        "${PROFILE_ZAI}.config.toml"
+        "${PROFILE_OPENROUTER}.config.toml"
+    )
+    backup_dir="${staged_home}/backups"
+    for name in "${names[@]}"; do
+        if ! rm -f "${codex_home}/${name}"; then
+            restore_failed=1
+            continue
+        fi
+        if [ -f "${backup_dir}/${name}" ]; then
+            cp -p "${backup_dir}/${name}" "${codex_home}/${name}" \
+                || restore_failed=1
+        fi
+    done
+    return "${restore_failed}"
+}
+
+commit_staged_codex_profiles() {
+    local backup_dir codex_home="$2" name staged_home="$1"
+    local -a names=(
+        "${PROFILE_ZAI}-models.json"
+        "${PROFILE_ZAI}.config.toml"
+        "${PROFILE_OPENROUTER}.config.toml"
+    )
+    backup_dir="${staged_home}/backups"
+    mkdir -p "${backup_dir}" || return 1
+
+    for name in "${names[@]}"; do
+        if [ -f "${codex_home}/${name}" ]; then
+            cp -p "${codex_home}/${name}" "${backup_dir}/${name}" || return 1
         fi
     done
 
+    for name in "${names[@]}"; do
+        if ! mv "${staged_home}/${name}" "${codex_home}/${name}"; then
+            if ! restore_codex_profiles "${staged_home}" "${codex_home}"; then
+                printf '[ai-backends] ERROR: Codex profile rollback was incomplete.\n' >&2
+            fi
+            return 1
+        fi
+    done
+}
+
+resolve_launcher_bin_dir() {
+    local codex_command
+    if [ -n "${AI_BACKENDS_BIN_DIR:-}" ]; then
+        printf '%s\n' "${AI_BACKENDS_BIN_DIR}"
+    elif case ":${PATH}:" in *":${HOME}/.local/bin:"*) true ;; *) false ;; esac; then
+        printf '%s\n' "${HOME}/.local/bin"
+    else
+        codex_command="$(command -v codex || true)"
+        if [ -n "${codex_command}" ] && [ -w "$(dirname "${codex_command}")" ]; then
+            dirname "${codex_command}"
+        else
+            printf '%s\n' "${HOME}/.local/bin"
+        fi
+    fi
+}
+
+validate_launcher_destinations() {
+    local bin_dir="$1" launcher script_path="$2" target
+
+    # Validate every destination before changing profiles or launchers so a
+    # refusal cannot leave a partially applied install behind.
     for launcher in codex-zai claude-zai codex-openrouter claude-openrouter; do
-        ln -sfn "${script_path}" "${bin_dir}/${launcher}"
+        target="${bin_dir}/${launcher}"
+        if [ -L "${target}" ]; then
+            if [ ! -e "${target}" ]; then
+                die "Refusing to replace dangling launcher symlink: ${target}"
+            fi
+            if [ "$(realpath "${target}")" != "${script_path}" ]; then
+                die "Refusing to replace launcher symlink pointing elsewhere: ${target}"
+            fi
+        elif [ -e "${target}" ]; then
+            die "Refusing to replace non-symlink launcher: ${target}"
+        fi
+    done
+}
+
+rollback_installed_launchers() {
+    local created_target script_path="$1"
+    for created_target in "${installed_launcher_paths[@]}"; do
+        if [ -L "${created_target}" ] && [ -e "${created_target}" ] \
+            && [ "$(realpath "${created_target}")" = "${script_path}" ]; then
+            rm -f "${created_target}"
+        fi
+    done
+    installed_launcher_paths=()
+}
+
+nearest_existing_path() {
+    local current="$1" parent
+    while [ ! -e "${current}" ] && [ ! -L "${current}" ]; do
+        parent="$(dirname "${current}")"
+        [ "${parent}" != "${current}" ] || break
+        current="${parent}"
+    done
+    printf '%s\n' "${current}"
+}
+
+prune_empty_directories() {
+    local anchor="$2" current="$1" parent
+    while [ "${current}" != "${anchor}" ]; do
+        rmdir "${current}" 2>/dev/null || break
+        parent="$(dirname "${current}")"
+        [ "${parent}" != "${current}" ] || break
+        current="${parent}"
+    done
+}
+
+cleanup_created_install_directories() {
+    local bin_anchor="$2" bin_dir="$1" codex_anchor="$4" codex_home="$3"
+    prune_empty_directories "${codex_home}" "${codex_anchor}"
+    prune_empty_directories "${bin_dir}" "${bin_anchor}"
+}
+
+write_launchers() {
+    local bin_dir="$1" launcher script_path="$2" target
+    installed_launcher_paths=()
+
+    for launcher in codex-zai claude-zai codex-openrouter claude-openrouter; do
+        target="${bin_dir}/${launcher}"
+        if [ -L "${target}" ] && [ -e "${target}" ] \
+            && [ "$(realpath "${target}")" = "${script_path}" ]; then
+            continue
+        fi
+        if ! ln -s "${script_path}" "${target}"; then
+            rollback_installed_launchers "${script_path}"
+            printf '[ai-backends] ERROR: Unable to create launcher without replacing an existing path: %s\n' \
+                "${target}" >&2
+            return 1
+        fi
+        installed_launcher_paths+=("${target}")
     done
 }
 
 install_backend_support() {
-    install_codex_zai_profile
-    install_codex_openrouter_profile
-    install_launchers
+    local bin_anchor bin_dir codex_anchor codex_home script_path staged_home
+    bin_dir="$(resolve_launcher_bin_dir)"
+    codex_home="${CODEX_HOME:-${HOME}/.codex}"
+    script_path="$(realpath "${BASH_SOURCE[0]}")"
+    if [ -e "${bin_dir}" ] && [ ! -d "${bin_dir}" ]; then
+        die "Refusing unsupported launcher directory: ${bin_dir}"
+    fi
+    if [ -e "${codex_home}" ] && [ ! -d "${codex_home}" ]; then
+        die "Refusing unsupported CODEX_HOME: ${codex_home}"
+    fi
+    validate_launcher_destinations "${bin_dir}" "${script_path}"
+    validate_codex_profile_destinations "${codex_home}"
+    bin_anchor="$(nearest_existing_path "${bin_dir}")"
+    codex_anchor="$(nearest_existing_path "${codex_home}")"
+    if ! mkdir -p "${bin_dir}"; then
+        cleanup_created_install_directories \
+            "${bin_dir}" "${bin_anchor}" "${codex_home}" "${codex_anchor}"
+        die "Unable to create launcher directory: ${bin_dir}"
+    fi
+    if ! mkdir -p "${codex_home}"; then
+        cleanup_created_install_directories \
+            "${bin_dir}" "${bin_anchor}" "${codex_home}" "${codex_anchor}"
+        die "Unable to create CODEX_HOME: ${codex_home}"
+    fi
+    if ! staged_home="$(mktemp -d "${codex_home}/.ai-backends-install.XXXXXX")"; then
+        cleanup_created_install_directories \
+            "${bin_dir}" "${bin_anchor}" "${codex_home}" "${codex_anchor}"
+        die "Unable to create the Codex profile staging directory."
+    fi
+    if ! (
+        set -e
+        install_codex_zai_profile "${staged_home}" "${codex_home}"
+        install_codex_openrouter_profile "${staged_home}"
+    ); then
+        rm -rf "${staged_home}"
+        cleanup_created_install_directories \
+            "${bin_dir}" "${bin_anchor}" "${codex_home}" "${codex_anchor}"
+        die "Codex profile staging failed."
+    fi
+    if ! write_launchers "${bin_dir}" "${script_path}"; then
+        rm -rf "${staged_home}"
+        cleanup_created_install_directories \
+            "${bin_dir}" "${bin_anchor}" "${codex_home}" "${codex_anchor}"
+        die "Launcher installation was rolled back."
+    fi
+    if ! commit_staged_codex_profiles "${staged_home}" "${codex_home}"; then
+        rollback_installed_launchers "${script_path}"
+        rm -rf "${staged_home}"
+        cleanup_created_install_directories \
+            "${bin_dir}" "${bin_anchor}" "${codex_home}" "${codex_anchor}"
+        die "Codex profile installation failed and launcher installation was rolled back."
+    fi
+    if ! verify_codex_profile_destinations "${codex_home}" \
+        || ! chmod 700 "${codex_home}"; then
+        restore_codex_profiles "${staged_home}" "${codex_home}" || true
+        rollback_installed_launchers "${script_path}"
+        rm -rf "${staged_home}"
+        cleanup_created_install_directories \
+            "${bin_dir}" "${bin_anchor}" "${codex_home}" "${codex_anchor}"
+        die "Final profile installation failed and all changes were rolled back."
+    fi
+    installed_launcher_paths=()
+    rm -rf "${staged_home}"
     printf '[ai-backends] Installed codex-zai, claude-zai, codex-openrouter, and claude-openrouter launchers.\n'
 }
 

--- a/.devcontainer/ai-backends.sh
+++ b/.devcontainer/ai-backends.sh
@@ -261,7 +261,9 @@ commit_staged_codex_profiles() {
     for name in "${names[@]}"; do
         if ! mv "${staged_home}/${name}" "${codex_home}/${name}"; then
             if ! restore_codex_profiles "${staged_home}" "${codex_home}"; then
-                printf '[ai-backends] ERROR: Codex profile rollback was incomplete.\n' >&2
+                printf '[ai-backends] ERROR: Codex profile rollback was incomplete; backups remain in %s.\n' \
+                    "${backup_dir}" >&2
+                return 2
             fi
             return 1
         fi
@@ -328,7 +330,9 @@ nearest_existing_path() {
 prune_empty_directories() {
     local anchor="$2" current="$1" parent
     while [ "${current}" != "${anchor}" ]; do
-        rmdir "${current}" 2>/dev/null || break
+        if [ -e "${current}" ] || [ -L "${current}" ]; then
+            rmdir "${current}" 2>/dev/null || break
+        fi
         parent="$(dirname "${current}")"
         [ "${parent}" != "${current}" ] || break
         current="${parent}"
@@ -407,20 +411,34 @@ install_backend_support() {
             "${bin_dir}" "${bin_anchor}" "${codex_home}" "${codex_anchor}"
         die "Launcher installation was rolled back."
     fi
-    if ! commit_staged_codex_profiles "${staged_home}" "${codex_home}"; then
+    local commit_status=0 restore_status=0
+    commit_staged_codex_profiles "${staged_home}" "${codex_home}" || commit_status=$?
+    if [ "${commit_status}" -ne 0 ]; then
         rollback_installed_launchers "${script_path}"
-        rm -rf "${staged_home}"
+        if [ "${commit_status}" -eq 1 ]; then
+            rm -rf "${staged_home}"
+        fi
         cleanup_created_install_directories \
             "${bin_dir}" "${bin_anchor}" "${codex_home}" "${codex_anchor}"
+        if [ "${commit_status}" -eq 2 ]; then
+            die "Codex profile installation and rollback failed; profile backups were preserved."
+        fi
         die "Codex profile installation failed and launcher installation was rolled back."
     fi
     if ! verify_codex_profile_destinations "${codex_home}" \
         || ! chmod 700 "${codex_home}"; then
-        restore_codex_profiles "${staged_home}" "${codex_home}" || true
+        restore_codex_profiles "${staged_home}" "${codex_home}" || restore_status=$?
         rollback_installed_launchers "${script_path}"
-        rm -rf "${staged_home}"
+        if [ "${restore_status}" -eq 0 ]; then
+            rm -rf "${staged_home}"
+        fi
         cleanup_created_install_directories \
             "${bin_dir}" "${bin_anchor}" "${codex_home}" "${codex_anchor}"
+        if [ "${restore_status}" -ne 0 ]; then
+            printf '[ai-backends] ERROR: Codex profile rollback was incomplete; backups remain in %s.\n' \
+                "${staged_home}/backups" >&2
+            die "Final profile installation and rollback failed; profile backups were preserved."
+        fi
         die "Final profile installation failed and all changes were rolled back."
     fi
     installed_launcher_paths=()

--- a/.devcontainer/test-ai-backends.sh
+++ b/.devcontainer/test-ai-backends.sh
@@ -118,12 +118,18 @@ done
 
 foreign_output="${test_root}/foreign-launcher.log"
 foreign_dir="${test_root}/foreign"
-mkdir -p "${foreign_dir}"
+foreign_codex_home="${test_root}/foreign-codex-home"
+mkdir -p "${foreign_dir}" "${foreign_codex_home}"
+chmod 755 "${foreign_codex_home}"
 printf '#!/usr/bin/env sh\nexit 0\n' >"${foreign_dir}/decoy"
 chmod 755 "${foreign_dir}/decoy"
 ln -s "${foreign_dir}/decoy" "${foreign_dir}/claude-zai"
+for profile in devcontainer-zai-models.json devcontainer-zai.config.toml devcontainer-openrouter.config.toml; do
+    printf 'preserve-%s\n' "${profile}" >"${foreign_codex_home}/${profile}"
+done
 if AI_BACKENDS_BIN_DIR="${foreign_dir}" \
     HOME="${test_home}" \
+    CODEX_HOME="${foreign_codex_home}" \
     bash "${launcher_script}" install >"${foreign_output}" 2>&1; then
     fail "install replaced a launcher symlink pointing at an unrelated program"
 fi
@@ -131,6 +137,35 @@ grep -Eq 'Refusing to replace launcher symlink pointing elsewhere' "${foreign_ou
     || fail "Foreign-symlink refusal did not provide actionable guidance"
 [ "$(readlink "${foreign_dir}/claude-zai")" = "${foreign_dir}/decoy" ] \
     || fail "Foreign-symlink refusal modified the existing symlink"
+for profile in devcontainer-zai-models.json devcontainer-zai.config.toml devcontainer-openrouter.config.toml; do
+    [ "$(cat "${foreign_codex_home}/${profile}")" = "preserve-${profile}" ] \
+        || fail "Foreign-symlink refusal modified ${profile}"
+done
+[ "$(stat -c '%a' "${foreign_codex_home}")" = "755" ] \
+    || fail "Foreign-symlink refusal modified CODEX_HOME permissions"
+
+dangling_output="${test_root}/dangling-launcher.log"
+dangling_dir="${test_root}/dangling"
+dangling_codex_home="${test_root}/dangling-codex-home"
+mkdir -p "${dangling_dir}" "${dangling_codex_home}"
+ln -s "${dangling_dir}/missing-decoy" "${dangling_dir}/claude-zai"
+for profile in devcontainer-zai-models.json devcontainer-zai.config.toml devcontainer-openrouter.config.toml; do
+    printf 'preserve-%s\n' "${profile}" >"${dangling_codex_home}/${profile}"
+done
+if AI_BACKENDS_BIN_DIR="${dangling_dir}" \
+    HOME="${test_home}" \
+    CODEX_HOME="${dangling_codex_home}" \
+    bash "${launcher_script}" install >"${dangling_output}" 2>&1; then
+    fail "install replaced a dangling launcher symlink"
+fi
+grep -Eq 'Refusing to replace dangling launcher symlink' "${dangling_output}" \
+    || fail "Dangling-symlink refusal did not provide actionable guidance"
+[ "$(readlink "${dangling_dir}/claude-zai")" = "${dangling_dir}/missing-decoy" ] \
+    || fail "Dangling-symlink refusal modified the existing symlink"
+for profile in devcontainer-zai-models.json devcontainer-zai.config.toml devcontainer-openrouter.config.toml; do
+    [ "$(cat "${dangling_codex_home}/${profile}")" = "preserve-${profile}" ] \
+        || fail "Dangling-symlink refusal modified ${profile}"
+done
 
 plain_output="${test_root}/plain-launcher.log"
 plain_dir="${test_root}/plain"
@@ -149,6 +184,159 @@ if [ -f "${plain_dir}/codex-zai" ] && [ ! -L "${plain_dir}/codex-zai" ]; then
 else
     fail "Non-symlink refusal modified the existing launcher file"
 fi
+
+profile_collision_output="${test_root}/profile-collision.log"
+profile_collision_dir="${test_root}/profile-collision-launchers"
+profile_collision_codex_home="${test_root}/profile-collision-codex-home"
+mkdir -p "${profile_collision_dir}" \
+    "${profile_collision_codex_home}/devcontainer-openrouter.config.toml"
+printf 'preserve-models\n' >"${profile_collision_codex_home}/devcontainer-zai-models.json"
+printf 'preserve-zai\n' >"${profile_collision_codex_home}/devcontainer-zai.config.toml"
+if AI_BACKENDS_BIN_DIR="${profile_collision_dir}" \
+    HOME="${test_home}" \
+    CODEX_HOME="${profile_collision_codex_home}" \
+    bash "${launcher_script}" install >"${profile_collision_output}" 2>&1; then
+    fail "install accepted a directory at a Codex profile path"
+fi
+grep -Eq 'Refusing unsupported Codex profile path' "${profile_collision_output}" \
+    || fail "Profile-path refusal did not provide actionable guidance"
+[ "$(cat "${profile_collision_codex_home}/devcontainer-zai-models.json")" = "preserve-models" ] \
+    || fail "Profile-path refusal modified the Z.ai model catalog"
+[ "$(cat "${profile_collision_codex_home}/devcontainer-zai.config.toml")" = "preserve-zai" ] \
+    || fail "Profile-path refusal modified the Z.ai profile"
+for launcher in codex-zai claude-zai codex-openrouter claude-openrouter; do
+    [ ! -e "${profile_collision_dir}/${launcher}" ] \
+        || fail "Profile-path refusal created ${launcher}"
+done
+
+write_collision_output="${test_root}/write-collision.log"
+write_collision_dir="${test_root}/write-collision-launchers"
+write_collision_codex_home="${test_root}/write-collision-codex-home"
+write_collision_bin="${test_root}/write-collision-bin"
+mkdir -p "${write_collision_dir}" "${write_collision_codex_home}" "${write_collision_bin}"
+chmod 755 "${write_collision_codex_home}"
+for profile in devcontainer-zai-models.json devcontainer-zai.config.toml devcontainer-openrouter.config.toml; do
+    printf 'preserve-%s\n' "${profile}" >"${write_collision_codex_home}/${profile}"
+done
+cat >"${write_collision_bin}/ln" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+"${REAL_LN:?}" "$@"
+if [ ! -e "${INJECT_LAUNCHER_DIR:?}/claude-zai" ]; then
+    printf '#!/usr/bin/env sh\nexit 0\n' >"${INJECT_LAUNCHER_DIR}/claude-zai"
+    chmod 755 "${INJECT_LAUNCHER_DIR}/claude-zai"
+fi
+STUB
+chmod 755 "${write_collision_bin}/ln"
+if PATH="${write_collision_bin}:/usr/bin:/bin" \
+    REAL_LN="$(command -v ln)" \
+    INJECT_LAUNCHER_DIR="${write_collision_dir}" \
+    AI_BACKENDS_BIN_DIR="${write_collision_dir}" \
+    HOME="${test_home}" \
+    CODEX_HOME="${write_collision_codex_home}" \
+    bash "${launcher_script}" install >"${write_collision_output}" 2>&1; then
+    fail "install accepted a launcher path created after preflight"
+fi
+grep -Eq 'Launcher installation was rolled back' "${write_collision_output}" \
+    || fail "Write-time launcher collision did not report rollback"
+if [ ! -f "${write_collision_dir}/claude-zai" ] \
+    || [ -L "${write_collision_dir}/claude-zai" ]; then
+    fail "Write-time collision modified the injected launcher"
+fi
+for launcher in codex-zai codex-openrouter claude-openrouter; do
+    [ ! -e "${write_collision_dir}/${launcher}" ] \
+        || fail "Write-time collision left ${launcher} partially installed"
+done
+for profile in devcontainer-zai-models.json devcontainer-zai.config.toml devcontainer-openrouter.config.toml; do
+    [ "$(cat "${write_collision_codex_home}/${profile}")" = "preserve-${profile}" ] \
+        || fail "Write-time collision modified ${profile}"
+done
+[ "$(stat -c '%a' "${write_collision_codex_home}")" = "755" ] \
+    || fail "Write-time collision modified CODEX_HOME permissions"
+
+occupied_bin="${test_root}/occupied-launcher-bin"
+absent_codex_home="${test_root}/must-remain-absent-codex-home"
+printf 'preserve-occupied-bin\n' >"${occupied_bin}"
+if AI_BACKENDS_BIN_DIR="${occupied_bin}" \
+    HOME="${test_home}" \
+    CODEX_HOME="${absent_codex_home}" \
+    bash "${launcher_script}" install >"${test_root}/occupied-bin.log" 2>&1; then
+    fail "install accepted a file as its launcher directory"
+fi
+grep -Eq 'Refusing unsupported launcher directory' "${test_root}/occupied-bin.log" \
+    || fail "Occupied launcher directory refusal did not provide actionable guidance"
+[ "$(cat "${occupied_bin}")" = "preserve-occupied-bin" ] \
+    || fail "Occupied launcher directory refusal modified the file"
+[ ! -e "${absent_codex_home}" ] \
+    || fail "Occupied launcher directory refusal created CODEX_HOME"
+
+mktemp_failure_bin="${test_root}/mktemp-failure-bin"
+mktemp_failure_launcher_parent="${test_root}/mktemp-failure-launcher-parent"
+mktemp_failure_codex_parent="${test_root}/mktemp-failure-codex-parent"
+mktemp_failure_launchers="${mktemp_failure_launcher_parent}/deep/bin"
+mktemp_failure_codex_home="${mktemp_failure_codex_parent}/deep/codex"
+mkdir -p "${mktemp_failure_bin}"
+cat >"${mktemp_failure_bin}/mktemp" <<'STUB'
+#!/usr/bin/env bash
+exit 73
+STUB
+chmod 755 "${mktemp_failure_bin}/mktemp"
+if PATH="${mktemp_failure_bin}:/usr/bin:/bin" \
+    AI_BACKENDS_BIN_DIR="${mktemp_failure_launchers}" \
+    HOME="${test_home}" \
+    CODEX_HOME="${mktemp_failure_codex_home}" \
+    bash "${launcher_script}" install >"${test_root}/mktemp-failure.log" 2>&1; then
+    fail "install accepted a failed staging-directory creation"
+fi
+grep -Eq 'Unable to create the Codex profile staging directory' "${test_root}/mktemp-failure.log" \
+    || fail "Staging-directory failure did not provide actionable guidance"
+[ ! -e "${mktemp_failure_launchers}" ] \
+    || fail "Staging-directory failure left the launcher directory behind"
+[ ! -e "${mktemp_failure_codex_home}" ] \
+    || fail "Staging-directory failure left CODEX_HOME behind"
+[ ! -e "${mktemp_failure_launcher_parent}" ] \
+    || fail "Staging-directory failure left a launcher parent behind"
+[ ! -e "${mktemp_failure_codex_parent}" ] \
+    || fail "Staging-directory failure left a CODEX_HOME parent behind"
+
+chmod_failure_bin="${test_root}/chmod-failure-bin"
+chmod_failure_launchers="${test_root}/chmod-failure-launchers"
+chmod_failure_codex_home="${test_root}/chmod-failure-codex-home"
+mkdir -p "${chmod_failure_bin}" "${chmod_failure_codex_home}"
+chmod 755 "${chmod_failure_codex_home}"
+for profile in devcontainer-zai-models.json devcontainer-zai.config.toml devcontainer-openrouter.config.toml; do
+    printf 'preserve-%s\n' "${profile}" >"${chmod_failure_codex_home}/${profile}"
+done
+cat >"${chmod_failure_bin}/chmod" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+last_argument="${!#}"
+if [ "${last_argument}" = "${FAIL_CHMOD_PATH:?}" ]; then
+    exit 74
+fi
+exec "${REAL_CHMOD:?}" "$@"
+STUB
+chmod 755 "${chmod_failure_bin}/chmod"
+if PATH="${chmod_failure_bin}:/usr/bin:/bin" \
+    REAL_CHMOD="$(command -v chmod)" \
+    FAIL_CHMOD_PATH="${chmod_failure_codex_home}" \
+    AI_BACKENDS_BIN_DIR="${chmod_failure_launchers}" \
+    HOME="${test_home}" \
+    CODEX_HOME="${chmod_failure_codex_home}" \
+    bash "${launcher_script}" install >"${test_root}/chmod-failure.log" 2>&1; then
+    fail "install accepted a failed final CODEX_HOME chmod"
+fi
+grep -Eq 'Final profile installation failed and all changes were rolled back' \
+    "${test_root}/chmod-failure.log" \
+    || fail "Final chmod failure did not report rollback"
+[ ! -e "${chmod_failure_launchers}" ] \
+    || fail "Final chmod failure left the launcher directory behind"
+for profile in devcontainer-zai-models.json devcontainer-zai.config.toml devcontainer-openrouter.config.toml; do
+    [ "$(cat "${chmod_failure_codex_home}/${profile}")" = "preserve-${profile}" ] \
+        || fail "Final chmod failure modified ${profile}"
+done
+[ "$(stat -c '%a' "${chmod_failure_codex_home}")" = "755" ] \
+    || fail "Final chmod failure modified CODEX_HOME permissions"
 [ "$(stat -c '%a' "${codex_home}/devcontainer-openrouter.config.toml")" = "600" ] \
     || fail "Codex OpenRouter profile permissions are not 600"
 jq -e '.models[0].slug == "glm-5.3"' \

--- a/.devcontainer/test-ai-backends.sh
+++ b/.devcontainer/test-ai-backends.sh
@@ -299,6 +299,38 @@ grep -Eq 'Unable to create the Codex profile staging directory' "${test_root}/mk
 [ ! -e "${mktemp_failure_codex_parent}" ] \
     || fail "Staging-directory failure left a CODEX_HOME parent behind"
 
+mkdir_failure_bin="${test_root}/mkdir-failure-bin"
+mkdir_failure_parent="${test_root}/mkdir-failure-parent"
+mkdir_failure_launchers="${mkdir_failure_parent}/deep/bin"
+mkdir_failure_codex_home="${test_root}/mkdir-failure-codex-home"
+mkdir -p "${mkdir_failure_bin}"
+cat >"${mkdir_failure_bin}/mkdir" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+last_argument="${!#}"
+if [ "${last_argument}" = "${FAIL_MKDIR_PATH:?}" ]; then
+    "${REAL_MKDIR:?}" -p "$(dirname "${last_argument}")"
+    exit 75
+fi
+exec "${REAL_MKDIR:?}" "$@"
+STUB
+chmod 755 "${mkdir_failure_bin}/mkdir"
+if PATH="${mkdir_failure_bin}:/usr/bin:/bin" \
+    REAL_MKDIR="$(command -v mkdir)" \
+    FAIL_MKDIR_PATH="${mkdir_failure_launchers}" \
+    AI_BACKENDS_BIN_DIR="${mkdir_failure_launchers}" \
+    HOME="${test_home}" \
+    CODEX_HOME="${mkdir_failure_codex_home}" \
+    bash "${launcher_script}" install >"${test_root}/mkdir-failure.log" 2>&1; then
+    fail "install accepted a partially failed launcher-directory creation"
+fi
+grep -Eq 'Unable to create launcher directory' "${test_root}/mkdir-failure.log" \
+    || fail "Partial launcher-directory failure did not provide actionable guidance"
+[ ! -e "${mkdir_failure_parent}" ] \
+    || fail "Partial launcher-directory failure left an intermediate directory behind"
+[ ! -e "${mkdir_failure_codex_home}" ] \
+    || fail "Partial launcher-directory failure created CODEX_HOME"
+
 chmod_failure_bin="${test_root}/chmod-failure-bin"
 chmod_failure_launchers="${test_root}/chmod-failure-launchers"
 chmod_failure_codex_home="${test_root}/chmod-failure-codex-home"
@@ -337,6 +369,53 @@ for profile in devcontainer-zai-models.json devcontainer-zai.config.toml devcont
 done
 [ "$(stat -c '%a' "${chmod_failure_codex_home}")" = "755" ] \
     || fail "Final chmod failure modified CODEX_HOME permissions"
+
+restore_failure_bin="${test_root}/restore-failure-bin"
+restore_failure_launchers="${test_root}/restore-failure-launchers"
+restore_failure_codex_home="${test_root}/restore-failure-codex-home"
+mkdir -p "${restore_failure_bin}" "${restore_failure_codex_home}"
+for profile in devcontainer-zai-models.json devcontainer-zai.config.toml devcontainer-openrouter.config.toml; do
+    printf 'recover-%s\n' "${profile}" >"${restore_failure_codex_home}/${profile}"
+done
+cat >"${restore_failure_bin}/chmod" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+last_argument="${!#}"
+if [ "${last_argument}" = "${FAIL_CHMOD_PATH:?}" ]; then
+    exit 76
+fi
+exec "${REAL_CHMOD:?}" "$@"
+STUB
+cat >"${restore_failure_bin}/cp" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+case "${2:-}" in
+    *'/.ai-backends-install.'*'/backups/'*) exit 77 ;;
+esac
+exec "${REAL_CP:?}" "$@"
+STUB
+chmod 755 "${restore_failure_bin}/chmod" "${restore_failure_bin}/cp"
+if PATH="${restore_failure_bin}:/usr/bin:/bin" \
+    REAL_CHMOD="$(command -v chmod)" \
+    REAL_CP="$(PATH=/usr/bin:/bin command -v cp)" \
+    FAIL_CHMOD_PATH="${restore_failure_codex_home}" \
+    AI_BACKENDS_BIN_DIR="${restore_failure_launchers}" \
+    HOME="${test_home}" \
+    CODEX_HOME="${restore_failure_codex_home}" \
+    bash "${launcher_script}" install >"${test_root}/restore-failure.log" 2>&1; then
+    fail "install discarded profile backups after an incomplete rollback"
+fi
+grep -Eq 'rollback was incomplete; backups remain in' "${test_root}/restore-failure.log" \
+    || fail "Incomplete rollback did not report the preserved backup location"
+[ ! -e "${restore_failure_launchers}" ] \
+    || fail "Incomplete profile rollback left the launcher directory behind"
+restore_backup_dir="$(find "${restore_failure_codex_home}" -maxdepth 2 -type d -name backups -print -quit)"
+[ -n "${restore_backup_dir}" ] \
+    || fail "Incomplete rollback discarded the profile backup directory"
+for profile in devcontainer-zai-models.json devcontainer-zai.config.toml devcontainer-openrouter.config.toml; do
+    [ "$(cat "${restore_backup_dir}/${profile}")" = "recover-${profile}" ] \
+        || fail "Incomplete rollback did not preserve the original ${profile} backup"
+done
 [ "$(stat -c '%a' "${codex_home}/devcontainer-openrouter.config.toml")" = "600" ] \
     || fail "Codex OpenRouter profile permissions are not 600"
 jq -e '.models[0].slug == "glm-5.3"' \


### PR DESCRIPTION
## Why

A refused backend install could overwrite Codex profiles before it found a launcher conflict. A dangling launcher link could also be replaced without proof that the installer owned it.

## What changed

- Validate launcher roots, profile paths, and all destinations before changing user state.
- Stage profiles and retain backups until final verification succeeds.
- Create launcher links without replacement.
- Restore profiles, links, permissions, and newly created directories when any install step fails.
- Explain how to reinstall links after moving a checkout.

## How we know

The backend test injects foreign links, dangling links, profile directories, write races, staging failures, and final permission failures. Each case proves that existing state survives and partial state is removed.

The focused backend test, ShellCheck, all 1,302 Node tests, spelling, Markdown checks, and `npm run validate:all` pass. Two independent adversarial reviews found no blocking issue.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to the devcontainer AI backend installer and its tests; behavior is more defensive and does not alter runtime API or auth paths in the application.
> 
> **Overview**
> Hardens **`ai-backends.sh install`** so a failed or refused install cannot leave partial Codex profiles or launcher symlinks behind.
> 
> **Preflight** now validates launcher bin dir, `CODEX_HOME`, every launcher target (refuses dangling, foreign, or non-symlink paths), and Codex profile destinations (no symlinks or directories). **Profiles** are written to a staging dir under `CODEX_HOME`, backed up, then committed; failures roll back launchers, restore profiles, prune empty dirs created during install, and preserve backup dirs when rollback itself fails. **Launchers** use non-replacing `ln -s` with explicit rollback instead of `ln -sfn`. Z.ai staging keeps `model_catalog_json` pointing at the real catalog path in `CODEX_HOME`.
> 
> **`.devcontainer/README.md`** documents removing stale launcher symlinks after moving the checkout (installer will not replace dangling links). **`test-ai-backends.sh`** adds regression cases for foreign/dangling launchers, profile collisions, write races, `mktemp`/`mkdir`/`chmod` failures, and incomplete restore.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85849a5f2ef4f74be8417d95620928c0f3565863. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->