### PR TITLE
Adopt the authorized Unity lock release

### DIFF
--- a/.github/workflows/perf-numbers.yml
+++ b/.github/workflows/perf-numbers.yml
@@ -193,7 +193,7 @@ jobs:
       has-autocommit-app: ${{ steps.check-autocommit-app.outputs.has-app }}
     steps:
       - name: Require a registered performance runner
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/check-unity-runner-availability@64bac446903115134dca8235410b332bc5a83547 # v1.14.0
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/check-unity-runner-availability@d79e1cc2acc892b619db2ca46f78291ca427016b # v1.14.2
         with:
           reader-app-id: ${{ secrets.BUILD_LOCK_READER_APP_ID }}
           reader-app-private-key: ${{ secrets.BUILD_LOCK_READER_APP_PRIVATE_KEY }}
@@ -267,7 +267,7 @@ jobs:
     steps:
       - name: Require current PR head before self-hosted setup
         timeout-minutes: 2
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-current-pr-head@64bac446903115134dca8235410b332bc5a83547 # v1.14.0
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-current-pr-head@d79e1cc2acc892b619db2ca46f78291ca427016b # v1.14.2
         with:
           github-token: ${{ github.token }}
           pull-request-number: ${{ github.event.pull_request.number }}
@@ -284,7 +284,7 @@ jobs:
       - name: Require manually installed Unity editor
         id: ensure_unity_editor
         timeout-minutes: 10
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/ensure-unity-editor@64bac446903115134dca8235410b332bc5a83547 # v1.14.0
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/ensure-unity-editor@d79e1cc2acc892b619db2ca46f78291ca427016b # v1.14.2
         with:
           unity-version: ${{ matrix.unity-version }}
           install-root: ${{ runner.tool_cache }}\u6-v3
@@ -433,7 +433,7 @@ jobs:
       - name: Acquire organization Unity lock
         id: acquire_lock
         timeout-minutes: 305
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@64bac446903115134dca8235410b332bc5a83547 # v1.14.0
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@d79e1cc2acc892b619db2ca46f78291ca427016b # v1.14.2
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: perf-${{ matrix.unity-version }}-${{ matrix.test-mode }}-${{ matrix.benchmark-suite }}
@@ -1230,7 +1230,7 @@ jobs:
         id: return_unity_license
         if: ${{ always() && steps.acquire_lock.outputs.acquired == 'true' }}
         timeout-minutes: 5
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/return-unity-license@64bac446903115134dca8235410b332bc5a83547
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/return-unity-license@d79e1cc2acc892b619db2ca46f78291ca427016b
         with:
           unity-version: ${{ matrix.unity-version }}
           tool-cache: ${{ runner.tool_cache }}
@@ -1242,7 +1242,7 @@ jobs:
         id: cleanup_classification
         if: ${{ always() && steps.acquire_lock.outputs.acquired == 'true' }}
         timeout-minutes: 2
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/classify-unity-cleanup-evidence@64bac446903115134dca8235410b332bc5a83547
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/classify-unity-cleanup-evidence@d79e1cc2acc892b619db2ca46f78291ca427016b
         with:
           return-log-path: ${{ steps.return_unity_license.outputs.return-log-path }}
           return-command-completed: ${{ steps.return_unity_license.outputs.return-command-completed }}
@@ -1254,7 +1254,7 @@ jobs:
         id: release_unity_lock
         if: always()
         timeout-minutes: 5
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@64bac446903115134dca8235410b332bc5a83547 # v1.14.0
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@d79e1cc2acc892b619db2ca46f78291ca427016b # v1.14.2
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: perf-${{ matrix.unity-version }}-${{ matrix.test-mode }}-${{ matrix.benchmark-suite }}
@@ -1269,7 +1269,7 @@ jobs:
       - name: Require confirmed Unity cleanup
         if: always()
         timeout-minutes: 2
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-confirmed-unity-cleanup@64bac446903115134dca8235410b332bc5a83547
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-confirmed-unity-cleanup@d79e1cc2acc892b619db2ca46f78291ca427016b
         with:
           # Typed binding to the one acquire step, exactly as the enrollment
           # contract requires. A leg that aborts before acquire ran reports an
