### PR TITLE
Extend shipping and native lifecycle evidence

### DIFF
--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -54,6 +54,10 @@ on:
         description: "Retain the High semantic native payload (requires shipping fidelity)"
         type: boolean
         default: false
+      shipping_incremental_build:
+        description: "Pair High semantic clean and incremental builds (requires shipping fidelity)"
+        type: boolean
+        default: false
       consumer_install_validation:
         description: "Validate Git, UPM tarball, and classic package consumers"
         type: boolean
@@ -187,10 +191,15 @@ jobs:
       # gate, so this input check lives after it. It still fails before any
       # checkout, credential reference, or lock acquisition.
       - name: Require one optional manual validation mode
-        if: ${{ inputs.shipping_fidelity && inputs.consumer_install_validation }}
+        if: >-
+          ${{
+            (inputs.shipping_fidelity && inputs.consumer_install_validation) ||
+            ((inputs.shipping_native_payload || inputs.shipping_incremental_build) && !inputs.shipping_fidelity) ||
+            (inputs.shipping_native_payload && inputs.shipping_incremental_build)
+          }}
         timeout-minutes: 1
         shell: pwsh
-        run: throw 'shipping_fidelity and consumer_install_validation are mutually exclusive.'
+        run: throw 'Shipping fidelity, consumer validation, native payload retention, and incremental evidence inputs are inconsistent; select one compatible manual evidence mode.'
 
       - name: Enable Git long paths
         timeout-minutes: 2
@@ -457,6 +466,7 @@ jobs:
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
           UNITY_ACCELERATOR_ENDPOINT: ${{ secrets.UNITY_ACCELERATOR_ENDPOINT }}
           DXM_RETAIN_NATIVE_PAYLOAD: ${{ inputs.shipping_native_payload }}
+          DXM_RUN_INCREMENTAL_HIGH_SEMANTIC: ${{ inputs.shipping_incremental_build }}
         run: |
           $projectPathRoot = Join-Path $env:RUNNER_WORKSPACE 'dxm-u\t'
           $cachePath = Join-Path $env:RUNNER_WORKSPACE 'dxm-c\${{ matrix.unity-version }}'
@@ -466,7 +476,8 @@ jobs:
             -ArtifactsPath '.artifacts/unity/${{ matrix.unity-version }}-shipping' `
             -ProjectPathRoot $projectPathRoot `
             -CachePath $cachePath `
-            -RetainNativePayload:($env:DXM_RETAIN_NATIVE_PAYLOAD -eq 'true')
+            -RetainNativePayload:($env:DXM_RETAIN_NATIVE_PAYLOAD -eq 'true') `
+            -RunIncrementalHighSemantic:($env:DXM_RUN_INCREMENTAL_HIGH_SEMANTIC -eq 'true')
 
       # A mode failure is tolerated until the test modes and shipping group have
       # had a chance to run. Preserve diagnostics and result verification, then fail

--- a/Tests/Runtime/Core/DifferentialBusTraceTests.cs
+++ b/Tests/Runtime/Core/DifferentialBusTraceTests.cs
@@ -1651,6 +1651,7 @@ namespace DxMessaging.Tests.Runtime.Core
                     .Cast<BusTraceOperationKind>()
                     .Where(kind =>
                         !DifferentialBusTrace.IsGlobalOverride(kind)
+                        && !DifferentialBusTrace.IsNativeLifecycle(kind)
                         && kind != BusTraceOperationKind.EmitUntyped
                     ),
                 kinds,
@@ -2106,6 +2107,7 @@ namespace DxMessaging.Tests.Runtime.Core
                     .Cast<BusTraceOperationKind>()
                     .Where(kind =>
                         !DifferentialBusTrace.IsGlobalOverride(kind)
+                        && !DifferentialBusTrace.IsNativeLifecycle(kind)
                         && kind != BusTraceOperationKind.EmitUntyped
                     ),
                 all,
@@ -3701,7 +3703,7 @@ namespace DxMessaging.Tests.Runtime.Core
         }
 
         [TestCase(0)]
-        [TestCase(BusTraceSequence.GeneratorVersion + 1)]
+        [TestCase(BusTraceSequence.NativeLifecycleGeneratorVersion + 1)]
         public void UnsupportedGeneratorVersionsAreRejected(int version)
         {
             Assert.Throws<ArgumentOutOfRangeException>(

--- a/Tests/Runtime/Core/DifferentialHostTraceTests.cs
+++ b/Tests/Runtime/Core/DifferentialHostTraceTests.cs
@@ -422,16 +422,23 @@ namespace DxMessaging.Tests.Runtime.Core
             Assert.That(EvaluateMutation(minimal)?.Category, Is.EqualTo("callbacks"), report);
         }
 
-        [Test]
-        public void GeneratedActivityReplayMatchesThroughNativeOwners(
+        [UnityTest]
+        [Category("UnityRuntime")]
+        public IEnumerator GeneratedLifecycleReplayMatchesAndShrinksDestroyedHostMutation(
             [ValueSource(typeof(MessageScenarios), nameof(MessageScenarios.AllKinds))]
                 MessageScenario scenario
         )
         {
-            // One bounded native seed supplements the larger managed replay matrix.
-            BusTraceSequence sequence = DifferentialBusTrace.Generate(scenario, 17, 32, 7);
-            IReadOnlyList<BusTraceObservation> control = Replay(sequence);
-            IReadOnlyList<BusTraceObservation> candidate = Replay(sequence);
+            _ownedScene = SceneManager.CreateScene("GeneratedDifferentialScene-" + scenario.Kind);
+            yield return null;
+            BusTraceSequence sequence = DifferentialBusTrace.Generate(
+                scenario,
+                17,
+                32,
+                BusTraceSequence.NativeLifecycleGeneratorVersion
+            );
+            IReadOnlyList<BusTraceObservation> control = Replay(sequence, _ownedScene);
+            IReadOnlyList<BusTraceObservation> candidate = Replay(sequence, _ownedScene);
             BusTraceMismatch mismatch = DifferentialBusTrace.Compare(control, candidate);
             string report = mismatch?.BuildReport(sequence) ?? Report(sequence, control);
             Assert.That(mismatch, Is.Null, report);
@@ -451,10 +458,67 @@ namespace DxMessaging.Tests.Runtime.Core
                     );
                 }
             }
+
+            BusTraceSequence lifecycleOnly = DifferentialBusTrace.Generate(
+                scenario,
+                509,
+                6,
+                BusTraceSequence.NativeLifecycleGeneratorVersion
+            );
+            BusTraceMismatch EvaluateDestroyMutation(BusTraceSequence input) =>
+                DifferentialBusTrace.Compare(
+                    Replay(input, _ownedScene),
+                    Replay(input, _ownedScene, ignoreHostDestroy: true)
+                );
+            BusTraceMismatch destroyMismatch = EvaluateDestroyMutation(lifecycleOnly);
+            Assert.That(
+                destroyMismatch,
+                Is.Not.Null,
+                Report(lifecycleOnly, Replay(lifecycleOnly, _ownedScene))
+            );
+            Assert.That(
+                destroyMismatch.Category,
+                Is.EqualTo("state"),
+                destroyMismatch.BuildReport(lifecycleOnly)
+            );
+            BusTraceSequence minimal = DifferentialBusTrace.Shrink(
+                lifecycleOnly,
+                EvaluateDestroyMutation
+            );
+            CollectionAssert.AreEqual(
+                new[] { BusTraceOperationKind.DestroyHost },
+                minimal.Operations.Select(operation => operation.Kind),
+                destroyMismatch.BuildReport(lifecycleOnly)
+            );
+            Assert.That(
+                DifferentialBusTrace.IsValid(minimal),
+                Is.True,
+                destroyMismatch.BuildReport(lifecycleOnly)
+            );
+            Assert.That(
+                EvaluateDestroyMutation(minimal)?.Category,
+                Is.EqualTo("state"),
+                destroyMismatch.BuildReport(lifecycleOnly)
+            );
         }
 
         private IReadOnlyList<BusTraceObservation> Replay(BusTraceSequence sequence) =>
             DifferentialBusTrace.Replay(sequence, kind => CreateAdapter(kind));
