### PR TITLE
Retain shipping payloads and cancel superseded CI

### DIFF
--- a/.github/workflows/perf-numbers.yml
+++ b/.github/workflows/perf-numbers.yml
@@ -95,18 +95,14 @@ on:
       - "requirements-brand.txt"
   workflow_dispatch:
 
-# Serialize merge-path runs on the same ref so two post-merge push jobs from
-# this workflow do not race each other. A separate freshness check still guards
-# against unrelated default-branch pushes landing while the benchmarks run. We do
-# NOT cancel in-progress runs -- that would abort an in-flight benchmark.
-#
-# Pull-request runs add the head SHA, so that merge-path serialization does not
-# also queue a pull request's current head behind a superseded run whose only
-# remaining act is to abort on the per-leg head guard (#332). Benchmarks stay
-# mutually exclusive through the organization build lock, and every licensed leg
-# re-checks the pull-request head before it can reach that lock.
+# Pull-request runs share one group across head revisions so
+# `cancel-in-progress: true` actually retires superseded runs. Push and dispatch
+# runs share a group per ref. A separate freshness check still guards against an
+# unrelated default-branch push landing while benchmarks run. Benchmarks remain
+# mutually exclusive through the organization build lock, whose cancellation-safe
+# acquire and cleanup paths protect the licensed seat.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number && format('{0}-{1}', github.event.pull_request.number, github.event.pull_request.head.sha) || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 # Top-level least-privilege. The default-branch refresh job (commit-perf-doc)

--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -50,6 +50,10 @@ on:
         description: "Run the exhaustive stripped-player matrix"
         type: boolean
         default: false
+      shipping_native_payload:
+        description: "Retain the High semantic native payload (requires shipping fidelity)"
+        type: boolean
+        default: false
       consumer_install_validation:
         description: "Validate Git, UPM tarball, and classic package consumers"
         type: boolean
@@ -451,6 +455,7 @@ jobs:
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
           UNITY_ACCELERATOR_ENDPOINT: ${{ secrets.UNITY_ACCELERATOR_ENDPOINT }}
+          DXM_RETAIN_NATIVE_PAYLOAD: ${{ inputs.shipping_native_payload }}
         run: |
           $projectPathRoot = Join-Path $env:RUNNER_WORKSPACE 'dxm-u\t'
           $cachePath = Join-Path $env:RUNNER_WORKSPACE 'dxm-c\${{ matrix.unity-version }}'
@@ -459,7 +464,8 @@ jobs:
             -UnityInstallRoot (Join-Path $env:RUNNER_TOOL_CACHE 'u6-v3') `
             -ArtifactsPath '.artifacts/unity/${{ matrix.unity-version }}-shipping' `
             -ProjectPathRoot $projectPathRoot `
-            -CachePath $cachePath
+            -CachePath $cachePath `
+            -RetainNativePayload:($env:DXM_RETAIN_NATIVE_PAYLOAD -eq 'true')
 
       # A mode failure is tolerated until the test modes and shipping group have
       # had a chance to run. Preserve diagnostics and result verification, then fail
@@ -647,6 +653,27 @@ jobs:
           name: unity-${{ matrix.unity-version }}-shipping
           path: .artifacts/unity/${{ matrix.unity-version }}-shipping
           include-hidden-files: true
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Upload shipping native payload
+        if: >-
+          ${{
+            steps.redact_tests.outcome == 'success' &&
+            steps.run_shipping.outcome == 'success' &&
+            steps.acquire_lock.outputs.acquired == 'true' &&
+            always() &&
+            !cancelled() &&
+            github.event_name == 'workflow_dispatch' &&
+            inputs.shipping_fidelity &&
+            inputs.shipping_native_payload &&
+            (matrix.unity-version == '2021.3.45f1' || matrix.unity-version == '6000.5.2f1')
+          }}
+        timeout-minutes: 10
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: unity-${{ matrix.unity-version }}-shipping-native-payload
+          path: .artifacts/unity/${{ matrix.unity-version }}-shipping-native-payload
           if-no-files-found: error
           retention-days: 14
 

--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -67,9 +67,10 @@ concurrency:
   # the cleanup chain runs under `if: always()`, and the scheduled reaper
   # recovers a holder whose runner died. Licensed Unity work is still
   # serialized by the organization build lock, not by this group, and every