@@ -1404,7 +1404,7 @@ jobs:
       - name: Require current PR head before reporting
         if: needs.perf-benchmarks.result == 'success'
         timeout-minutes: 2
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-current-pr-head@64bac446903115134dca8235410b332bc5a83547 # v1.14.0
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-current-pr-head@d79e1cc2acc892b619db2ca46f78291ca427016b # v1.14.2
         with:
           github-token: ${{ github.token }}
           pull-request-number: ${{ github.event.pull_request.number }}
@@ -1640,7 +1640,7 @@ jobs:
         id: report-freshness
         if: always()
         timeout-minutes: 2
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-current-pr-head@64bac446903115134dca8235410b332bc5a83547 # v1.14.0
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-current-pr-head@d79e1cc2acc892b619db2ca46f78291ca427016b # v1.14.2
         with:
           github-token: ${{ github.token }}
           pull-request-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,7 +168,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Require a registered Unity runner
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/check-unity-runner-availability@64bac446903115134dca8235410b332bc5a83547 # v1.14.0
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/check-unity-runner-availability@d79e1cc2acc892b619db2ca46f78291ca427016b # v1.14.2
         with:
           reader-app-id: ${{ secrets.BUILD_LOCK_READER_APP_ID }}
           reader-app-private-key: ${{ secrets.BUILD_LOCK_READER_APP_PRIVATE_KEY }}
@@ -198,7 +198,7 @@ jobs:
       - name: Require manually installed Unity editor
         id: ensure_unity_editor
         timeout-minutes: 10
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/ensure-unity-editor@64bac446903115134dca8235410b332bc5a83547 # v1.14.0
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/ensure-unity-editor@d79e1cc2acc892b619db2ca46f78291ca427016b # v1.14.2
         with:
           unity-version: 2022.3.45f1
           install-root: ${{ runner.tool_cache }}\u6-v3
@@ -278,7 +278,7 @@ jobs:
       - name: Acquire organization Unity lock
         id: acquire_lock
         timeout-minutes: 305
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@64bac446903115134dca8235410b332bc5a83547 # v1.14.0
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@d79e1cc2acc892b619db2ca46f78291ca427016b # v1.14.2
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: release-editmode
@@ -389,7 +389,7 @@ jobs:
         id: return_unity_license
         if: ${{ always() && steps.acquire_lock.outputs.acquired == 'true' }}
         timeout-minutes: 5
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/return-unity-license@64bac446903115134dca8235410b332bc5a83547
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/return-unity-license@d79e1cc2acc892b619db2ca46f78291ca427016b
         with:
           unity-version: 2022.3.45f1
           tool-cache: ${{ runner.tool_cache }}
@@ -401,7 +401,7 @@ jobs:
         id: cleanup_classification
         if: ${{ always() && steps.acquire_lock.outputs.acquired == 'true' }}
         timeout-minutes: 2
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/classify-unity-cleanup-evidence@64bac446903115134dca8235410b332bc5a83547
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/classify-unity-cleanup-evidence@d79e1cc2acc892b619db2ca46f78291ca427016b
         with:
           return-log-path: ${{ steps.return_unity_license.outputs.return-log-path }}
           return-command-completed: ${{ steps.return_unity_license.outputs.return-command-completed }}
@@ -413,7 +413,7 @@ jobs:
         id: release_unity_lock
         if: always()
         timeout-minutes: 5
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@64bac446903115134dca8235410b332bc5a83547 # v1.14.0
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@d79e1cc2acc892b619db2ca46f78291ca427016b # v1.14.2
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: release-editmode
@@ -428,7 +428,7 @@ jobs:
       - name: Require confirmed Unity cleanup
         if: always()
         timeout-minutes: 2
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-confirmed-unity-cleanup@64bac446903115134dca8235410b332bc5a83547
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-confirmed-unity-cleanup@d79e1cc2acc892b619db2ca46f78291ca427016b
         with:
           # Typed binding to the one acquire step, exactly as the enrollment
           # contract requires. A leg that aborts before acquire ran reports an