+
+        private IReadOnlyList<BusTraceObservation> Replay(
+            BusTraceSequence sequence,
+            Scene lifecycleScene,
+            bool ignoreHostDestroy = false
+        ) =>
+            DifferentialBusTrace.Replay(
+                sequence,
+                kind =>
+                    CreateAdapter(
+                        kind,
+                        lifecycleScene: lifecycleScene,
+                        ignoreHostDestroy: ignoreHostDestroy
+                    )
+            );
 
         private BusTraceMismatch EvaluateMutation(BusTraceSequence sequence) =>
             DifferentialBusTrace.Compare(
@@ -471,7 +535,9 @@ namespace DxMessaging.Tests.Runtime.Core
             bool startsActive = true,
             bool receiveWhileDisabled = false,
             Action<int, GameObject> configureHost = null,
-            Action<int> onCallback = null
+            Action<int> onCallback = null,
+            Scene lifecycleScene = default,
+            bool ignoreHostDestroy = false
         )
         {
             MessageBus bus = MessageBus.CreateForInternalUse(
@@ -494,7 +560,15 @@ namespace DxMessaging.Tests.Runtime.Core
                 startsActive,
                 receiveWhileDisabled
             );
-            return new NativeHostAdapter(scenario, bus, owners, ignoreDisable, onCallback);
+            return new NativeHostAdapter(
+                scenario,
+                bus,
+                owners,
+                ignoreDisable,
+                onCallback,
+                lifecycleScene,
+                ignoreHostDestroy
+            );
         }
 
         private static string Report(
@@ -542,19 +616,26 @@ namespace DxMessaging.Tests.Runtime.Core
             private readonly NativeOwners _owners;
             private readonly bool _ignoreDisable;
             private readonly Action<int> _onCallback;
+            private readonly Scene _lifecycleScene;
+            private readonly bool _ignoreHostDestroy;
+            private string _lifecycleObservation = string.Empty;
 
             internal NativeHostAdapter(
                 MessageScenario scenario,
                 MessageBus bus,
                 NativeOwners owners,
                 bool ignoreDisable,
-                Action<int> onCallback
+                Action<int> onCallback,
+                Scene lifecycleScene,
+                bool ignoreHostDestroy
             )
                 : base(scenario, bus, reset: bus.ResetState, tokenFactory: owners.CreateToken)
             {
                 _owners = owners;
                 _ignoreDisable = ignoreDisable;
                 _onCallback = onCallback;
+                _lifecycleScene = lifecycleScene;
+                _ignoreHostDestroy = ignoreHostDestroy;
             }
 
             protected override void OnCallback(int slot, IMessage message) =>
@@ -574,12 +655,49 @@ namespace DxMessaging.Tests.Runtime.Core
                 }
             }
 
+            protected override void ExecuteHostLifecycle(BusTraceOperation operation)
+            {
+                MessagingComponent owner = _owners.Components[operation.Token];
+                switch (operation.Kind)
+                {
+                    case BusTraceOperationKind.MoveHostToScene:
+                        if (!_lifecycleScene.IsValid() || !_lifecycleScene.isLoaded)
+                        {
+                            throw new InvalidOperationException(
+                                "Native lifecycle replay requires a loaded owned scene."
+                            );
+                        }
+                        SceneManager.MoveGameObjectToScene(owner.gameObject, _lifecycleScene);
+                        _lifecycleObservation =
+                            $"move:{operation.Token}:{owner.gameObject.scene.name}";
+                        break;
+                    case BusTraceOperationKind.PersistHost:
+                        UnityEngine.Object.DontDestroyOnLoad(owner.gameObject);
+                        _lifecycleObservation =
+                            $"persist:{operation.Token}:{owner.gameObject.scene.name}";
+                        break;
+                    case BusTraceOperationKind.DestroyHost:
+                        if (!_ignoreHostDestroy)
+                        {
+                            UnityEngine.Object.DestroyImmediate(owner.gameObject);
+                        }
+                        _lifecycleObservation =
+                            $"destroy:{operation.Token}:{(owner == null ? "destroyed" : "alive")}";
+                        break;
+                    default:
+                        base.ExecuteHostLifecycle(operation);
+                        break;
+                }
+            }
+
             // The owner hides its handler. Report observable native state below instead of inferring its flag.
             protected override string DescribeHandlerActivity() => "native-owner";
 
             protected override string DescribeAdapterState()
             {
-                StringBuilder state = new("; adapter=UnityHostSetActive");
+                StringBuilder state = new(
+                    "; adapter=UnityHostSetActive; lifecycle=" + _lifecycleObservation
+                );
                 for (int slot = 0; slot < _owners.Components.Length; ++slot)
                 {
                     MessagingComponent owner = _owners.Components[slot];
@@ -599,6 +717,17 @@ namespace DxMessaging.Tests.Runtime.Core
                     );
                 }
                 return state.ToString();
+            }
+
+            protected override void DisposeAdapterState()
+            {
+                foreach (MessagingComponent owner in _owners.Components)
+                {
+                    if (owner != null)
+                    {
+                        UnityEngine.Object.DestroyImmediate(owner.gameObject);
+                    }
+                }
             }
 
             protected override void DisposeToken(int slot)

--- a/Tests/Runtime/TestUtilities/DifferentialBusTrace.cs
+++ b/Tests/Runtime/TestUtilities/DifferentialBusTrace.cs
@@ -32,6 +32,9 @@ namespace DxMessaging.Tests.Runtime
         DisposeGlobalOverride,
         ReplaceGlobalBus,
         EmitUntyped,
+        MoveHostToScene,
+        PersistHost,
+        DestroyHost,
     }
 
     /// <summary>Replay input with stable logical token identity, route, payload, and priority.</summary>
