### PR TITLE
Speed up cross-platform script tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -779,7 +779,9 @@ jobs:
           # Let the probes finish their descendant cleanup even if this shell exits early.
           trap 'wait "$heartbeat_pid" || true' EXIT
           script_status=0
-          node --test scripts/ || script_status=$?
+          # The native glob lets Node 22 run test files in separate worker processes;
+          # scripts/ resolves to scripts/index.js and registers every suite in one process.
+          node --test 'scripts/**/*.test.js' || script_status=$?
           heartbeat_status=0
           wait "$heartbeat_pid" || heartbeat_status=$?
           echo "::group::Unity editor heartbeat guards"

--- a/scripts/__tests__/ci-aggregate-workflow.test.js
+++ b/scripts/__tests__/ci-aggregate-workflow.test.js
@@ -1,5 +1,4 @@
 "use strict";
-
 const { test } = require("node:test");
 const assert = require("node:assert/strict");
 const fs = require("node:fs");
@@ -38,7 +37,6 @@ function resolveLockActionPin(actionNames) {
   assert.ok(comments.size <= 1, `${label} version comments disagree: ${[...comments]}`);
   return { sha: [...shas.keys()][0], comment: [...comments][0] || "" };
 }
-
 // Acquire/editor/preflight/head-guard share the build lock; return/classify/release/require-confirmed share cleanup policy.
 // prettier-ignore
 const [LOCK_ACTION_PIN, CLEANUP_POLICY_PIN] = [["check-unity-runner-availability", "acquire-build-lock", "release-build-lock", "require-current-pr-head", "ensure-unity-editor"], ["return-unity-license", "classify-unity-cleanup-evidence", "require-confirmed-unity-cleanup"]].map((group) => resolveLockActionPin(group));
@@ -46,10 +44,8 @@ const LOCK_ACTION_SHA = LOCK_ACTION_PIN.sha;
 const ACQUIRE_ACTION_SHA = LOCK_ACTION_PIN.sha;
 const CLEANUP_POLICY_SHA = CLEANUP_POLICY_PIN.sha;
 // SYNC: workflow-test-vectors.json UNITY_LOCK_WINDOWS mirrors scripts/validate-unity-pr-policy.py LICENSED_LOCK_WINDOWS.
-
 // prettier-ignore
 const CONSOLIDATED_WORKFLOWS = ["actionlint.yml", "csharpier-check.yml", "dotnet-tests.yml", "json-format-check.yml", "lint-doc-links.yml", "markdownlint.yml", "script-tests.yml", "spellcheck.yml", "validate-banner.yml", "validate-docs.yml", "validate-llms-txt.yml", "yaml-format-lint.yml"];
-
 // prettier-ignore
 const AGGREGATED_JOBS = ["changes", "actionlint", "markdownlint", "csharpier", "dotnet", "json-format", "line-endings", "spellcheck", "validate-banner", "validate-llms-txt", "yaml-format-lint", "script-tests", "validate-docs", "lint-doc-links"];
 
@@ -401,14 +397,19 @@ test("source marker scan is tracked-file scoped and cannot self-match workflow t
 test("script validators run once while script tests stay cross-platform", () => {
   const source = readWorkflow();
   const scriptTests = getJobBlock(source, "script-tests");
-  const setupDotnet = getStepBlock(scriptTests, "Setup .NET");
+  const runScriptTests = getStepBlock(
+    scriptTests,
+    "Run script tests and Unity editor heartbeat guards"
+  );
   const validators = getStepBlock(scriptTests, "Run validators");
 
   assert.match(
     scriptTests,
     /os:\n          - ubuntu-latest\n          - macos-latest\n          - windows-latest/
   );
-  assert.match(setupDotnet, /matrix\.os == 'ubuntu-latest'/);
+  assert.match(getStepBlock(scriptTests, "Setup .NET"), /matrix\.os == 'ubuntu-latest'/);
+  assert.match(runScriptTests, /node --test 'scripts\/\*\*\/\*\.test\.js'/);
+  assert.doesNotMatch(runScriptTests, /node --test scripts\//);
   assert.match(validators, /matrix\.os == 'ubuntu-latest'/);
   assert.match(validators, /\n        run: npm run validate:all\n/);
 });


### PR DESCRIPTION
## Why

The script-test job loads all 32 test files into one process on Node 22. This keeps independent test files on the static CI critical path longer than needed.

## What changed

- CI passes the native test-file glob to Node 22.
- The workflow contract pins the parallel command and rejects the serial command.
- Local `npm test` remains compatible with Node 20.

## How we know

An exact Node 22 A/B run passed the same 1,300 tests in the same order. The old command took 153.96 seconds. The new command took 85.33 seconds.

[PR CI run 34418433720](https://github.com/Ambiguous-Interactive/DxMessaging/actions/runs/34418433720) passes on all three systems. The changed step fell by 58 seconds on Ubuntu, 24 seconds on macOS, and 39 seconds on Windows. The required CI workflow fell from about 3m57s to 3m01s against the latest successful master run.

Three more local runs passed all 1,300 tests. The full overlapped step also passed 44 heartbeat guards.

`npm run validate:all`, actionlint, Prettier, and the focused workflow contract pass.

## Type of Change

- [x] Refactor (code change that neither fixes a bug nor adds a feature)

## Checklist

- [x] All tests pass locally
- [x] Code is properly formatted
- [x] I have added tests that prove the change is effective
- [x] No documentation or CHANGELOG update is required
- [x] The change does not introduce breaking changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only test invocation change with a regression guard; no production or auth logic touched.
> 
> **Overview**
> **CI script tests** now invoke `node --test 'scripts/**/*.test.js'` instead of `node --test scripts/`, so Node 22 can run each `*.test.js` file in separate workers rather than loading everything through `scripts/index.js` in one process. Comments in `ci.yml` document why the glob matters.
> 
> The **workflow contract test** in `ci-aggregate-workflow.test.js` was updated to assert the parallel command on the “Run script tests and Unity editor heartbeat guards” step and to forbid the old `node --test scripts/` form, keeping the heartbeat overlap behavior unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23b03f42fa307b33dd4046dc52c4f3680f9a28cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->