@@ -475,7 +475,7 @@ jobs:
       - name: Require manually installed Unity editor
         id: ensure_unity_editor
         timeout-minutes: 10
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/ensure-unity-editor@64bac446903115134dca8235410b332bc5a83547 # v1.14.0
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/ensure-unity-editor@d79e1cc2acc892b619db2ca46f78291ca427016b # v1.14.2
         with:
           unity-version: 2022.3.45f1
           install-root: ${{ runner.tool_cache }}\u6-v3
@@ -540,7 +540,7 @@ jobs:
       - name: Acquire organization Unity lock
         id: acquire_lock
         timeout-minutes: 305
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@64bac446903115134dca8235410b332bc5a83547 # v1.14.0
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@d79e1cc2acc892b619db2ca46f78291ca427016b # v1.14.2
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: release-unitypackage
@@ -636,7 +636,7 @@ jobs:
         id: return_unity_license
         if: ${{ always() && steps.acquire_lock.outputs.acquired == 'true' }}
         timeout-minutes: 5
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/return-unity-license@64bac446903115134dca8235410b332bc5a83547
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/return-unity-license@d79e1cc2acc892b619db2ca46f78291ca427016b
         with:
           unity-version: 2022.3.45f1
           tool-cache: ${{ runner.tool_cache }}
@@ -648,7 +648,7 @@ jobs:
         id: cleanup_classification
         if: ${{ always() && steps.acquire_lock.outputs.acquired == 'true' }}
         timeout-minutes: 2
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/classify-unity-cleanup-evidence@64bac446903115134dca8235410b332bc5a83547
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/classify-unity-cleanup-evidence@d79e1cc2acc892b619db2ca46f78291ca427016b
         with:
           return-log-path: ${{ steps.return_unity_license.outputs.return-log-path }}
           return-command-completed: ${{ steps.return_unity_license.outputs.return-command-completed }}
@@ -660,7 +660,7 @@ jobs:
         id: release_unity_lock
         if: always()
         timeout-minutes: 5
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@64bac446903115134dca8235410b332bc5a83547 # v1.14.0
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@d79e1cc2acc892b619db2ca46f78291ca427016b # v1.14.2
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: release-unitypackage
@@ -675,7 +675,7 @@ jobs:
       - name: Require confirmed Unity cleanup
         if: always()
         timeout-minutes: 2
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-confirmed-unity-cleanup@64bac446903115134dca8235410b332bc5a83547
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-confirmed-unity-cleanup@d79e1cc2acc892b619db2ca46f78291ca427016b
         with:
           # Typed binding to the one acquire step, exactly as the enrollment
           # contract requires. A leg that aborts before acquire ran reports an

--- a/.github/workflows/runner-bootstrap.yml
+++ b/.github/workflows/runner-bootstrap.yml
@@ -69,7 +69,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Require a registered Windows Unity runner
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/check-unity-runner-availability@64bac446903115134dca8235410b332bc5a83547 # v1.14.0
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/check-unity-runner-availability@d79e1cc2acc892b619db2ca46f78291ca427016b # v1.14.2
         with:
           reader-app-id: ${{ secrets.BUILD_LOCK_READER_APP_ID }}
           reader-app-private-key: ${{ secrets.BUILD_LOCK_READER_APP_PRIVATE_KEY }}

--- a/.github/workflows/unity-benchmarks.yml
+++ b/.github/workflows/unity-benchmarks.yml
@@ -33,7 +33,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Require a registered Unity runner
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/check-unity-runner-availability@64bac446903115134dca8235410b332bc5a83547 # v1.14.0
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/check-unity-runner-availability@d79e1cc2acc892b619db2ca46f78291ca427016b # v1.14.2
         with:
           reader-app-id: ${{ secrets.BUILD_LOCK_READER_APP_ID }}
           reader-app-private-key: ${{ secrets.BUILD_LOCK_READER_APP_PRIVATE_KEY }}