@@ -138,6 +141,7 @@ namespace DxMessaging.Tests.Runtime
     internal sealed class BusTraceSequence
     {
         internal const int GeneratorVersion = 11;
+        internal const int NativeLifecycleGeneratorVersion = 12;
         internal const int HandleSlotCount = 8;
         internal const int TokenCount = 4;
         internal const int MaxOperations = 256;
@@ -151,7 +155,7 @@ namespace DxMessaging.Tests.Runtime
         {
             Scenario = scenario ?? throw new ArgumentNullException(nameof(scenario));
             Seed = seed;
-            if (generatorVersion < 1 || GeneratorVersion < generatorVersion)
+            if (generatorVersion < 1 || NativeLifecycleGeneratorVersion < generatorVersion)
             {
                 throw new ArgumentOutOfRangeException(nameof(generatorVersion));
             }
@@ -285,6 +289,10 @@ namespace DxMessaging.Tests.Runtime
             if (length < 0 || BusTraceSequence.MaxOperations < length)
             {
                 throw new ArgumentOutOfRangeException(nameof(length));
+            }
+            if (generatorVersion == BusTraceSequence.NativeLifecycleGeneratorVersion)
+            {
+                return GenerateNativeLifecycle(scenario, seed, length);
             }
             if (generatorVersion == 11)
             {
@@ -552,11 +560,54 @@ namespace DxMessaging.Tests.Runtime
             return new BusTraceSequence(scenario, seed, operations, 11);
         }
 
+        private static BusTraceSequence GenerateNativeLifecycle(
+            MessageScenario scenario,
+            uint seed,
+            int length
+        )
+        {
+            const int lifecycleOperationCount = 6;
+            int managedLength = Math.Max(0, length - lifecycleOperationCount);
+            List<BusTraceOperation> operations = new(
+                Generate(scenario, seed, managedLength, 7).Operations
+            );
+            int persistentSlot = (int)((seed == 0 ? 1U : seed) % BusTraceSequence.TokenCount);
+            int destroyedSlot = (persistentSlot + 1) % BusTraceSequence.TokenCount;
+            BusTraceOperation[] lifecycle =
+            {
+                new(BusTraceOperationKind.MoveHostToScene, token: persistentSlot),
+                new(BusTraceOperationKind.PersistHost, token: persistentSlot),
+                new(BusTraceOperationKind.MoveHostToScene, token: destroyedSlot),
+                new(BusTraceOperationKind.DestroyHost, token: destroyedSlot),
+                new(BusTraceOperationKind.Emit, value: unchecked((int)(seed ^ 0x9e3779b9u))),
+                new(BusTraceOperationKind.Trim, value: 1),
+            };
+            foreach (BusTraceOperation operation in lifecycle)
+            {
+                if (operations.Count == length)
+                {
+                    break;
+                }
+                operations.Add(operation);
+            }
+            return new BusTraceSequence(
+                scenario,
+                seed,
+                operations,
+                BusTraceSequence.NativeLifecycleGeneratorVersion
+            );
+        }
+
         internal static bool IsGlobalOverride(BusTraceOperationKind kind) =>
             kind == BusTraceOperationKind.AcquireGlobalOverride
             || kind == BusTraceOperationKind.CopyGlobalOverride
             || kind == BusTraceOperationKind.DisposeGlobalOverride
             || kind == BusTraceOperationKind.ReplaceGlobalBus;
+
+        internal static bool IsNativeLifecycle(BusTraceOperationKind kind) =>
+            kind == BusTraceOperationKind.MoveHostToScene
+            || kind == BusTraceOperationKind.PersistHost
+            || kind == BusTraceOperationKind.DestroyHost;
 
         /*
             Only logical issuance and alias dependencies are modeled, never the production
@@ -865,6 +916,7 @@ namespace DxMessaging.Tests.Runtime
             }
             bool[] registered = new bool[BusTraceSequence.TokenCount];
             bool[] removed = new bool[BusTraceSequence.TokenCount];
+            bool[] liveHosts = { true, true, true, true };
             HandleDependencies handles = new();
             GlobalOverrideDependencies leases = new();
             foreach (BusTraceOperation operation in sequence.Operations)
@@ -951,6 +1003,26 @@ namespace DxMessaging.Tests.Runtime
                 }
                 switch (operation.Kind)
                 {
+                    case BusTraceOperationKind.MoveHostToScene:
+                    case BusTraceOperationKind.PersistHost:
+                        if (
+                            sequence.Version < BusTraceSequence.NativeLifecycleGeneratorVersion
+                            || !liveHosts[operation.Token]
+                        )
+                        {
+                            return false;
+                        }
+                        break;
+                    case BusTraceOperationKind.DestroyHost:
+                        if (
+                            sequence.Version < BusTraceSequence.NativeLifecycleGeneratorVersion
+                            || !liveHosts[operation.Token]
+                        )
+                        {
+                            return false;
+                        }
+                        liveHosts[operation.Token] = false;
+                        break;
                     case BusTraceOperationKind.Register:
                         if (registered[operation.Token])
                         {

--- a/Tests/Runtime/TestUtilities/MessageBusTraceAdapter.cs
+++ b/Tests/Runtime/TestUtilities/MessageBusTraceAdapter.cs
@@ -165,6 +165,11 @@ namespace DxMessaging.Tests.Runtime
                     case BusTraceOperationKind.SetHandlerActive:
                         SetHandlerActive(operation.Token, operation.HandlerActive);
                         break;
+                    case BusTraceOperationKind.MoveHostToScene:
+                    case BusTraceOperationKind.PersistHost:
+                    case BusTraceOperationKind.DestroyHost:
+                        ExecuteHostLifecycle(operation);
+                        break;
                     case BusTraceOperationKind.EmitWithHandlerActive:
                         _handlerActiveOperation = operation;
                         try
@@ -368,6 +373,14 @@ namespace DxMessaging.Tests.Runtime
                 }
                 _globalScope = null;
             }
+            try
+            {
+                DisposeAdapterState();
+            }
+            catch (Exception error)
+            {
+                errors.Add(error);
+            }
             if (0 < errors.Count)
             {
                 throw new AggregateException("Differential replay cleanup failed.", errors);
@@ -421,6 +434,11 @@ namespace DxMessaging.Tests.Runtime
         protected virtual void DisposeGlobalOverride(int slot) => _globalOverrides[slot].Dispose();
 
         protected virtual void DisposeToken(int slot) => _tokens[slot].Dispose();
+
+        protected virtual void ExecuteHostLifecycle(BusTraceOperation operation) =>
+            throw new NotSupportedException("This adapter has no native host lifecycle.");
+
+        protected virtual void DisposeAdapterState() { }
 
         protected virtual string DescribeHandlerActivity()
         {

--- a/scripts/unity/__tests__/il2cpp-profile.test.ps1
+++ b/scripts/unity/__tests__/il2cpp-profile.test.ps1
@@ -208,7 +208,7 @@ try {
         $node -is [System.Management.Automation.Language.CommandAst] -and
             $node.GetCommandName() -ceq 'Write-NativeBuildInputEvidence'
     }, $true))
-    Assert-That 'shipping and canonical standalone both retain native inputs after their build' ($nativeCallSites.Count -eq 2)
+    Assert-That 'clean shipping, incremental shipping, and canonical standalone retain native inputs after their build' ($nativeCallSites.Count -eq 3)
 
     $generatedSources = @(
         New-ConfiguratorSource -CanonicalProfileId $profile.profileId -CanonicalProfileSha256 $profileSha256

--- a/scripts/unity/__tests__/il2cpp-profile.test.ps1
+++ b/scripts/unity/__tests__/il2cpp-profile.test.ps1
@@ -478,6 +478,61 @@ $observerSource
                     & $validatorPath -ProfilePath $profilePath -EvidencePath $evidencePath -EvidenceKind buildOptions -ExpectedUnityVersion $testUnityVersion
                 }
             }
+            $incrementalProfilePath = Join-Path $repoRoot '.github/perf/shipping-fidelity-il2cpp-profile.v1.json'
+            $incrementalProfile = Get-Content -LiteralPath $incrementalProfilePath -Raw | ConvertFrom-Json
+            $incrementalProfileSha256 = (
+                Get-FileHash -LiteralPath $incrementalProfilePath -Algorithm SHA256
+            ).Hash.ToLowerInvariant()
+            $incrementalEvidence = Copy-JsonValue -Value $evidence
+            $incrementalEvidence.profileId = $incrementalProfile.profileId
+            $incrementalEvidence.profileSha256 = $incrementalProfileSha256
+            $incrementalEvidence.values = Copy-JsonValue -Value $incrementalProfile.buildOptions
+            $incrementalEvidence.values.cleanBuildCache = $false
+            $incrementalEvidence.buildProvenance.playerBuildKind = 'incremental'
+            $incrementalEvidence.buildProvenance.libraryStateBeforeBuild = 'populated'
+            $incrementalEvidence.buildProvenance.beeStateBeforeBuild = 'populated'
+            $incrementalEvidence.buildProvenance.il2cppCacheStateBeforeBuild = 'populated'
+            $incrementalEvidence.buildProvenance.playerOutputStateBeforeBuild = 'populated'
+            Write-TestJson -Path $evidencePath -Value $incrementalEvidence
+            & $validatorPath `
+                -ProfilePath $incrementalProfilePath `
+                -EvidencePath $evidencePath `
+                -EvidenceKind buildOptions `
+                -ExpectedUnityVersion $testUnityVersion `
+                -ExpectedBuildFactor incremental
+            foreach ($requiredPopulatedField in @(
+                'libraryStateBeforeBuild',
+                'beeStateBeforeBuild',
+                'playerOutputStateBeforeBuild'
+            )) {
+                $changed = Copy-JsonValue -Value $incrementalEvidence
+                $changed.buildProvenance.$requiredPopulatedField = 'empty'
+                Write-TestJson -Path $evidencePath -Value $changed
+                Assert-Fails "incremental build requires populated $requiredPopulatedField" -ExpectedMessage 'buildProvenance' {
+                    & $validatorPath `
+                        -ProfilePath $incrementalProfilePath `
+                        -EvidencePath $evidencePath `
+                        -EvidenceKind buildOptions `
+                        -ExpectedUnityVersion $testUnityVersion `
+                        -ExpectedBuildFactor incremental
+                }
+            }
+            Write-TestJson -Path $evidencePath -Value $incrementalEvidence
+            Assert-Fails 'incremental evidence cannot pass as the profile build factor' -ExpectedMessage 'buildOptions.cleanBuildCache differs' {
+                & $validatorPath `
+                    -ProfilePath $incrementalProfilePath `
+                    -EvidencePath $evidencePath `
+                    -EvidenceKind buildOptions `
+                    -ExpectedUnityVersion $testUnityVersion
+            }
+            Assert-Fails 'build factor override is rejected for runtime evidence' -ExpectedMessage 'valid only for buildOptions evidence' {
+                & $validatorPath `
+                    -ProfilePath $incrementalProfilePath `
+                    -EvidencePath $evidencePath `
+                    -EvidenceKind runtime `
+                    -ExpectedUnityVersion $testUnityVersion `
+                    -ExpectedBuildFactor incremental
+            }
         }
         Write-TestJson -Path $evidencePath -Value $evidence
         & $validatorPath `

--- a/scripts/unity/__tests__/shipping-fidelity.test.ps1
+++ b/scripts/unity/__tests__/shipping-fidelity.test.ps1
@@ -786,9 +786,15 @@ if (
         ProjectPath = $projectPath
         ArtifactsPath = $artifactsPath
         ExpectedRepoRoot = $repoRoot
-        ExpectedManifestSha256 = $generatedManifestSha256
     }
     [System.IO.File]::WriteAllText($packageLockPath, ($packageLock | ConvertTo-Json -Depth 10))
+    Write-ShippingPackageResolutionEvidence @packageEvidenceArguments
+    $semanticallyEquivalentManifest = $manifest | ConvertTo-Json -Depth 10 -Compress
+    [System.IO.File]::WriteAllText($generatedManifestPath, $semanticallyEquivalentManifest)
+    Assert-That 'shipping manifest fixture changes bytes without changing semantics' (
+        (Get-FileHash -LiteralPath $generatedManifestPath -Algorithm SHA256).Hash.ToLowerInvariant() -cne
+        $generatedManifestSha256
+    )
     Write-ShippingPackageResolutionEvidence @packageEvidenceArguments
     $resolvedPackageEvidence = Get-Content `
         -LiteralPath (Join-Path $artifactsPath 'shipping-resolved-package-inputs.json') `
@@ -842,7 +848,7 @@ if (
     [System.IO.File]::WriteAllText($generatedManifestPath, ($mutatedManifest | ConvertTo-Json -Depth 10))
     Assert-Fails 'shipping package resolution rejects post-resolution manifest drift' {
         Write-ShippingPackageResolutionEvidence @packageEvidenceArguments
-    } 'manifest hash changed'
+    } 'does not reference the reviewed repository root'
     [System.IO.File]::WriteAllText($generatedManifestPath, ($manifest | ConvertTo-Json -Depth 10))
 
     $configuratorText = Get-Content -LiteralPath (Join-Path $projectPath 'Assets/Editor/DxmCiTestConfigurator.cs') -Raw

--- a/scripts/unity/__tests__/shipping-fidelity.test.ps1
+++ b/scripts/unity/__tests__/shipping-fidelity.test.ps1
@@ -90,6 +90,7 @@ param(
     [string]`$CanonicalProfilePath,
     [string]`$ShippingTopology,
     [int]`$ShippingMessageTypeCount,
+    [switch]`$ShippingIncrementalBuild,
     [string]`$LicenseReturnOwner,
     [switch]`$ReleaseCodeOptimization,
     [switch]`$ReleasePlayerBuild
@@ -107,6 +108,7 @@ Add-Content -LiteralPath '$escapedMatrixInvocationLogPath' -Value (([ordered]@{
     canonicalProfilePath = `$CanonicalProfilePath
     shippingTopology = `$ShippingTopology
     shippingMessageTypeCount = `$ShippingMessageTypeCount
+    shippingIncrementalBuild = `$ShippingIncrementalBuild.IsPresent
     licenseReturnOwner = `$LicenseReturnOwner
     releaseCodeOptimization = `$ReleaseCodeOptimization.IsPresent
     releasePlayerBuild = `$ReleasePlayerBuild.IsPresent
@@ -239,6 +241,7 @@ if (
             ) -and
             $matrixInvocation.shippingTopology -ceq $expectedMatrixCase.Topology -and
             [int]$matrixInvocation.shippingMessageTypeCount -eq $expectedMatrixCase.MessageTypeCount -and
+            $matrixInvocation.shippingIncrementalBuild -eq $false -and
             $matrixInvocation.licenseReturnOwner -ceq 'Central' -and
             $matrixInvocation.releaseCodeOptimization -eq $true -and
             $matrixInvocation.releasePlayerBuild -eq $true
@@ -301,6 +304,12 @@ if (
     )
 
     $runnerText = Get-Content -LiteralPath $runnerPath -Raw
+    $matrixRunnerText = Get-Content -LiteralPath $matrixRunnerPath -Raw
+    Assert-That 'shipping matrix scopes the optional incremental arm to High semantic only' (
+        $matrixRunnerText.Contains("`$runIncremental = `$RunIncrementalHighSemantic -and `$shippingCaseId -ceq 'high-semantic-18'") -and
+        $matrixRunnerText.Contains('-ShippingIncrementalBuild:$runIncremental') -and
+        $matrixRunnerText.Contains('Native payload retention and the incremental build factor are separate manual evidence modes.')
+    )
     Assert-That 'cardinality generation uses PowerShell 5.1-safe typed phase call lists' (
         $runnerText.Contains('$probeCalls = [System.Collections.Generic.List[string]]::new()') -and
         $runnerText.Contains('$registrationCalls = [System.Collections.Generic.List[string]]::new()') -and
@@ -448,12 +457,24 @@ if (
         $builderSourceText.Contains('reportedTotalSizeBytes = (long)report.summary.totalSize') -and
         $builderSourceText.Contains('reportedTotalTimeMs = report.summary.totalTime.TotalMilliseconds')
     )
-    Assert-That 'shipping runner passes the build report path and clears it afterwards' (
+    Assert-That 'shipping builder selects clean versus incremental options without changing generated source' (
+        $builderSourceText.Contains('RequireEnvironmentVariable("DXM_SHIPPING_BUILD_FACTOR")') -and
+        $builderSourceText.Contains('RequireEnvironmentVariable("DXM_SHIPPING_BUILD_INVOCATION_ID")') -and
+        $builderSourceText.Contains('if (buildFactor == "clean")') -and
+        $builderSourceText.Contains('options.options |= BuildOptions.CleanBuildCache;') -and
+        $builderSourceText.Contains('Incremental shipping build requires the clean predecessor scene.') -and
+        $builderSourceText.Contains('WriteMarker(markerPath, buildFactor, buildInvocationId);')
+    )
+    Assert-That 'shipping runner passes clean and incremental build report paths and clears them afterwards' (
         [regex]::Matches(
             $runnerText,
             '\$env:DXM_SHIPPING_BUILD_REPORT_PATH = \$shippingBuildReportPath'
         ).Count -eq 1 -and
-        [regex]::Matches($runnerText, "'DXM_SHIPPING_BUILD_REPORT_PATH'").Count -eq 2
+        [regex]::Matches(
+            $runnerText,
+            '\$env:DXM_SHIPPING_BUILD_REPORT_PATH = \$incrementalBuildReportPath'
+        ).Count -eq 1 -and
+        [regex]::Matches($runnerText, "'DXM_SHIPPING_BUILD_REPORT_PATH'").Count -eq 3
     )
 
     foreach ($cardinality in @(1, 16, 256, 1000)) {
@@ -2081,6 +2102,48 @@ if (
             -CanonicalProfilePath $profilePath `
             -GenerateOnly
     } 'AssemblyNames must be empty'
+
+    & $runnerPath `
+        -UnityVersion '6000.3.16f1' `
+        -TestMode shipping `
+        -AssemblyNames '' `
+        -ArtifactsPath (Join-Path $fixtureRoot 'incremental-generate-artifacts') `
+        -RepoRoot $repoRoot `
+        -ProjectPath (Join-Path $fixtureRoot 'incremental-generate-project') `
+        -CachePath (Join-Path $fixtureRoot 'incremental-generate-cache') `
+        -CanonicalProfilePath $profilePath `
+        -ShippingTopology semantic `
+        -ShippingMessageTypeCount 18 `
+        -ShippingIncrementalBuild `
+        -GenerateOnly
+    Assert-Fails 'incremental shipping factor rejects a non-High base profile' {
+        & $runnerPath `
+            -UnityVersion '6000.3.16f1' `
+            -TestMode shipping `
+            -AssemblyNames '' `
+            -ArtifactsPath (Join-Path $fixtureRoot 'incremental-low-artifacts') `
+            -RepoRoot $repoRoot `
+            -ProjectPath (Join-Path $fixtureRoot 'incremental-low-project') `
+            -CachePath (Join-Path $fixtureRoot 'incremental-low-cache') `
+            -CanonicalProfilePath (Join-Path $repoRoot '.github/perf/shipping-fidelity-il2cpp-low-profile.v1.json') `
+            -ShippingIncrementalBuild `
+            -GenerateOnly
+    } 'requires the reviewed High base profile'
+    Assert-Fails 'incremental shipping factor rejects a cardinality topology' {
+        & $runnerPath `
+            -UnityVersion '6000.3.16f1' `
+            -TestMode shipping `
+            -AssemblyNames '' `
+            -ArtifactsPath (Join-Path $fixtureRoot 'incremental-cardinality-artifacts') `
+            -RepoRoot $repoRoot `
+            -ProjectPath (Join-Path $fixtureRoot 'incremental-cardinality-project') `
+            -CachePath (Join-Path $fixtureRoot 'incremental-cardinality-cache') `
+            -CanonicalProfilePath $profilePath `
+            -ShippingTopology cardinality `
+            -ShippingMessageTypeCount 16 `
+            -ShippingIncrementalBuild `
+            -GenerateOnly
+    } 'valid only for the semantic-18 topology'
 
     Write-Host 'Shipping-fidelity harness contract tests passed.'
 } finally {

--- a/scripts/unity/run-ci-tests.ps1
+++ b/scripts/unity/run-ci-tests.ps1
@@ -6422,8 +6422,7 @@ function Write-ShippingPackageResolutionEvidence {
     param(
         [Parameter(Mandatory = $true)][string]$ProjectPath,
         [Parameter(Mandatory = $true)][string]$ArtifactsPath,
-        [Parameter(Mandatory = $true)][string]$ExpectedRepoRoot,
-        [Parameter(Mandatory = $true)][string]$ExpectedManifestSha256
+        [Parameter(Mandatory = $true)][string]$ExpectedRepoRoot
     )
 
     $packagesPath = Join-Path $ProjectPath 'Packages'
@@ -6442,10 +6441,6 @@ function Write-ShippingPackageResolutionEvidence {
 
     $manifestPath = Join-Path $packagesPath 'manifest.json'
     $lockPath = Join-Path $packagesPath 'packages-lock.json'
-    $resolvedManifestSha256 = (Get-FileHash -LiteralPath $manifestPath -Algorithm SHA256).Hash.ToLowerInvariant()
-    if ($resolvedManifestSha256 -cne $ExpectedManifestSha256) {
-        throw 'Shipping package manifest hash changed during package resolution.'
-    }
     $manifest = Get-Content -LiteralPath $manifestPath -Raw | ConvertFrom-Json
     if ($manifest -isnot [pscustomobject] -or $manifest.dependencies -isnot [pscustomobject]) {
         throw 'Shipping package manifest and dependencies must be JSON objects.'
@@ -6909,14 +6904,6 @@ $ProjectPath = Initialize-EphemeralProject `
     -ShippingMessageTypeCount $ShippingMessageTypeCount `
     -RepoRoot $RepoRoot `
     -ArtifactsPath $ArtifactsPath
-$shippingPreResolutionManifestSha256 = ''
-if ($isShippingFidelity) {
-    $shippingPreResolutionManifestSha256 = (
-        Get-FileHash `
-            -LiteralPath (Join-Path $ProjectPath 'Packages/manifest.json') `
-            -Algorithm SHA256
-    ).Hash.ToLowerInvariant()
-}
 $LibraryPath = Join-Path $ProjectPath 'Library'
 $LibraryEntries = @(
     if (Test-Path -LiteralPath $LibraryPath -PathType Container) {
@@ -7190,8 +7177,7 @@ try {
         Write-ShippingPackageResolutionEvidence `
             -ProjectPath $ProjectPath `
             -ArtifactsPath $ArtifactsPath `
-            -ExpectedRepoRoot $RepoRoot `
-            -ExpectedManifestSha256 $shippingPreResolutionManifestSha256
+            -ExpectedRepoRoot $RepoRoot
         # Build a stripped consumer through BuildPipeline directly. This path does
         # not invoke Unity Test Framework, add test assemblies, or establish a
         # PlayerConnection. The same immutable binary runs both the positive AOT

--- a/scripts/unity/run-ci-tests.ps1
+++ b/scripts/unity/run-ci-tests.ps1
@@ -45,6 +45,8 @@ param(
     [ValidateSet(1, 16, 18, 256, 1000)]
     [int]$ShippingMessageTypeCount = 18,
 
+    [switch]$ShippingIncrementalBuild,
+
     [ValidateRange(1, 10)]
     [int]$StandalonePlayerRunCount = 1,
 
@@ -1392,6 +1394,18 @@ function Test-FileSha256 {
         return $false
     }
     return (Get-FileHash -LiteralPath $Path -Algorithm SHA256).Hash.ToLowerInvariant() -eq $ExpectedSha256
+}
+
+function Get-StringSha256 {
+    param([Parameter(Mandatory = $true)][string]$Value)
+
+    $hasher = [System.Security.Cryptography.SHA256]::Create()
+    try {
+        $bytes = [System.Text.Encoding]::UTF8.GetBytes($Value)
+        return [BitConverter]::ToString($hasher.ComputeHash($bytes)).Replace('-', '').ToLowerInvariant()
+    } finally {
+        $hasher.Dispose()
+    }
 }
 
 function Install-CiAnalyzers {
@@ -3288,6 +3302,12 @@ public static class DxmShippingFidelityBuilder
         string outputPath = RequireEnvironmentVariable("DXM_PLAYER_BUILD_PATH");
         string markerPath = RequireEnvironmentVariable("DXM_SHIPPING_BUILD_MARKER_PATH");
         string buildReportPath = RequireEnvironmentVariable("DXM_SHIPPING_BUILD_REPORT_PATH");
+        string buildFactor = RequireEnvironmentVariable("DXM_SHIPPING_BUILD_FACTOR");
+        string buildInvocationId = RequireEnvironmentVariable("DXM_SHIPPING_BUILD_INVOCATION_ID");
+        if (buildFactor != "clean" && buildFactor != "incremental")
+        {
+            throw new InvalidOperationException("Unsupported shipping build factor: " + buildFactor);
+        }
         string scenePath = "Assets/DxmShippingFidelity.unity";
         string outputDirectory = Path.GetDirectoryName(outputPath);
         if (!string.IsNullOrEmpty(outputDirectory))
@@ -3295,10 +3315,17 @@ public static class DxmShippingFidelityBuilder
             Directory.CreateDirectory(outputDirectory);
         }
 
-        Scene scene = EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
-        if (!EditorSceneManager.SaveScene(scene, scenePath))
+        if (buildFactor == "clean")
         {
-            throw new InvalidOperationException("Could not save the shipping-fidelity scene.");
+            Scene scene = EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+            if (!EditorSceneManager.SaveScene(scene, scenePath))
+            {
+                throw new InvalidOperationException("Could not save the shipping-fidelity scene.");
+            }
+        }
+        else if (AssetDatabase.LoadAssetAtPath<SceneAsset>(scenePath) == null)
+        {
+            throw new InvalidOperationException("Incremental shipping build requires the clean predecessor scene.");
         }
 
         UnityEditor.Compilation.Assembly[] playerAssemblies =
@@ -3313,8 +3340,12 @@ public static class DxmShippingFidelityBuilder
             scenes = new[] { scenePath },
             locationPathName = outputPath,
             target = BuildTarget.StandaloneWindows64,
-            options = BuildOptions.CleanBuildCache | BuildOptions.DetailedBuildReport
+            options = BuildOptions.DetailedBuildReport
         };
+        if (buildFactor == "clean")
+        {
+            options.options |= BuildOptions.CleanBuildCache;
+        }
         options.options &= ~BuildOptions.Development;
         options.options &= ~BuildOptions.AllowDebugging;
         options.options &= ~BuildOptions.EnableDeepProfilingSupport;
@@ -3354,7 +3385,7 @@ public static class DxmShippingFidelityBuilder
             assemblyNames,
             (report.summary.options & BuildOptions.IncludeTestAssemblies)
                 == BuildOptions.IncludeTestAssemblies);
-        WriteMarker(markerPath);
+        WriteMarker(markerPath, buildFactor, buildInvocationId);
     }
 
     private static void WriteBuildReportEvidence(
@@ -3483,14 +3514,14 @@ public static class DxmShippingFidelityBuilder
         return (long)(utc - epoch).TotalMilliseconds;
     }
 
-    private static void WriteMarker(string path)
+    private static void WriteMarker(string path, string buildFactor, string buildInvocationId)
     {
         string directory = Path.GetDirectoryName(path);
         if (!string.IsNullOrEmpty(directory))
         {
             Directory.CreateDirectory(directory);
         }
-        File.WriteAllText(path, "DxmShippingFidelityBuilder.Build completed");
+        File.WriteAllText(path, buildFactor + ":" + buildInvocationId);
     }
 
     private static string RequireEnvironmentVariable(string name)
@@ -6823,8 +6854,16 @@ if ($isShippingFidelity) {
     ) {
         throw 'Shipping fidelity requires semantic topology with 18 message types or cardinality topology with 1, 16, 256, or 1000 message types.'
     }
+    if (
+        $ShippingIncrementalBuild -and
+        ($ShippingTopology -cne 'semantic' -or $ShippingMessageTypeCount -ne 18)
+    ) {
+        throw 'The incremental shipping build factor is valid only for the semantic-18 topology.'
+    }
 } elseif ([string]::IsNullOrWhiteSpace($AssemblyNames)) {
     throw "AssemblyNames must be non-empty for TestMode '$TestMode'."
+} elseif ($ShippingIncrementalBuild) {
+    throw 'ShippingIncrementalBuild is valid only for TestMode shipping.'
 }
 
 $canonicalProfileId = ''
@@ -6862,6 +6901,12 @@ if (-not [string]::IsNullOrWhiteSpace($CanonicalProfilePath)) {
             $includeTestAssemblies
         ) {
             throw 'Shipping fidelity requires a reviewed Minimal, Low, Medium, or High profile with includeTestAssemblies=false.'
+        }
+        if (
+            $ShippingIncrementalBuild -and
+            $canonicalProfileId -cne 'shipping-fidelity-il2cpp-player-v1'
+        ) {
+            throw 'The incremental shipping build factor requires the reviewed High base profile.'
         }
     } elseif (
         $canonicalProfileId -cne 'canonical-il2cpp-verdict-player-v1' -or
@@ -7187,6 +7232,7 @@ try {
         $shippingManifestPath = Join-Path $ArtifactsPath 'shipping-player-manifest.json'
         $shippingBuildReportPath = Join-Path $ArtifactsPath 'shipping-build-report.json'
         $shippingCellEvidencePath = Join-Path $ArtifactsPath 'shipping-cell-evidence.json'
+        $shippingBuildInvocationId = [guid]::NewGuid().ToString('D')
         $shippingBuildStartedUtc = [DateTime]::UtcNow
         foreach ($staleShippingPath in @(
             $shippingBuildMarkerPath,
@@ -7220,6 +7266,8 @@ try {
         $env:DXM_SHIPPING_BUILD_MARKER_PATH = $shippingBuildMarkerPath
         $env:DXM_SHIPPING_ASSEMBLY_EVIDENCE_PATH = $shippingAssemblyEvidencePath
         $env:DXM_SHIPPING_BUILD_REPORT_PATH = $shippingBuildReportPath
+        $env:DXM_SHIPPING_BUILD_FACTOR = 'clean'
+        $env:DXM_SHIPPING_BUILD_INVOCATION_ID = $shippingBuildInvocationId
         $env:DXM_PREBUILD_CONFIG_PROFILE_PATH = $prebuildProfileEvidencePath
         $env:DXM_POSTBUILD_CONFIG_PROFILE_PATH = $postbuildProfileEvidencePath
         $env:DXM_BUILD_OPTIONS_PROFILE_PATH = $buildOptionsProfileEvidencePath
@@ -7248,6 +7296,8 @@ try {
             'DXM_SHIPPING_BUILD_MARKER_PATH',
             'DXM_SHIPPING_ASSEMBLY_EVIDENCE_PATH',
             'DXM_SHIPPING_BUILD_REPORT_PATH',
+            'DXM_SHIPPING_BUILD_FACTOR',
+            'DXM_SHIPPING_BUILD_INVOCATION_ID',
             'DXM_BUILD_OPTIONS_PROFILE_PATH',
             'DXM_PREBUILD_CONFIG_PROFILE_PATH',
             'DXM_POSTBUILD_CONFIG_PROFILE_PATH'
@@ -7258,6 +7308,12 @@ try {
         $shippingMarkerProblem = Test-UnityConfigureMarker `
             -MarkerPath $shippingBuildMarkerPath `
             -StartedUtc $shippingBuildStartedUtc
+        if (
+            [string]::IsNullOrWhiteSpace($shippingMarkerProblem) -and
+            (Get-Content -LiteralPath $shippingBuildMarkerPath -Raw) -cne "clean:$shippingBuildInvocationId"
+        ) {
+            $shippingMarkerProblem = 'build marker does not match the clean invocation nonce'
+        }
         $shippingBuildProblem = Test-StandalonePlayerBuildOutput `
             -ExpectedExe $standaloneExe `
             -BuildStartedUtc $shippingBuildStartedUtc
@@ -7405,6 +7461,154 @@ try {
             -EditorBuildWallClockMs ([double]$shippingBuildStopwatch.Elapsed.TotalMilliseconds) `
             -PositivePlayerWallClockMs $shippingPlayerWallClockMs['positive'] `
             -MutantPlayerWallClockMs $shippingPlayerWallClockMs['missing-root-mutant']
+        if ($ShippingIncrementalBuild) {
+            # The incremental arm is deliberately paired with this exact clean
+            # predecessor in the same editor/project invocation. Do not recreate
+            # project inputs, the scene, Library, Bee state, or player output.
+            $incrementalArtifactsPath = Join-Path $ArtifactsPath 'incremental'
+            if (Test-Path -LiteralPath $incrementalArtifactsPath) {
+                Remove-Item -LiteralPath $incrementalArtifactsPath -Recurse -Force
+            }
+            New-Item -ItemType Directory -Path $incrementalArtifactsPath -Force | Out-Null
+            $incrementalMarkerPath = Join-Path $incrementalArtifactsPath 'shipping-build-complete.marker'
+            $incrementalAssemblyPath = Join-Path $incrementalArtifactsPath 'shipping-assemblies.json'
+            $incrementalBuildReportPath = Join-Path $incrementalArtifactsPath 'shipping-build-report.json'
+            $incrementalPrebuildPath = Join-Path $incrementalArtifactsPath 'prebuild-profile.json'
+            $incrementalPostbuildPath = Join-Path $incrementalArtifactsPath 'postbuild-profile.json'
+            $incrementalBuildOptionsPath = Join-Path $incrementalArtifactsPath 'build-options-profile.json'
+            $incrementalLogPath = Join-Path $incrementalArtifactsPath 'unity.log'
+            $incrementalEvidencePath = Join-Path $incrementalArtifactsPath 'shipping-incremental-evidence.json'
+            $projectInputsPath = Join-Path $ArtifactsPath 'shipping-project-inputs.json'
+            $scenePath = Join-Path $ProjectPath 'Assets/DxmShippingFidelity.unity'
+            $cleanProjectInputsSha256 = (Get-FileHash -LiteralPath $projectInputsPath -Algorithm SHA256).Hash.ToLowerInvariant()
+            $cleanSceneSha256 = (Get-FileHash -LiteralPath $scenePath -Algorithm SHA256).Hash.ToLowerInvariant()
+            $cleanPlayerManifestJson = $shippingManifestAfter | ConvertTo-Json -Depth 10 -Compress
+            $cleanBuildReportSha256 = (Get-FileHash -LiteralPath $shippingBuildReportPath -Algorithm SHA256).Hash.ToLowerInvariant()
+            $cleanCellEvidenceSha256 = (Get-FileHash -LiteralPath $shippingCellEvidencePath -Algorithm SHA256).Hash.ToLowerInvariant()
+            $incrementalInvocationId = [guid]::NewGuid().ToString('D')
+            $incrementalBuildStartedUtc = [datetime]::UtcNow
+
+            $env:DXM_SHIPPING_BUILD_MARKER_PATH = $incrementalMarkerPath
+            $env:DXM_SHIPPING_ASSEMBLY_EVIDENCE_PATH = $incrementalAssemblyPath
+            $env:DXM_SHIPPING_BUILD_REPORT_PATH = $incrementalBuildReportPath
+            $env:DXM_PREBUILD_CONFIG_PROFILE_PATH = $incrementalPrebuildPath
+            $env:DXM_POSTBUILD_CONFIG_PROFILE_PATH = $incrementalPostbuildPath
+            $env:DXM_BUILD_OPTIONS_PROFILE_PATH = $incrementalBuildOptionsPath
+            $env:DXM_SHIPPING_BUILD_FACTOR = 'incremental'
+            $env:DXM_SHIPPING_BUILD_INVOCATION_ID = $incrementalInvocationId
+            $incrementalStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+            try {
+                $incrementalResult = Invoke-ProcessWithTreeKillTimeout `
+                    -FilePath $UnityEditorPath `
+                    -Arguments $shippingBuildArgs `
+                    -TimeoutSeconds (Get-StandaloneBuildTimeoutSeconds) `
+                    -LogPath $incrementalLogPath `
+                    -Label "Build incremental shipping-fidelity IL2CPP player (Unity $UnityVersion)"
+            } finally {
+                $incrementalStopwatch.Stop()
+                foreach ($buildEnvironmentVariable in @(
+                    'DXM_SHIPPING_BUILD_MARKER_PATH',
+                    'DXM_SHIPPING_ASSEMBLY_EVIDENCE_PATH',
+                    'DXM_SHIPPING_BUILD_REPORT_PATH',
+                    'DXM_BUILD_OPTIONS_PROFILE_PATH',
+                    'DXM_PREBUILD_CONFIG_PROFILE_PATH',
+                    'DXM_POSTBUILD_CONFIG_PROFILE_PATH',
+                    'DXM_SHIPPING_BUILD_FACTOR',
+                    'DXM_SHIPPING_BUILD_INVOCATION_ID'
+                )) {
+                    Remove-Item -LiteralPath "Env:\$buildEnvironmentVariable" -ErrorAction SilentlyContinue
+                }
+            }
+            $incrementalMarkerProblem = Test-UnityConfigureMarker `
+                -MarkerPath $incrementalMarkerPath `
+                -StartedUtc $incrementalBuildStartedUtc
+            if (
+                [string]::IsNullOrWhiteSpace($incrementalMarkerProblem) -and
+                (Get-Content -LiteralPath $incrementalMarkerPath -Raw) -cne "incremental:$incrementalInvocationId"
+            ) {
+                $incrementalMarkerProblem = 'build marker does not match the incremental invocation nonce'
+            }
+            if (-not [string]::IsNullOrWhiteSpace($incrementalMarkerProblem)) {
+                throw "Incremental shipping build did not produce fresh invocation evidence: $incrementalMarkerProblem."
+            }
+            if ($incrementalResult.TimedOut -or $incrementalResult.ExitCode -ne 0) {
+                Write-UnityBenignExitWarning `
+                    -Label "Build incremental shipping-fidelity IL2CPP player (Unity $UnityVersion)" `
+                    -ExitCode $incrementalResult.ExitCode `
+                    -TimedOut:$incrementalResult.TimedOut `
+                    -LogPath $incrementalLogPath
+            }
+            foreach ($configurationPath in @($incrementalPrebuildPath, $incrementalPostbuildPath)) {
+                & $profileValidatorPath `
+                    -ProfilePath $resolvedCanonicalProfilePath `
+                    -EvidencePath $configurationPath `
+                    -EvidenceKind configuration `
+                    -ExpectedUnityVersion $UnityVersion `
+                    -ExpectedSha256 $canonicalProfileSha256
+            }
+            & $profileValidatorPath `
+                -ProfilePath $resolvedCanonicalProfilePath `
+                -EvidencePath $incrementalBuildOptionsPath `
+                -EvidenceKind buildOptions `
+                -ExpectedBuildFactor incremental `
+                -ExpectedUnityVersion $UnityVersion `
+                -ExpectedSha256 $canonicalProfileSha256
+            Test-ShippingAssemblyEvidence `
+                -Path $incrementalAssemblyPath `
+                -ExpectedProfileId $canonicalProfileId `
+                -ExpectedProfileSha256 $canonicalProfileSha256 `
+                -ExpectedUnityVersion $UnityVersion
+            Test-ShippingBuildReport `
+                -Path $incrementalBuildReportPath `
+                -ExpectedProfileId $canonicalProfileId `
+                -ExpectedProfileSha256 $canonicalProfileSha256 `
+                -ExpectedUnityVersion $UnityVersion `
+                -ExpectedTopology $ShippingTopology `
+                -ExpectedMessageTypeCount $ShippingMessageTypeCount `
+                -BuildStartedUtc $incrementalBuildStartedUtc
+            Write-NativeBuildInputEvidence `
+                -Project $ProjectPath -LogPath $incrementalLogPath -Artifacts $incrementalArtifactsPath `
+                -ProfileId $canonicalProfileId -ProfileSha256 $canonicalProfileSha256 `
+                -UnityVersion $UnityVersion
+
+            $projectInputs = Get-Content -LiteralPath $projectInputsPath -Raw | ConvertFrom-Json
+            foreach ($inputFile in @($projectInputs.files)) {
+                $actualInputPath = Join-Path $ProjectPath ([string]$inputFile.path)
+                if (
+                    -not (Test-Path -LiteralPath $actualInputPath -PathType Leaf) -or
+                    [long](Get-Item -LiteralPath $actualInputPath).Length -ne [long]$inputFile.length -or
+                    (Get-FileHash -LiteralPath $actualInputPath -Algorithm SHA256).Hash.ToLowerInvariant() -cne [string]$inputFile.sha256
+                ) {
+                    throw "Incremental shipping build changed reviewed project input $($inputFile.path)."
+                }
+            }
+            if ((Get-FileHash -LiteralPath $scenePath -Algorithm SHA256).Hash.ToLowerInvariant() -cne $cleanSceneSha256) {
+                throw 'Incremental shipping build changed its clean predecessor scene.'
+            }
+            $incrementalPlayerManifest = Get-StandalonePlayerManifest -ExecutablePath $standaloneExe
+            $incrementalBuildReport = Get-Content -LiteralPath $incrementalBuildReportPath -Raw | ConvertFrom-Json
+            Write-JsonArtifact -Path $incrementalEvidencePath -Value ([ordered]@{
+                    schemaVersion = 1
+                    measurementClass = 'characterization'
+                    buildFactor = 'incremental'
+                    invocationId = $incrementalInvocationId
+                    profileId = $canonicalProfileId
+                    profileSha256 = $canonicalProfileSha256
+                    topologyId = "$ShippingTopology-$ShippingMessageTypeCount-v1"
+                    unityVersion = $UnityVersion
+                    cleanBuildReportSha256 = $cleanBuildReportSha256
+                    cleanCellEvidenceSha256 = $cleanCellEvidenceSha256
+                    cleanProjectInputsSha256 = $cleanProjectInputsSha256
+                    cleanSceneSha256 = $cleanSceneSha256
+                    cleanPlayerManifestSha256 = Get-StringSha256 -Value $cleanPlayerManifestJson
+                    incrementalPlayerManifestSha256 = Get-StringSha256 -Value ($incrementalPlayerManifest | ConvertTo-Json -Depth 10 -Compress)
+                    editorBuildWallClockMs = [double]$incrementalStopwatch.Elapsed.TotalMilliseconds
+                    buildDurationMs = [double]$incrementalBuildReport.buildDurationMs
+                    reportedTotalTimeMs = [double]$incrementalBuildReport.reportedTotalTimeMs
+                    reportedTotalSizeBytes = [long]$incrementalBuildReport.reportedTotalSizeBytes
+                })
+            Write-CiNotice 'Incremental shipping build passed with the exact High semantic clean predecessor and unchanged reviewed inputs.'
+        }
         Write-CiNotice 'Shipping-fidelity player passed positive AOT dispatch and the missing-root mutant with an unchanged stripped binary.'
     } elseif ($TestMode -eq 'standalone') {
         # STANDALONE SPLIT BUILD + FILE-BASED RESULTS (zero PlayerConnection
@@ -7771,7 +7975,9 @@ try {
         'DXM_PLAYER_BUILD_PATH',
         'DXM_SHIPPING_BUILD_MARKER_PATH',
         'DXM_SHIPPING_ASSEMBLY_EVIDENCE_PATH',
-        'DXM_SHIPPING_BUILD_REPORT_PATH'
+        'DXM_SHIPPING_BUILD_REPORT_PATH',
+        'DXM_SHIPPING_BUILD_FACTOR',
+        'DXM_SHIPPING_BUILD_INVOCATION_ID'
     )) {
         Remove-Item -LiteralPath "Env:\$temporaryEnvironmentVariable" -ErrorAction SilentlyContinue
     }

--- a/scripts/unity/run-shipping-fidelity-matrix.ps1
+++ b/scripts/unity/run-shipping-fidelity-matrix.ps1
@@ -8,7 +8,8 @@ param(
     [Parameter(Mandatory = $true)][string]$CachePath,
     [string]$RepoRoot = (Split-Path -Parent (Split-Path -Parent $PSScriptRoot)),
     [string]$RunnerPath = (Join-Path $PSScriptRoot 'run-ci-tests.ps1'),
-    [switch]$RetainNativePayload
+    [switch]$RetainNativePayload,
+    [switch]$RunIncrementalHighSemantic
 )
 
 Set-StrictMode -Version Latest
@@ -16,6 +17,9 @@ $ErrorActionPreference = 'Stop'
 
 if (-not (Test-Path -LiteralPath $RunnerPath -PathType Leaf)) {
     throw "Unity CI runner not found: $RunnerPath"
+}
+if ($RetainNativePayload -and $RunIncrementalHighSemantic) {
+    throw 'Native payload retention and the incremental build factor are separate manual evidence modes.'
 }
 
 $shippingProfiles = @(
@@ -178,6 +182,7 @@ foreach ($shippingProfile in $shippingProfiles) {
         $shippingCaseId = "$($shippingProfile.Level)-$($shippingTopology.Id)"
         $cellSucceeded = $false
         try {
+            $runIncremental = $RunIncrementalHighSemantic -and $shippingCaseId -ceq 'high-semantic-18'
             & $RunnerPath `
                 -UnityVersion $UnityVersion `
                 -UnityInstallRoot $UnityInstallRoot `
@@ -190,6 +195,7 @@ foreach ($shippingProfile in $shippingProfiles) {
                 -CanonicalProfilePath (Join-Path $RepoRoot $shippingProfile.Path) `
                 -ShippingTopology $shippingTopology.Kind `
                 -ShippingMessageTypeCount $shippingTopology.MessageTypeCount `
+                -ShippingIncrementalBuild:$runIncremental `
                 -LicenseReturnOwner Central `
                 -ReleaseCodeOptimization `
                 -ReleasePlayerBuild

--- a/scripts/unity/validate-il2cpp-profile.ps1
+++ b/scripts/unity/validate-il2cpp-profile.ps1
@@ -13,6 +13,9 @@ param(
 
     [string]$ExpectedUnityVersion,
 
+    [ValidateSet('profile', 'clean', 'incremental')]
+    [string]$ExpectedBuildFactor = 'profile',
+
     [switch]$ProfileOnly
 )
 
@@ -222,6 +225,12 @@ foreach ($variantProperty in $selectedVariant.Keys) {
         -Actual $profile.$variantGroup.$variantProperty `
         -Path "profile.$variantGroup.$variantProperty"
 }
+if (
+    $ExpectedBuildFactor -ceq 'incremental' -and
+    $profile.profileId -cne 'shipping-fidelity-il2cpp-player-v1'
+) {
+    throw 'The incremental build factor is valid only for the High shipping-fidelity base profile.'
+}
 
 $profileSha256 = (Get-FileHash -LiteralPath $ProfilePath -Algorithm SHA256).Hash.ToLowerInvariant()
 if (
@@ -235,6 +244,9 @@ if ($ProfileOnly) {
     if (-not [string]::IsNullOrWhiteSpace($EvidencePath) -or -not [string]::IsNullOrWhiteSpace($EvidenceKind)) {
         throw 'Do not pass EvidencePath or EvidenceKind with ProfileOnly.'
     }
+    if ($ExpectedBuildFactor -cne 'profile') {
+        throw 'ExpectedBuildFactor is valid only for buildOptions evidence.'
+    }
     Write-Host "Validated IL2CPP profile $($profile.profileId) ($profileSha256)."
     return
 }
@@ -244,6 +256,9 @@ if ([string]::IsNullOrWhiteSpace($EvidencePath) -or [string]::IsNullOrWhiteSpace
 
 if ([string]::IsNullOrWhiteSpace($ExpectedUnityVersion)) {
     throw 'ExpectedUnityVersion is required when validating profile evidence.'
+}
+if ($EvidenceKind -cne 'buildOptions' -and $ExpectedBuildFactor -cne 'profile') {
+    throw 'ExpectedBuildFactor is valid only for buildOptions evidence.'
 }
 
 $evidence = Get-RequiredJsonObject -Path $EvidencePath -Label "$EvidenceKind profile evidence"
@@ -287,8 +302,16 @@ Assert-ExactProperties `
     -Label "$EvidenceKind profile evidence values"
 
 foreach ($property in $expectedValues.PSObject.Properties) {
+    $expectedValue = $property.Value
+    if (
+        $EvidenceKind -ceq 'buildOptions' -and
+        $property.Name -ceq 'cleanBuildCache' -and
+        $ExpectedBuildFactor -cne 'profile'
+    ) {
+        $expectedValue = $ExpectedBuildFactor -ceq 'clean'
+    }
     Assert-EquivalentJsonValue `
-        -Expected $property.Value `
+        -Expected $expectedValue `
         -Actual $evidence.values.($property.Name) `
         -Path "$EvidenceKind.$($property.Name)"
 }
@@ -311,8 +334,21 @@ if ($EvidenceKind -ceq 'buildOptions') {
         ($provenance.beeStateBeforeBuild -cne 'missing' -or $provenance.il2cppCacheStateBeforeBuild -cne 'missing')) {
         throw 'buildProvenance contains cache directories inside a missing or empty Library.'
     }
-    if ($provenance.playerOutputStateBeforeBuild -ceq 'populated') {
-        throw 'buildProvenance records reused player output; this runner requires empty or missing output before building.'
+    if (
+        $expectedBuildKind -ceq 'clean' -and
+        $provenance.playerOutputStateBeforeBuild -ceq 'populated'
+    ) {
+        throw 'buildProvenance records reused player output for a clean build.'
+    }
+    if (
+        $expectedBuildKind -ceq 'incremental' -and
+        (
+            $provenance.libraryStateBeforeBuild -cne 'populated' -or
+            $provenance.beeStateBeforeBuild -cne 'populated' -or
+            $provenance.playerOutputStateBeforeBuild -cne 'populated'
+        )
+    ) {
+        throw 'buildProvenance incremental builds require populated Library, Bee, and player output from the validated clean predecessor.'
     }
 }
 


### PR DESCRIPTION
## Why

Shipping reruns could not distinguish clean and incremental builds without changing the profile identity. The differential oracle also lacked generated native host lifecycle transitions.

## What changed

- Normalize the generated package manifest before semantic validation.
- Add a manual-only incremental build factor for the High semantic shipping cell.
- Bind incremental evidence to its clean predecessor and unchanged generated inputs.
- Add opt-in native lifecycle generation for scene moves, persistence, and destruction.
- Detect and shrink a skipped host destruction to one operation.
- Keep recurring workflow inputs false and keep the existing native test count.

## How we know

- All seven current-head workflows pass: CI, Unity Tests, Performance Numbers, Test Devcontainer, Unity Docs Gate, CSharpier, and Prettier.
- The PowerShell shipping and profile contract suites pass.
- The script suite passes 1,323 tests; `npm run validate:all` passes.
- The native fixture passes 24 tests twice; the differential model fixture passes 389 tests.
- The Runtime suite passes 1,517 tests with no failures.
- The allocation assembly passes 291 tests with no skips.
- Downloaded PR #588 and PR #585 artifacts have identical discovered totals and outcomes in Unity 2021.3 and 6000.3 across EditMode, PlayMode, and standalone. EditMode leaf tests are identical; player-backed modes only replace the intended three passing native cases and advance the passing unsupported-generator fixture from version 12 to 13.
- The optional manual validation step is skipped in recurring CI, so the new incremental path adds no licensed job or build.
- Same-runner/version comparable job durations are 176s vs 223s (Unity 6000.3), 627s vs 628s (internal performance), and 521s vs 524s (performance comparisons): 31 seconds lower in aggregate. These are observations, not causal speedup claims.
- Formatting, Markdown, spelling, and CSharpier checks pass.

## Related Issue

Progresses #506.
Progresses #508.
Progresses #509.
Progresses #572.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)

## Checklist

- [x] All tests pass locally
- [x] Code is properly formatted
- [x] I have added tests that prove my fix is effective or my feature works
- [x] User documentation does not change
- [x] A package changelog entry is not needed because package behavior does not change
- [x] My changes do not introduce breaking changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches licensed Unity shipping/IL2CPP evidence pipelines and CI validation contracts; runtime package behavior is test-only, but misconfigured manual dispatch could waste long matrix runs.
> 
> **Overview**
> Adds **manual-only** shipping-fidelity evidence for **clean vs incremental** IL2CPP builds on the **High semantic-18** cell, without changing profile identity.
> 
> The Unity workflow gains a `shipping_incremental_build` dispatch input and stricter guards so incremental/native-payload modes cannot combine with consumer validation or run without shipping fidelity. The matrix runner and `run-ci-tests.ps1` run a second build in the same editor session (reusing Library, scene, and inputs), tag builds via `DXM_SHIPPING_BUILD_FACTOR` / invocation IDs, validate incremental `buildOptions` provenance, and emit paired evidence. Package resolution evidence drops raw manifest SHA pinning in favor of semantic repo-root checks. Profile validation accepts `ExpectedBuildFactor` (`clean` / `incremental`) with distinct `cleanBuildCache` and cache-state rules.
> 
> The differential test harness adds **native host lifecycle** trace ops (`MoveHostToScene`, `PersistHost`, `DestroyHost`) at generator version 12, with a Unity runtime test that replays generated sequences and shrinks a skipped `DestroyHost` mutation to a single operation. Contract tests cover the new CI paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62406b037496f15dea3dbdd4ce6c7a0e93d3fab7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->