-  # leg re-checks the pull-request head before it can reach that lock, so two
-  # runs of one pull request can never both do licensed work (#332).
-  group: unity-tests-${{ github.event.pull_request.number && format('{0}-{1}', github.event.pull_request.number, github.event.pull_request.head.sha) || github.ref }}
+  # leg re-checks the pull-request head before it can reach that lock. Pull
+  # requests therefore share one group across head revisions so this setting
+  # actually cancels superseded runs; push and dispatch runs stay keyed by ref.
+  group: unity-tests-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/docs/runbooks/perf-benchmark-methodology.md
+++ b/docs/runbooks/perf-benchmark-methodology.md
@@ -383,6 +383,20 @@ metrics because the Release player strips the required profiler recorder (see
   This correctness slice does
   not contribute benchmark rows or change the published performance profile.
 
+  A manual run can also enable `shipping_native_payload` with `shipping_fidelity`.
+  For each endpoint editor, this retains the launcher, `GameAssembly.dll`, and
+  `global-metadata.dat` from the High semantic cell in a separate artifact. The
+  runner checks each source and copied file against the directory manifest that
+  matched before and after both player launches. Pull requests, pushes, scheduled
+  runs, and default manual runs do not copy or upload these files, so this option
+  does not add work to recurring CI.
+
+  GitHub retains this binary artifact for 14 days. Do not treat it as campaign
+  evidence until a maintainer downloads it, checks it for private material,
+  publishes it at an immutable location, restores that publication independently,
+  and verifies the hashes from `source-player-manifest.json`. The regular shipping
+  artifact remains the privacy-scanned text evidence bundle.
+
 - **EditMode leg (not published)** also runs in-editor under Mono with
   `-releaseCodeOptimization`. It remains a fast scope for local iteration, and
   manually dispatched `unity-benchmarks.yml` runs the editmode + playmode

--- a/docs/runbooks/required-checks.md
+++ b/docs/runbooks/required-checks.md
@@ -124,16 +124,17 @@ a rerun or a smaller PR; the companion must never turn incomplete data into a
 successful skip. Moving classification inside the licensed workflow requires an
 organization-policy-compatible aggregate change, not an added permissive skip.
 
-The `concurrency` setting keeps `cancel-in-progress: false` on purpose, because
-hard-cancelling a run that holds the organization build lock is the scenario the
-license-return guarantee exists to prevent. The group is keyed by pull-request
-head SHA so that policy does not also queue the current head behind a superseded
-run: push runs keep the `github.ref` key and stay serialized, pull-request runs
-partition per head, and every job-level group in the file uses the same key.
-Nothing is cancelled, and licensed work stays mutually exclusive through the
-organization build lock. A superseded pull-request run still starts, but each
-leg aborts at the `Require current PR head before setup` guard before any
-expensive setup, so a superseded run costs seconds instead of a license seat.
+The top-level `concurrency` setting keeps literal `cancel-in-progress: true`, as
+required by the organization build-lock enrollment contract. Pull-request runs
+share one group keyed by pull-request number, so a new head cancels the
+superseded run instead of leaving its remaining matrix legs queued. Push and
+manual runs share a group per ref. Cancellation is safe because the central
+acquire action handles cancellation signals, every licensed job retains its
+`if: always()` cleanup chain, and the scheduled reaper recovers stale holders.
+The organization build lock still provides mutual exclusion for licensed work.
+The per-leg current-head checks remain as defense in depth before setup and lock
+acquisition. Job-level preflight groups may partition per head because they run
+on GitHub-hosted infrastructure and cannot acquire a licensed seat.
 
 The required Unity check name is the stable aggregate:
 

--- a/scripts/__tests__/unity-artifact-redaction.test.js
+++ b/scripts/__tests__/unity-artifact-redaction.test.js
@@ -117,8 +117,8 @@ test("every Unity artifact upload is preceded by sensitive-data redaction in the
   const uploads = unityUploads();
   assert.equal(
     uploads.length,
-    9,
-    "the number of Unity-log-bearing uploads changed; confirm each one is still redacted"
+    10,
+    "the number of Unity artifact uploads changed; confirm each one is still redacted"
   );
   const unprotected = uploads.filter((upload) => !covers(upload.inForce, upload.uploadedPath));
   assert.deepEqual(

--- a/scripts/unity/__tests__/shipping-fidelity.test.ps1
+++ b/scripts/unity/__tests__/shipping-fidelity.test.ps1
@@ -1385,6 +1385,68 @@ if (
         throw "Function 'Read-ShippingCellEvidence' was not found in run-shipping-fidelity-matrix.ps1."
     }
     Invoke-Expression $readerDefinition.Extent.Text
+    $payloadCopyDefinition = $matrixAst.FindAll(
+        {
+            param($node)
+            $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+                $node.Name -eq 'Copy-NativePayloadEvidence'
+        },
+        $true
+    ) | Select-Object -First 1
+    if (-not $payloadCopyDefinition) {
+        throw "Function 'Copy-NativePayloadEvidence' was not found in run-shipping-fidelity-matrix.ps1."
+    }
+    Invoke-Expression $payloadCopyDefinition.Extent.Text
+
+    $nativeMetadataDirectory = Join-Path $cellPlayerDataDirectory 'il2cpp_data/Metadata'
+    New-Item -ItemType Directory -Path $nativeMetadataDirectory -Force | Out-Null
+    $nativeMetadataPath = Join-Path $nativeMetadataDirectory 'global-metadata.dat'
+    [System.IO.File]::WriteAllBytes($nativeMetadataPath, [byte[]](1, 2, 3, 4))
+    $nativePlayerManifest = Get-StandalonePlayerManifest -ExecutablePath $cellPlayerExePath
+    $nativeManifestEnvelope = [ordered]@{
+        schemaVersion = 2
+        topologyId = 'semantic-18-v1'
+        messageTypeCount = 18
+        playerDirectoryManifestMatches = $true
+        playerDirectoryManifestBefore = $nativePlayerManifest
+        playerDirectoryManifestAfter = Copy-JsonValue -Value $nativePlayerManifest
+        runs = @('positive', 'missing-root-mutant')
+    }
+    $nativeCellArtifacts = Join-Path $fixtureRoot 'native-cell-artifacts'
+    New-Item -ItemType Directory -Path $nativeCellArtifacts -Force | Out-Null
+    [System.IO.File]::WriteAllText(
+        (Join-Path $nativeCellArtifacts 'shipping-player-manifest.json'),
+        ($nativeManifestEnvelope | ConvertTo-Json -Depth 10)
+    )
+    $nativeDestination = Join-Path $fixtureRoot 'native-payload'
+    Copy-NativePayloadEvidence `
+        -CellArtifactsPath $nativeCellArtifacts `
+        -PlayerRoot $cellPlayerDirectory `
+        -Destination $nativeDestination
+    Assert-That 'native payload capture retains all three manifest-bound files' (
+        (Test-Path -LiteralPath (Join-Path $nativeDestination 'DxmShippingPlayer.exe') -PathType Leaf) -and
+        (Test-Path -LiteralPath (Join-Path $nativeDestination 'GameAssembly.dll') -PathType Leaf) -and
+        (Test-Path -LiteralPath (Join-Path $nativeDestination 'global-metadata.dat') -PathType Leaf) -and
+        (Test-Path -LiteralPath (Join-Path $nativeDestination 'source-player-manifest.json') -PathType Leaf)
+    )
+    Assert-That 'native payload capture preserves the validated metadata hash' (
+        (Get-FileHash -LiteralPath (Join-Path $nativeDestination 'global-metadata.dat') -Algorithm SHA256).Hash -ceq
+        (Get-FileHash -LiteralPath $nativeMetadataPath -Algorithm SHA256).Hash
+    )
+    Assert-Fails 'native payload capture rejects a stale destination' {
+        Copy-NativePayloadEvidence `
+            -CellArtifactsPath $nativeCellArtifacts `
+            -PlayerRoot $cellPlayerDirectory `
+            -Destination $nativeDestination
+    } 'destination already exists'
+    [System.IO.File]::WriteAllBytes($nativeMetadataPath, [byte[]](4, 3, 2, 1))
+    Assert-Fails 'native payload capture rejects bytes changed after manifest validation' {
+        Copy-NativePayloadEvidence `
+            -CellArtifactsPath $nativeCellArtifacts `
+            -PlayerRoot $cellPlayerDirectory `
+            -Destination (Join-Path $fixtureRoot 'mutated-native-payload')
+    } 'differs from its validated player manifest'
+    [System.IO.File]::WriteAllBytes($nativeMetadataPath, [byte[]](1, 2, 3, 4))
 
     $readerFixturePath = Join-Path $fixtureRoot 'reader-cell-evidence.json'
     $readableCell = Copy-JsonValue -Value $cellEvidence

--- a/scripts/unity/run-shipping-fidelity-matrix.ps1
+++ b/scripts/unity/run-shipping-fidelity-matrix.ps1
@@ -208,12 +208,20 @@ foreach ($shippingProfile in $shippingProfiles) {
         # point of this slice, but it is reported as its own class so nobody
         # reads it as a stripping regression.
         try {
-            $cellRows.Add((
-                Read-ShippingCellEvidence `
-                    -Path (Join-Path (Join-Path $ArtifactsPath $shippingCaseId) 'shipping-cell-evidence.json') `
-                    -CellId $shippingCaseId
-            ))
-            if ($RetainNativePayload -and $shippingCaseId -ceq 'high-semantic-18') {
+            $cellRow = Read-ShippingCellEvidence `
+                -Path (Join-Path (Join-Path $ArtifactsPath $shippingCaseId) 'shipping-cell-evidence.json') `
+                -CellId $shippingCaseId
+            $cellRows.Add($cellRow)
+        } catch {
+            $failure = "{0}: passed its shipping proof but wrote unusable evidence: {1}" -f
+                $shippingCaseId, $_.Exception.Message
+            $failures.Add($failure)
+            $unreadableEvidenceCellIds.Add($shippingCaseId)
+            Write-Warning "Shipping-fidelity cell evidence is unusable; continuing to preserve later evidence. $failure"
+            continue
+        }
+        if ($RetainNativePayload -and $shippingCaseId -ceq 'high-semantic-18') {
+            try {
                 $cellArtifactsPath = Join-Path $ArtifactsPath $shippingCaseId
                 $playerRoot = Join-Path (
                     Join-Path $ProjectPathRoot "$UnityVersion-shipping-$shippingCaseId"
@@ -222,13 +230,12 @@ foreach ($shippingProfile in $shippingProfiles) {
                     -CellArtifactsPath $cellArtifactsPath `
                     -PlayerRoot $playerRoot `
                     -Destination "$ArtifactsPath-native-payload"
+            } catch {
+                $failure = "{0}: native payload retention failed: {1}" -f
+                    $shippingCaseId, $_.Exception.Message
+                $failures.Add($failure)
+                Write-Warning "Shipping-fidelity native payload is unusable. $failure"
             }
-        } catch {
-            $failure = "{0}: passed its shipping proof but wrote unusable evidence: {1}" -f
-                $shippingCaseId, $_.Exception.Message
-            $failures.Add($failure)
-            $unreadableEvidenceCellIds.Add($shippingCaseId)
-            Write-Warning "Shipping-fidelity cell evidence is unusable; continuing to preserve later evidence. $failure"
         }
     }
 }

--- a/scripts/unity/run-shipping-fidelity-matrix.ps1
+++ b/scripts/unity/run-shipping-fidelity-matrix.ps1
@@ -7,7 +7,8 @@ param(
     [Parameter(Mandatory = $true)][string]$ProjectPathRoot,
     [Parameter(Mandatory = $true)][string]$CachePath,
     [string]$RepoRoot = (Split-Path -Parent (Split-Path -Parent $PSScriptRoot)),
-    [string]$RunnerPath = (Join-Path $PSScriptRoot 'run-ci-tests.ps1')
+    [string]$RunnerPath = (Join-Path $PSScriptRoot 'run-ci-tests.ps1'),
+    [switch]$RetainNativePayload
 )
 
 Set-StrictMode -Version Latest
@@ -108,6 +109,65 @@ function Read-ShippingCellEvidence {
     return $row
 }
 
+function Copy-NativePayloadEvidence {
+    param(
+        [Parameter(Mandatory = $true)][string]$CellArtifactsPath,
+        [Parameter(Mandatory = $true)][string]$PlayerRoot,
+        [Parameter(Mandatory = $true)][string]$Destination
+    )
+
+    $sourceManifestPath = Join-Path $CellArtifactsPath 'shipping-player-manifest.json'
+    $manifest = Get-Content -LiteralPath $sourceManifestPath -Raw | ConvertFrom-Json
+    if (
+        [int]$manifest.schemaVersion -ne 2 -or
+        [string]$manifest.topologyId -cne 'semantic-18-v1' -or
+        -not [bool]$manifest.playerDirectoryManifestMatches
+    ) {
+        throw 'Native payload retention requires the validated High semantic player manifest.'
+    }
+    $roles = @(
+        [ordered]@{ Name = 'DxmShippingPlayer.exe'; Suffix = 'DxmShippingPlayer.exe' },
+        [ordered]@{ Name = 'GameAssembly.dll'; Suffix = 'GameAssembly.dll' },
+        [ordered]@{ Name = 'global-metadata.dat'; Suffix = 'global-metadata.dat' }
+    )
+    if (Test-Path -LiteralPath $Destination) {
+        throw "Native payload destination already exists: $Destination"
+    }
+    New-Item -ItemType Directory -Path $Destination -Force | Out-Null
+    Copy-Item -LiteralPath $sourceManifestPath -Destination (Join-Path $Destination 'source-player-manifest.json')
+    foreach ($role in $roles) {
+        $matches = @(
+            $manifest.playerDirectoryManifestBefore.files |
+                Where-Object {
+                    $path = [string]$_.path
+                    $path -ceq $role.Suffix -or $path.EndsWith("/$($role.Suffix)", [StringComparison]::Ordinal)
+                }
+        )
+        if ($matches.Count -ne 1) {
+            throw "Native player manifest must contain exactly one $($role.Suffix)."
+        }
+        $sourcePath = $PlayerRoot
+        foreach ($segment in ([string]$matches[0].path).Split('/')) {
+            $sourcePath = Join-Path $sourcePath $segment
+        }
+        $source = Get-Item -LiteralPath $sourcePath -ErrorAction Stop
+        $sourceHash = (Get-FileHash -LiteralPath $source.FullName -Algorithm SHA256).Hash
+        if (
+            [long]$source.Length -ne [long]$matches[0].length -or
+            $sourceHash -cne [string]$matches[0].sha256
+        ) {
+            throw "Native payload $($role.Suffix) differs from its validated player manifest."
+        }
+        $destinationPath = Join-Path $Destination $role.Name
+        Copy-Item -LiteralPath $source.FullName -Destination $destinationPath
+        $copy = Get-Item -LiteralPath $destinationPath -ErrorAction Stop
+        $copyHash = (Get-FileHash -LiteralPath $copy.FullName -Algorithm SHA256).Hash
+        if ([long]$copy.Length -ne [long]$matches[0].length -or $copyHash -cne $sourceHash) {
+            throw "Native payload copy $($role.Name) differs from its validated source."
+        }
+    }
+}
+
 $failures = [System.Collections.Generic.List[string]]::new()
 $failedCellIds = [System.Collections.Generic.List[string]]::new()
 $unreadableEvidenceCellIds = [System.Collections.Generic.List[string]]::new()
@@ -153,6 +213,16 @@ foreach ($shippingProfile in $shippingProfiles) {
                     -Path (Join-Path (Join-Path $ArtifactsPath $shippingCaseId) 'shipping-cell-evidence.json') `
                     -CellId $shippingCaseId
             ))
+            if ($RetainNativePayload -and $shippingCaseId -ceq 'high-semantic-18') {
+                $cellArtifactsPath = Join-Path $ArtifactsPath $shippingCaseId
+                $playerRoot = Join-Path (
+                    Join-Path $ProjectPathRoot "$UnityVersion-shipping-$shippingCaseId"
+                ) 'Build/DxmShippingPlayer'
+                Copy-NativePayloadEvidence `
+                    -CellArtifactsPath $cellArtifactsPath `
+                    -PlayerRoot $playerRoot `
+                    -Destination "$ArtifactsPath-native-payload"
+            }
         } catch {
             $failure = "{0}: passed its shipping proof but wrote unusable evidence: {1}" -f
                 $shippingCaseId, $_.Exception.Message

--- a/scripts/validate-unity-pr-policy.py
+++ b/scripts/validate-unity-pr-policy.py
@@ -2838,6 +2838,7 @@ def validate_grouped_unity_correctness() -> None:
         "-ArtifactsPath '.artifacts/unity/${{ matrix.unity-version }}-shipping'",
         "-ProjectPathRoot $projectPathRoot",
         "-CachePath $cachePath",
+        "-RetainNativePayload:($env:DXM_RETAIN_NATIVE_PAYLOAD -eq 'true')",
     ):
         require(fragment in shipping, f"shipping: grouped run missing {fragment!r}")
     require(
@@ -2911,6 +2912,16 @@ def validate_grouped_unity_correctness() -> None:
         and "unity-${{ matrix.unity-version }}-shipping" in shipping_upload
         and ".artifacts/unity/${{ matrix.unity-version }}-shipping" in shipping_upload,
         "shipping fidelity must upload isolated evidence after lock acquisition, skip cancellation, and fail when it is absent",
+    )
+    native_upload = step_block(job, "Upload shipping native payload")
+    require(
+        "inputs.shipping_native_payload" in native_upload
+        and "steps.run_shipping.outcome == 'success'" in native_upload
+        and "steps.acquire_lock.outputs.acquired == 'true'" in native_upload
+        and "unity-${{ matrix.unity-version }}-shipping-native-payload" in native_upload
+        and ".artifacts/unity/${{ matrix.unity-version }}-shipping-native-payload" in native_upload
+        and "if-no-files-found: error" in native_upload,
+        "shipping native payload must remain manual, isolated, and fail when absent",
     )
     require(
         job.count("-LicenseReturnOwner Central") == 3,

--- a/scripts/validate-unity-pr-policy.py
+++ b/scripts/validate-unity-pr-policy.py
@@ -63,12 +63,13 @@ SUPERSEDED_GUARD = re.compile(
 )
 # The enrollment contract (build-lock #274) pins literal `cancel-in-progress:
 # true`, so a superseded run is cancelled instead of queueing. The concurrency
-# GROUP still carries the head: push runs serialize per ref, pull-request runs
-# partition per head SHA (#332). Every group in the
-# workflow must use this one key -- a job-level group keyed only by `github.ref`
-# would let a newer run cancel a superseded run's preflight, skipping that run's
-# licensed matrix and leaving its aggregate to report a result shape the gate
-# does not enumerate.
+# GROUP must omit the head SHA: push runs serialize per ref, while every revision
+# of one pull request shares a group so `cancel-in-progress` can retire the old
+# run. Job-level preflight groups may still partition per head; they do not reach
+# licensed work and remain subordinate to the workflow-level cancellation.
+PULL_REQUEST_CONCURRENCY_KEY = (
+    "${{ github.event.pull_request.number || github.ref }}"
+)
 PER_HEAD_CONCURRENCY_KEY = (
     "${{ github.event.pull_request.number && "
     "format('{0}-{1}', github.event.pull_request.number, "
@@ -862,22 +863,15 @@ def concurrency_groups(source: str) -> list[str | None]:
     return groups
 
 
-def validate_per_head_concurrency(source: str, label: str) -> None:
-    """Every concurrency group in a licensed Unity workflow partitions per head SHA."""
+def validate_workflow_concurrency_group(source: str, label: str, prefix: str) -> None:
+    """The workflow group must let a newer PR head cancel the superseded run."""
     groups = concurrency_groups(source)
     require(bool(groups), f"{label}: no concurrency block declared")
-    for group in groups:
-        require(
-            group is not None,
-            f"{label}: every concurrency block must name a group",
-        )
-        assert group is not None
-        require(
-            group.endswith(PER_HEAD_CONCURRENCY_KEY),
-            f"{label}: concurrency group {group!r} must end with the per-head key "
-            f"{PER_HEAD_CONCURRENCY_KEY!r} so a superseded pull-request run cannot "
-            "hold it while the run for the current head waits",
-        )
+    require(
+        groups[0] == f"{prefix}{PULL_REQUEST_CONCURRENCY_KEY}",
+        f"{label}: workflow concurrency group must omit the head SHA so "
+        "cancel-in-progress can retire superseded pull-request runs",
+    )
 
 
 def validate_licensed_workflow_policy(source: str) -> str:
@@ -893,7 +887,7 @@ def validate_licensed_workflow_policy(source: str) -> str:
         == ["  cancel-in-progress: true"],
         "Unity workflow concurrency must use one literal cancel-in-progress: true (build-lock #274)",
     )
-    validate_per_head_concurrency(source, "unity-tests.yml")
+    validate_workflow_concurrency_group(source, "unity-tests.yml", "unity-tests-")
 
     licensed = job_block(source, "unity-tests")
     require(
@@ -3599,7 +3593,7 @@ def validate_perf_pr_policy() -> None:
     """Keep PR performance evidence trusted, current, and credential-free."""
     perf_path = Path(".github/workflows/perf-numbers.yml")
     source = perf_path.read_text(encoding="utf-8")
-    validate_per_head_concurrency(source, "perf-numbers.yml")
+    validate_workflow_concurrency_group(source, "perf-numbers.yml", "${{ github.workflow }}-")
     preflight = job_block(source, "runner-preflight")
     benchmark = job_block(source, "perf-benchmarks")
     comment = job_block(source, "comment-perf-doc")
@@ -4712,9 +4706,9 @@ steps:
     )
     require_policy_mutation_rejected(
         source,
+        f"  group: unity-tests-{PULL_REQUEST_CONCURRENCY_KEY}\n",
         f"  group: unity-tests-{PER_HEAD_CONCURRENCY_KEY}\n",
-        "  group: unity-tests-${{ github.event.pull_request.number || github.ref }}\n",
-        "per-head concurrency group",
+        "pull-request concurrency group",
     )
     require_policy_mutation_rejected(
         source,


### PR DESCRIPTION
## Why

The shipping campaign cannot restore or inspect the exact native player bytes. Existing bundles retain text evidence and hashes only. The licensed workflows also claimed to cancel superseded runs, but their per-head concurrency keys placed every revision in a different group, leaving stale work queued.

## What changed

- Add a manual input that retains three native files from the High semantic player.
- Verify source and copied bytes against the unchanged player manifest.
- Upload the payload separately after the existing privacy scan.
- Keep native payload capture disabled for pull request, push, schedule, and default manual execution.
- Document the offline review and immutable publication requirements.
- Key licensed pull-request workflows by PR number so `cancel-in-progress: true` actually retires superseded Unity and performance runs.
- Lock the effective concurrency shape in the Unity policy validator.

## How we know

- All 1,323 script tests pass.
- The shipping PowerShell contract suite passes.
- `npm run validate:all` passes.
- Formatting, Markdown, spelling, pre-commit, and actionlint checks pass.
- Mutation and stale-destination tests prove the copy path fails closed.
- The policy validator rejects restoring a per-head concurrency group.
- A live second push automatically canceled the [superseded Unity run](https://github.com/Ambiguous-Interactive/DxMessaging/actions/runs/34723484338) in 9 seconds and the [superseded performance run](https://github.com/Ambiguous-Interactive/DxMessaging/actions/runs/34723484327) in 17 seconds.
- Every final-head check passes. Twelve downloaded Unity archives preserve every PR #582 fullname/result/label outcome exactly, with zero removed or changed tests; both performance archives preserve all 202 internal, 479 native comparison, and five allocation-honesty outcomes.
- Matched-runner Unity execution is unchanged within measurement noise: 155 versus 156 seconds for Unity 6000.3, 578 versus 578 seconds for internal performance, and 424 versus 421 seconds for comparisons. The opt-in payload path is skipped in recurring CI.

## Related Issue

Progresses #506.
Progresses #508.
Corrects the ineffective cancellation shape left by #584.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)

## Checklist

- [x] All tests pass locally
- [x] Code is properly formatted
- [x] I have added tests that prove my feature works
- [x] I have updated the documentation accordingly
- [x] A package changelog entry is not needed because package behavior does not change
- [x] My changes do not introduce breaking changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Concurrency group changes affect how licensed Unity and perf workflows cancel and queue; the new manual binary artifact path must stay gated and redaction-covered.
> 
> **Overview**
> Fixes **licensed workflow concurrency** so superseded pull-request runs are actually cancelled: `unity-tests.yml` and `perf-numbers.yml` now key PR concurrency by **pull-request number** (push/dispatch still by ref), matching literal `cancel-in-progress: true` and the build-lock contract. Runbooks and `validate-unity-pr-policy.py` are updated to require this shape and reject restoring per-head SHA groups.
> 
> Adds an **opt-in manual shipping path** for campaign inspection: `workflow_dispatch` input `shipping_native_payload` (with `shipping_fidelity`) drives `-RetainNativePayload` in `run-shipping-fidelity-matrix.ps1`. For the **High semantic** cell only, `Copy-NativePayloadEvidence` copies the launcher, `GameAssembly.dll`, and `global-metadata.dat` after hash/manifest checks, and CI uploads a separate **14-day** artifact on endpoint editors—**not** on PR/push/schedule/default manual runs. Tests cover copy failures, redaction coverage (10 uploads), and policy fragments for the new upload step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a5f9b7d7698599f2d9c55a85a7191d230fbaaa6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->