@@ -69,7 +69,7 @@ jobs:
       - name: Require manually installed Unity editor
         id: ensure_unity_editor
         timeout-minutes: 10
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/ensure-unity-editor@64bac446903115134dca8235410b332bc5a83547 # v1.14.0
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/ensure-unity-editor@d79e1cc2acc892b619db2ca46f78291ca427016b # v1.14.2
         with:
           unity-version: ${{ matrix.unity-version }}
           install-root: ${{ runner.tool_cache }}\u6-v3
@@ -163,7 +163,7 @@ jobs:
       - name: Acquire organization Unity lock
         id: acquire_lock
         timeout-minutes: 305
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@64bac446903115134dca8235410b332bc5a83547 # v1.14.0
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@d79e1cc2acc892b619db2ca46f78291ca427016b # v1.14.2
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}
@@ -278,7 +278,7 @@ jobs:
         id: return_unity_license
         if: ${{ always() && steps.acquire_lock.outputs.acquired == 'true' }}
         timeout-minutes: 5
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/return-unity-license@64bac446903115134dca8235410b332bc5a83547
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/return-unity-license@d79e1cc2acc892b619db2ca46f78291ca427016b
         with:
           unity-version: ${{ matrix.unity-version }}
           tool-cache: ${{ runner.tool_cache }}
@@ -290,7 +290,7 @@ jobs:
         id: cleanup_classification
         if: ${{ always() && steps.acquire_lock.outputs.acquired == 'true' }}
         timeout-minutes: 2
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/classify-unity-cleanup-evidence@64bac446903115134dca8235410b332bc5a83547
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/classify-unity-cleanup-evidence@d79e1cc2acc892b619db2ca46f78291ca427016b
         with:
           return-log-path: ${{ steps.return_unity_license.outputs.return-log-path }}
           return-command-completed: ${{ steps.return_unity_license.outputs.return-command-completed }}
@@ -302,7 +302,7 @@ jobs:
         id: release_unity_lock
         if: always()
         timeout-minutes: 5
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@64bac446903115134dca8235410b332bc5a83547 # v1.14.0
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@d79e1cc2acc892b619db2ca46f78291ca427016b # v1.14.2
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}
@@ -317,7 +317,7 @@ jobs:
       - name: Require confirmed Unity cleanup
         if: always()
         timeout-minutes: 2
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-confirmed-unity-cleanup@64bac446903115134dca8235410b332bc5a83547
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-confirmed-unity-cleanup@d79e1cc2acc892b619db2ca46f78291ca427016b
         with:
           # Typed binding to the one acquire step, exactly as the enrollment
           # contract requires. A leg that aborts before acquire ran reports an

--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -95,7 +95,7 @@ jobs:
       cancel-in-progress: false
     steps:
       - name: Require a registered Unity runner
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/check-unity-runner-availability@64bac446903115134dca8235410b332bc5a83547 # v1.14.0
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/check-unity-runner-availability@d79e1cc2acc892b619db2ca46f78291ca427016b # v1.14.2
         with:
           reader-app-id: ${{ secrets.BUILD_LOCK_READER_APP_ID }}
           reader-app-private-key: ${{ secrets.BUILD_LOCK_READER_APP_PRIVATE_KEY }}
@@ -143,7 +143,7 @@ jobs:
     steps:
       - name: Require current PR head before setup
         timeout-minutes: 2
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-current-pr-head@64bac446903115134dca8235410b332bc5a83547 # v1.14.0
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-current-pr-head@d79e1cc2acc892b619db2ca46f78291ca427016b # v1.14.2
         with:
           github-token: ${{ github.token }}
           pull-request-number: ${{ github.event.pull_request.number }}
@@ -159,7 +159,7 @@ jobs:
       - name: Require manually installed Unity editor
         id: ensure_unity_editor
         timeout-minutes: 10
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/ensure-unity-editor@64bac446903115134dca8235410b332bc5a83547 # v1.14.0
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/ensure-unity-editor@d79e1cc2acc892b619db2ca46f78291ca427016b # v1.14.2
         with:
           unity-version: ${{ matrix.unity-version }}
           install-root: ${{ runner.tool_cache }}\u6-v3
@@ -278,7 +278,7 @@ jobs:
             matrix.unity-version == '6000.5.2f1'
           }}
         timeout-minutes: 2
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-current-pr-head@64bac446903115134dca8235410b332bc5a83547 # v1.14.0
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-current-pr-head@d79e1cc2acc892b619db2ca46f78291ca427016b # v1.14.2
         with:
           github-token: ${{ github.token }}
           pull-request-number: ${{ github.event.pull_request.number }}
@@ -287,7 +287,7 @@ jobs:
       - name: Acquire organization Unity lock
         id: acquire_lock
         timeout-minutes: 305
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@64bac446903115134dca8235410b332bc5a83547 # v1.14.0
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@d79e1cc2acc892b619db2ca46f78291ca427016b # v1.14.2
         with:
           lock-name: wallstop-organization-builds
           # Every matrix axis is part of the holder identity, so each expanded
@@ -666,7 +666,7 @@ jobs:
         id: return_unity_license
         if: ${{ always() && steps.acquire_lock.outputs.acquired == 'true' }}
         timeout-minutes: 5
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/return-unity-license@64bac446903115134dca8235410b332bc5a83547
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/return-unity-license@d79e1cc2acc892b619db2ca46f78291ca427016b
         with:
           unity-version: ${{ matrix.unity-version }}
           tool-cache: ${{ runner.tool_cache }}
@@ -681,7 +681,7 @@ jobs:
         id: cleanup_classification
         if: ${{ always() && steps.acquire_lock.outputs.acquired == 'true' }}
         timeout-minutes: 2
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/classify-unity-cleanup-evidence@64bac446903115134dca8235410b332bc5a83547
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/classify-unity-cleanup-evidence@d79e1cc2acc892b619db2ca46f78291ca427016b
         with:
           return-log-path: ${{ steps.return_unity_license.outputs.return-log-path }}
           return-command-completed: ${{ steps.return_unity_license.outputs.return-command-completed }}
@@ -693,7 +693,7 @@ jobs:
         id: release_unity_lock
         if: always()
         timeout-minutes: 5
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@64bac446903115134dca8235410b332bc5a83547 # v1.14.0
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@d79e1cc2acc892b619db2ca46f78291ca427016b # v1.14.2
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}-all-modes
@@ -708,7 +708,7 @@ jobs:
       - name: Require confirmed Unity cleanup
         if: always()
         timeout-minutes: 2
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-confirmed-unity-cleanup@64bac446903115134dca8235410b332bc5a83547
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-confirmed-unity-cleanup@d79e1cc2acc892b619db2ca46f78291ca427016b
         with:
           # Typed binding to the one acquire step, exactly as the enrollment
           # contract requires. A leg that aborts before acquire ran reports an

--- a/Tests/Runtime/Core/UntypedDispatchTests.cs
+++ b/Tests/Runtime/Core/UntypedDispatchTests.cs
@@ -259,6 +259,9 @@ namespace DxMessaging.Tests.Runtime.Core
     /// this payload through a concrete typed call, which could mask the missing native target.
     /// Custom-bus rooting uses a distinct payload type. Interceptors replace readonly payloads
     /// through the ref parameter to preserve mutation coverage without an analyzer suppression.
+    /// 2026-09-09: a supplemental direct regression guard uses route-specific handlers and
+    /// post-processors to capture the bridge's typed local after payload and context mutation
+    /// while the caller's original box stays unchanged.
     /// </remarks>
     public sealed class UntypedStructPayloadTests
     {
@@ -284,23 +287,47 @@ namespace DxMessaging.Tests.Runtime.Core
             InstanceId context = new(0x6A17_4002);
             NonEmptyManualMessage original = new(marker, value);
             List<(long Marker, int Value)> observed = new();
+            List<(int Context, long Marker, int Value)> postObserved = new();
             int interceptions = 0;
+            int originalRouteCalls = 0;
+            int rewrittenRouteCalls = 0;
+            InstanceId rewrittenContext = new(context.Id + 11);
             switch (scenario.Kind)
             {
                 case MessageKind.Untargeted:
-                    _ = token.RegisterUntargeted<NonEmptyManualMessage>(Record);
+                    _ = token.RegisterUntargeted<NonEmptyManualMessage>(RecordOriginalRoute);
                     _ = token.RegisterUntargetedInterceptor<NonEmptyManualMessage>(Intercept);
+                    _ = token.RegisterUntargetedPostProcessor<NonEmptyManualMessage>(
+                        RecordUntargetedPost
+                    );
                     break;
                 case MessageKind.Targeted:
-                    _ = token.RegisterTargeted<NonEmptyManualMessage>(context, Record);
+                    _ = token.RegisterTargeted<NonEmptyManualMessage>(context, RecordOriginalRoute);
+                    _ = token.RegisterTargeted<NonEmptyManualMessage>(
+                        rewrittenContext,
+                        RecordRewrittenRoute
+                    );
                     _ = token.RegisterTargetedInterceptor<NonEmptyManualMessage>(
                         InterceptWithContext
                     );
+                    _ = token.RegisterTargetedWithoutTargetingPostProcessor<NonEmptyManualMessage>(
+                        RecordContextPost
+                    );
                     break;
                 case MessageKind.Broadcast:
-                    _ = token.RegisterBroadcast<NonEmptyManualMessage>(context, Record);
+                    _ = token.RegisterBroadcast<NonEmptyManualMessage>(
+                        context,
+                        RecordOriginalRoute
+                    );
+                    _ = token.RegisterBroadcast<NonEmptyManualMessage>(
+                        rewrittenContext,
+                        RecordRewrittenRoute
+                    );
                     _ = token.RegisterBroadcastInterceptor<NonEmptyManualMessage>(
                         InterceptWithContext
+                    );
+                    _ = token.RegisterBroadcastWithoutSourcePostProcessor<NonEmptyManualMessage>(
+                        RecordContextPost
                     );
                     break;
                 default:
@@ -318,11 +345,35 @@ namespace DxMessaging.Tests.Runtime.Core
             emit();
             string label = $"[{scenario.Kind}] aot={invokeAotBridge}, mutate={mutate}";
             (long Marker, int Value) expected = mutate ? (marker + 9, value + 7) : (marker, value);
+            int expectedContext =
+                scenario.Kind == MessageKind.Untargeted
+                    ? 0
+                    : (mutate ? rewrittenContext.Id : context.Id);
             CollectionAssert.AreEqual(
                 new[] { expected, expected },
                 observed,
                 label
-                    + ": both cold and cached dispatch must deliver the actual struct fields and interceptor changes."
+                    + ": first and repeated dispatch must deliver the actual struct fields and interceptor changes."
+            );
+            CollectionAssert.AreEqual(
+                new[]
+                {
+                    (expectedContext, expected.Marker, expected.Value),
+                    (expectedContext, expected.Marker, expected.Value),
+                },
+                postObserved,
+                label
+                    + ": post-processors must observe the bridge's internal final payload and routed context."
+            );
+            Assert.That(
+                originalRouteCalls,
+                Is.EqualTo(scenario.Kind == MessageKind.Untargeted || !mutate ? 2 : 0),
+                label + ": context mutation must stop dispatch to the original route."
+            );
+            Assert.That(
+                rewrittenRouteCalls,
+                Is.EqualTo(scenario.Kind != MessageKind.Untargeted && mutate ? 2 : 0),
+                label + ": context mutation must dispatch through the rewritten route."
             );
             Assert.That(
                 interceptions,
@@ -343,8 +394,23 @@ namespace DxMessaging.Tests.Runtime.Core
             );
             return;
 
-            void Record(in NonEmptyManualMessage message) =>
+            void RecordOriginalRoute(in NonEmptyManualMessage message)
+            {
+                ++originalRouteCalls;
                 observed.Add((message.Marker, message.Value));
+            }
+
+            void RecordRewrittenRoute(in NonEmptyManualMessage message)
+            {
+                ++rewrittenRouteCalls;
+                observed.Add((message.Marker, message.Value));
+            }
+
+            void RecordUntargetedPost(in NonEmptyManualMessage message) =>
+                postObserved.Add((0, message.Marker, message.Value));
+
+            void RecordContextPost(in InstanceId routedContext, in NonEmptyManualMessage message) =>
+                postObserved.Add((routedContext.Id, message.Marker, message.Value));
 
             bool Intercept(ref NonEmptyManualMessage message)
             {
@@ -366,6 +432,10 @@ namespace DxMessaging.Tests.Runtime.Core
                     Is.EqualTo(context),
                     $"[{scenario.Kind}]: the bridge must preserve the actual target/source."
                 );
+                if (mutate)
+                {
+                    routedContext = rewrittenContext;
+                }
                 return Intercept(ref message);
             }
         }

--- a/docs/ops/ambiguous-release-migration.md
+++ b/docs/ops/ambiguous-release-migration.md
@@ -101,7 +101,7 @@ organization lock.
     uses: ./.github/actions/validate-unity-license
 
   - name: Acquire organization Unity lock
-    uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@64bac446903115134dca8235410b332bc5a83547 # v1.14.0
+    uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@d79e1cc2acc892b619db2ca46f78291ca427016b # v1.14.2
     with:
       lock-name: wallstop-organization-builds
       runner-id: ${{ runner.name }}

--- a/docs/ops/ci-and-github-settings.md
+++ b/docs/ops/ci-and-github-settings.md
@@ -36,7 +36,7 @@ the central lock immediately before the licensed Unity section:
   uses: ./.github/actions/validate-unity-license
 
 - name: Acquire organization Unity lock
-  uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@64bac446903115134dca8235410b332bc5a83547 # v1.14.0
+  uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@d79e1cc2acc892b619db2ca46f78291ca427016b # v1.14.2
   with:
     lock-name: wallstop-organization-builds
     runner-id: ${{ runner.name }}


### PR DESCRIPTION
## Why

The current lock pin misses cleanup fixes in the authorized v1.14.2 release. Existing bridge tests did not record final values after interceptor mutation.

## What changed

- Pin all 40 workflow uses to the authorized v1.14.2 commit.
- Update both copyable documentation examples to the same immutable commit.
- Extend the existing 12-case untyped bridge matrix with route and post-processor observations.
- Keep the caller's boxed struct unchanged while checking the typed dispatch copy.

## How we know

- The full script suite passed 1,300 tests.
- The workflow contract passed all 26 tests.
- The Unity PlayMode suite passed 1,517 tests with one expected skip.
- The focused Unity fixture passed 15 tests twice after the final format.
- The focused fixture took 0.259 seconds and 0.090 seconds.
- No discovered test cases were added.
- Both adversarial reviews found no remaining correctness issue after fixes.

## Related Issue

Related to #509.

Supersedes #567.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)

## Checklist

- [x] All tests pass locally
- [x] Code is properly formatted
- [x] I have added tests that prove the guarded behavior
- [x] I have updated the documentation accordingly
- [x] The CHANGELOG needs no entry because runtime behavior is unchanged
- [x] My changes do not introduce breaking changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Pins change how organization Unity locks are released and cleanup is verified on every licensed workflow leg; runtime product code is unchanged, but a bad pin could block or mis-handle CI lock cleanup.
> 
> **Overview**
> **Adopts organization build-lock v1.14.2** across Unity CI (`perf-numbers`, `release`, `runner-bootstrap`, `unity-benchmarks`, `unity-tests`) and the ops doc snippets that show `acquire-build-lock`. Every `ambiguous-organization-build-lock` step moves from the v1.14.0 SHA to commit `d79e1cc…` (labeled v1.14.2), including runner preflight, PR-head guards, editor checks, lock acquire/release, license return, cleanup classification, and confirmed-cleanup gates.
> 
> **Strengthens untyped struct bridge regression coverage** in `UntypedStructPayloadTests.BoxedPayloadValuesAndInterceptorMutationsSurviveEveryBridge`: post-processors now record the final typed payload and routed context; targeted/broadcast paths register a second handler on a rewritten context and assert interceptors that change `routedContext` steer dispatch away from the original route; existing assertions still require the caller’s boxed struct to stay unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf9d8e1a0376ff7a51a2c888b61b73472c60f15d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->